### PR TITLE
Update Scope

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -148,10 +148,7 @@ impl SingleExpression {
                 let value = bytes.to_simplicity();
                 ProgNode::comp(ProgNode::unit(), ProgNode::const_word(value))
             }
-            SingleExpressionInner::Witness(name) => {
-                scope.insert_witness(name.clone());
-                ProgNode::witness(name.as_inner().clone())
-            }
+            SingleExpressionInner::Witness(name) => ProgNode::witness(name.as_inner().clone()),
             SingleExpressionInner::Variable(identifier) => {
                 let res = scope.get(identifier);
                 println!("Identifier {}: {}", identifier, res.arrow());

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -150,7 +150,7 @@ impl SingleExpression {
             }
             SingleExpressionInner::Witness(name) => ProgNode::witness(name.as_inner().clone()),
             SingleExpressionInner::Variable(identifier) => {
-                let res = scope.get(identifier);
+                let res = scope.get(&Pattern::Identifier(identifier.clone()));
                 println!("Identifier {}: {}", identifier, res.arrow());
                 res
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ pub fn _compile(file: &Path) -> Arc<Node<Named<Commit<Elements>>>> {
 
     let prog = Program::parse(pairs.next().unwrap());
 
-    let mut scope = GlobalScope::new();
+    let mut scope = GlobalScope::default();
     let simplicity_prog = prog.eval(&mut scope);
     simplicity_prog
         .finalize_types_main()
@@ -176,7 +176,7 @@ mod tests {
             }
         }
         let prog = Program { statements: stmts };
-        let mut scope = GlobalScope::new();
+        let mut scope = GlobalScope::default();
         let simplicity_prog = prog.eval(&mut scope);
         let mut vec = Vec::new();
         let mut writer = BitWriter::new(&mut vec);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod dummy_env;
 pub mod named;
 pub mod parse;
 pub mod scope;
+mod util;
 
 use std::{collections::HashMap, path::Path, sync::Arc};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,6 @@ use crate::{
 #[grammar = "minimal.pest"]
 pub struct IdentParser;
 
-
 pub fn _compile(file: &Path) -> Arc<Node<Named<Commit<Elements>>>> {
     let file = std::fs::read_to_string(file).unwrap();
     let mut pairs = IdentParser::parse(Rule::program, &file).unwrap_or_else(|e| panic!("{}", e));

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -4,12 +4,53 @@ use crate::{named::ProgExt, ProgNode};
 
 /// Tracker of variable bindings.
 ///
-/// Internally there is a stack of scopes.
-/// A new scope is pushed for each (nested) block expression.
+/// Each Simfony expression expects an _input value_.
+/// A Simfony expression is translated into a Simplicity expression
+/// that similarly expects an _input value_.
+/// Simfony variable names are translated into Simplicity expressions
+/// that extract the seeked value from the input value of the encompassing expression.
 ///
-/// Bindings from higher scopes (in the stack) overwrite bindings from lower scopes.
+/// Each (nested) block expression introduces a new scope.
+/// Bindings from inner scopes overwrite bindings from outer scopes.
+/// Bindings live as long as their scope.
 #[derive(Debug, Clone)]
 pub struct GlobalScope {
+    /// For each scope, the set of assigned variables.
+    ///
+    /// A stack of scopes. Each scope is a stack of patterns.
+    /// New patterns are pushed onto the top _(current, innermost)_ scope.
+    ///
+    /// The stack of scopes corresponds to a _pattern tree_.
+    ///
+    /// The stack `[[p1], [p2, p3]]` corresponds to a nested product of patterns:
+    ///
+    /// ```text
+    ///    .
+    ///   / \
+    /// p3   .
+    ///     / \
+    ///   p2   p1
+    /// ```
+    ///
+    /// And so on.
+    ///
+    /// Inner scopes occur higher in the tree than outer scopes.
+    /// Later assignments occur higher in the tree than earlier assignments.
+    ///
+    /// The pattern tree is isomorphic to the _current input value_.
+    /// The isomorphism maps variable names from the pattern tree to values from the input.
+    ///
+    /// ```text
+    ///    .              .
+    ///   / \            / \
+    /// p3   .         v3   .
+    ///     / \            / \
+    ///   p2   p1   ↔    v2   v1
+    ///
+    /// p3 ↔ v3
+    /// p2 ↔ v2
+    /// p1 ↔ v1
+    /// ```
     variables: Vec<Vec<Pattern>>,
 }
 
@@ -27,40 +68,48 @@ impl GlobalScope {
         }
     }
 
-    /// Pushes a new scope to the stack.
+    /// Push a new scope onto the stack.
     pub fn push_scope(&mut self) {
         self.variables.push(Vec::new());
     }
 
-    /// Pops the latest scope from the stack.
+    /// Pop a scope from the stack.
     ///
     /// # Panics
     ///
-    /// Panics if the stack is empty.
+    /// The stack is empty.
     pub fn pop_scope(&mut self) {
-        self.variables.pop().expect("Popping scope zero");
+        self.variables.pop().expect("Empty stack");
     }
 
-    /// Pushes a new variable to the latest scope.
+    /// Push an assignment to the current scope.
+    ///
+    /// The input was updated in a let statement `let p = v`:
+    ///
+    /// ```text
+    ///   .
+    ///  / \
+    /// v   previous
+    /// ```
+    ///
+    /// Update the pattern tree accordingly:
+    ///
+    /// ```text
+    ///   .
+    ///  / \
+    /// p   previous
+    /// ```
     pub fn insert(&mut self, pattern: Pattern) {
         self.variables.last_mut().unwrap().push(pattern);
     }
 
-    /// Get a Simplicity expression that returns the value of the given `identifier`.
+    /// Get a Simplicity expression that returns the value of a variable.
     ///
-    /// The expression is a sequence of `take` and `drop` followed by `iden`,
-    /// which extracts the seeked value from the environment.
-    ///
-    /// The environment starts as the unit value.
-    ///
-    /// Each let statement updates the environment to become
-    /// the product of the assigned value (left) and of the previous environment (right).
-    ///
-    /// (Block) expressions consume the environment and return their output.
+    /// The expression takes the current input value and returns the seeked value.
     ///
     /// ## Example
     ///
-    /// ```
+    /// ```text
     /// let a: u8 = 0;
     /// let b = {
     ///     let b: u8 = 1;
@@ -69,27 +118,23 @@ impl GlobalScope {
     /// };
     /// ```
     ///
-    /// The stack of scopes looks like this:
-    ///
-    /// `[a] [b c]`
-    ///
-    /// The environment looks like this:
+    /// The pattern tree (left) and the input value (right) are as follows:
     ///
     /// ```text
-    ///   .
-    ///  / \
-    /// C   .
-    ///    / \
-    ///   B   .
-    ///      / \
-    ///     A   1
+    ///    .            .
+    ///   / \          / \
+    ///  c   .        2   .
+    ///     / \          / \
+    ///    b   .   ↔    1   .
+    ///       / \          / \
+    ///      a   _        0  ()
     /// ```
     ///
-    /// To extract `a`, we need the expression `drop drop take iden`.
+    /// The expression `drop drop take iden` returns the value `0` for variable `a`.
     ///
     /// ## Panics
     ///
-    /// The `identifier` is undefined.
+    /// The variable is not defined.
     pub fn get(&self, identifier: &Identifier) -> ProgNode {
         let mut pos = 0;
 

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -107,9 +107,16 @@ impl GlobalScope {
         self.variables.last_mut().unwrap().push(pattern);
     }
 
-    /// Get a Simplicity expression that returns the value of a variable.
-    ///
-    /// The expression takes the current input value and returns the seeked value.
+    /// Return a pattern that corresponds to the current input value.
+    fn to_pattern(&self) -> Pattern {
+        let mut it = self.variables.iter().flat_map(|scope| scope.iter());
+        let first = it.next().unwrap();
+        it.cloned()
+            .fold(first.clone(), |acc, next| Pattern::product(next, acc))
+    }
+
+    /// Get a Simplicity expression that returns a value of the shape of the target.
+    /// The expression consumes the current input value.
     ///
     /// ## Example
     ///
@@ -118,7 +125,7 @@ impl GlobalScope {
     /// let b = {
     ///     let b: u8 = 1;
     ///     let c: u8 = 2;
-    ///     a  // here we seek the value of `a`
+    ///     (a, b)  // here we seek the value of `(a, b)`
     /// };
     /// ```
     ///
@@ -134,37 +141,17 @@ impl GlobalScope {
     ///      a   _        0  ()
     /// ```
     ///
-    /// The expression `drop drop take iden` returns the value `0` for variable `a`.
+    /// The expression `drop pair (drop take iden) (take iden)` returns the seeked value.
     ///
     /// ## Panics
     ///
-    /// The variable is not defined.
-    pub fn get(&self, identifier: &Identifier) -> ProgNode {
-        if let Some((pos, path)) = self
-            .variables
-            .iter()
-            .rev() // Innermost scope has precedence
-            .flat_map(|scope| scope.iter().rev()) // Last assignment has precedence
-            .enumerate()
-            .find_map(|(idx, pattern)| pattern.get_path(identifier).map(|expr| (idx, expr)))
-        {
-            let mut expr = ProgNode::iden();
-            for short in path.into_iter().rev() {
-                match short {
-                    Short::O => expr = ProgNode::take(expr),
-                    Short::I => expr = ProgNode::drop_(expr),
-                }
-            }
-            if pos + 1 < self.variables.iter().map(|scope| scope.len()).sum() {
-                expr = ProgNode::take(expr);
-            }
-            for _ in 0..pos {
-                expr = ProgNode::drop_(expr);
-            }
-            return expr;
+    /// A variable is undefined.
+    pub fn get(&self, target: &Pattern) -> ProgNode {
+        let env_pattern = self.to_pattern();
+        match env_pattern.translate(target) {
+            Ok(expr) => expr,
+            Err(identifier) => panic!("\"{identifier}\" is undefined"),
         }
-
-        panic!("\"{identifier}\" is undefined");
     }
 }
 

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -1,3 +1,7 @@
+use std::sync::Arc;
+
+use miniscript::iter::{Tree, TreeLike};
+
 use crate::array::{DirectedTree, Direction};
 use crate::parse::{Identifier, Pattern};
 use crate::{named::ProgExt, ProgNode};
@@ -136,14 +140,21 @@ impl GlobalScope {
     ///
     /// The variable is not defined.
     pub fn get(&self, identifier: &Identifier) -> ProgNode {
-        if let Some((pos, mut expr)) = self
+        if let Some((pos, path)) = self
             .variables
             .iter()
             .rev() // Innermost scope has precedence
             .flat_map(|scope| scope.iter().rev()) // Last assignment has precedence
             .enumerate()
-            .find_map(|(idx, pattern)| pattern.get_program(identifier).map(|expr| (idx, expr)))
+            .find_map(|(idx, pattern)| pattern.get_path(identifier).map(|expr| (idx, expr)))
         {
+            let mut expr = ProgNode::iden();
+            for short in path.into_iter().rev() {
+                match short {
+                    Short::O => expr = ProgNode::take(expr),
+                    Short::I => expr = ProgNode::drop_(expr),
+                }
+            }
             if pos + 1 < self.variables.iter().map(|scope| scope.len()).sum() {
                 expr = ProgNode::take(expr);
             }
@@ -158,6 +169,7 @@ impl GlobalScope {
 }
 
 impl Pattern {
+    /// Access the identifier inside the pattern.
     pub fn get_identifier(&self) -> Option<&Identifier> {
         match self {
             Pattern::Identifier(i) => Some(i),
@@ -165,7 +177,9 @@ impl Pattern {
         }
     }
 
-    pub fn get_program(&self, identifier: &Identifier) -> Option<ProgNode> {
+    /// Get a sequence of take-drop-iden that returns the value of the given variable.
+    /// The sequence takes a Simplicity value of the shape of this pattern as input.
+    fn get_path(&self, identifier: &Identifier) -> Option<Vec<Short>> {
         let base_pattern = self.to_base();
         let directed_tree = DirectedTree::from(&base_pattern);
         let equals_identifier = |pattern: &Pattern| {
@@ -174,18 +188,287 @@ impl Pattern {
                 .map(|i| i == identifier)
                 .unwrap_or(false)
         };
-        let (_, mut path) = directed_tree.find(equals_identifier)?;
+        let path = directed_tree.find(equals_identifier)?.1;
+        let short = path
+            .into_iter()
+            .filter_map(|d| match d {
+                Direction::Left => Some(Short::O),
+                Direction::Right => Some(Short::I),
+                _ => None,
+            })
+            .collect();
+        Some(short)
+    }
 
-        let mut output = ProgNode::iden();
-        while let Some(direction) = path.pop() {
-            match direction {
-                Direction::Left => output = ProgNode::take(output),
-                Direction::Right => output = ProgNode::drop_(output),
-                Direction::Down => unreachable!("There are no unary patterns"),
-                Direction::Index(..) => unreachable!("Base patterns exclude arrays"),
+    /// Get a Simplicity expression that returns a value of the shape of the target.
+    /// The expression takes a Simplicity value of the shape of this pattern as input.
+    fn get_translation_node(&self, target: &Self) -> Result<TranslationNode, Identifier> {
+        let mut output = vec![];
+        for data in target.to_base().post_order_iter() {
+            match data.node {
+                Pattern::Identifier(i) => {
+                    let path = self.get_path(i).ok_or(i.clone())?;
+                    output.push(TranslationNode::Short(path));
+                }
+                Pattern::Ignore => {
+                    output.push(TranslationNode::Unit);
+                }
+                Pattern::Product(..) => {
+                    let node_r = output.pop().unwrap();
+                    let node_l = output.pop().unwrap();
+                    output.push(TranslationNode::Pair(Arc::new(node_l), Arc::new(node_r)));
+                }
+                Pattern::Array(_) => unreachable!(),
+            }
+        }
+        debug_assert!(output.len() == 1);
+        Ok(output.pop().unwrap())
+    }
+
+    /// Get a compressed Simplicity expression that returns a value of the shape of the target.
+    /// The expression takes a Simplicity value of the shape of this pattern as input.
+    pub fn translate(&self, other: &Self) -> Result<ProgNode, Identifier> {
+        let node = self.get_translation_node(other)?;
+        let compressed = Arc::new(node.compress());
+        Ok(compressed.to_expr())
+    }
+}
+
+/// Abbreviation for the take or drop combinator.
+///
+/// Sequences of [`Short::O`] and [`Short::I`] are followed by an implicit `iden` combinator.
+/// Because `iden` always follows, it doesn't make sense to explicitly add it in code.
+/// The sequence `[Short::O, Short::I]` stands for `take drop iden`, and so on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum Short {
+    /// Take
+    O,
+    /// Drop
+    I,
+}
+
+/// Simplicity expression that translates a nested Simplicity product value into another.
+///
+/// Only a small set of combinators is needed for this operation.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum TranslationNode {
+    Unit,
+    Short(Vec<Short>),
+    Pair(Arc<Self>, Arc<Self>),
+}
+
+impl<'a> TreeLike for &'a TranslationNode {
+    fn as_node(&self) -> Tree<Self> {
+        match self {
+            TranslationNode::Unit | TranslationNode::Short(_) => Tree::Nullary,
+            TranslationNode::Pair(l, r) => Tree::Binary(l, r),
+        }
+    }
+}
+
+impl TranslationNode {
+    /// Eliminate an unnecessary pair if possible.
+    /// Return the minimized node.
+    fn eliminate_pair(&self) -> Option<Self> {
+        if let Self::Pair(l, r) = self {
+            match (l.as_ref(), r.as_ref()) {
+                // xoh ▵ unit ↦ xh, where x ∈ {o, i}*
+                (Self::Short(vec), Self::Unit) => {
+                    let (last, prefix) = vec.split_last()?;
+                    if let Short::O = last {
+                        return Some(Self::Short(prefix.to_vec()));
+                    }
+                }
+                // unit ▵ xih ↦ xh, where x ∈ {o, i}*
+                (Self::Unit, Self::Short(vec)) => {
+                    let (last, prefix) = vec.split_last()?;
+                    if let Short::I = last {
+                        return Some(Self::Short(prefix.to_vec()));
+                    }
+                }
+                // xoh ▵ xih ↦ xh, where x ∈ {o, i}*
+                (Self::Short(vec_l), Self::Short(vec_r)) => {
+                    let (last_l, prefix_l) = vec_l.split_last()?;
+                    let (last_r, prefix_r) = vec_r.split_last()?;
+                    if let (Short::O, Short::I) = (last_l, last_r) {
+                        if prefix_l == prefix_r {
+                            return Some(Self::Short(prefix_l.to_vec()));
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        None
+    }
+
+    /// Recursively eliminate all unnecessary pairs.
+    /// Return the minimized node.
+    fn compress(&self) -> Self {
+        let mut output = vec![];
+        for data in self.post_order_iter() {
+            match data.node {
+                Self::Unit | Self::Short(..) => {
+                    output.push(data.node.clone());
+                }
+                Self::Pair(..) => {
+                    let compressed_r = output.pop().unwrap();
+                    let compressed_l = output.pop().unwrap();
+                    let pair = Self::Pair(Arc::new(compressed_l), Arc::new(compressed_r));
+
+                    if let Some(compressed_pair) = pair.eliminate_pair() {
+                        output.push(compressed_pair);
+                    } else {
+                        output.push(pair);
+                    }
+                }
+            }
+        }
+        debug_assert!(output.len() == 1);
+        output.pop().unwrap()
+    }
+
+    /// Eliminate an unnecessary take / drop if possible.
+    /// Return the left and right child of the minimized node, and the parent combinator.
+    ///
+    /// [`TranslationNode`] doesn't support take / drop combinators with arbitrary children,
+    /// so the minimized node is returned in parts. This function is called when [`TranslationNode`]
+    /// is converted into [`ProgNode`]. The latter supports arbitrary take / drop combinators.
+    fn eliminate_take_drop(&self) -> Option<(Self, Self, Short)> {
+        if let Self::Pair(l, r) = self {
+            // ox ▵ oy ↦ o(x ▵ y), where x, y ∈ {o, i}*
+            // ix ▵ iy ↦ i(x ▵ y), where x, y ∈ {o, i}*
+            if let (Self::Short(vec_l), Self::Short(vec_r)) = (l.as_ref(), r.as_ref()) {
+                let (first_l, suffix_l) = vec_l.split_first()?;
+                let (first_r, suffix_r) = vec_r.split_first()?;
+                if first_l == first_r {
+                    return Some((
+                        Self::Short(suffix_l.to_vec()),
+                        Self::Short(suffix_r.to_vec()),
+                        *first_l,
+                    ));
+                }
+            }
+        }
+        None
+    }
+
+    /// Convert a [`TranslateNode`] into the corresponding Simplicity expression.
+    fn to_expr(self: Arc<Self>) -> ProgNode {
+        enum Item {
+            Convert(Arc<TranslationNode>),
+            MakeTake,
+            MakeDrop,
+            MakePair,
+        }
+
+        let mut stack = vec![Item::Convert(self)];
+        let mut output = vec![];
+
+        // We iterate over the tree in pre-order.
+        // However, we change the tree as we iterate,
+        // so using `VerbosePreOrderIter` seems impossible.
+        while let Some(top) = stack.pop() {
+            match top {
+                Item::Convert(node) => match node.as_ref() {
+                    TranslationNode::Unit => {
+                        output.push(ProgNode::unit());
+                    }
+                    TranslationNode::Short(vec) => {
+                        let mut expr = ProgNode::iden();
+                        for short in vec.iter().rev() {
+                            match short {
+                                Short::O => expr = ProgNode::take(expr),
+                                Short::I => expr = ProgNode::drop_(expr),
+                            }
+                        }
+                        output.push(expr);
+                    }
+                    TranslationNode::Pair(l, r) => {
+                        if let Some((new_l, new_r, short)) = node.eliminate_take_drop() {
+                            match short {
+                                Short::O => stack.push(Item::MakeTake),
+                                Short::I => stack.push(Item::MakeDrop),
+                            }
+                            stack.push(Item::MakePair);
+                            stack.push(Item::Convert(Arc::new(new_r)));
+                            stack.push(Item::Convert(Arc::new(new_l)));
+                        } else {
+                            stack.push(Item::MakePair);
+                            stack.push(Item::Convert(r.clone()));
+                            stack.push(Item::Convert(l.clone()));
+                        }
+                    }
+                },
+                Item::MakePair => {
+                    let expr_r = output.pop().unwrap();
+                    let expr_l = output.pop().unwrap();
+                    output.push(ProgNode::pair(expr_l, expr_r));
+                }
+                Item::MakeTake => {
+                    let expr = output.pop().unwrap();
+                    output.push(ProgNode::take(expr));
+                }
+                Item::MakeDrop => {
+                    let expr = output.pop().unwrap();
+                    output.push(ProgNode::drop_(expr));
+                }
             }
         }
 
-        Some(output)
+        debug_assert!(output.len() == 1);
+        output.pop().unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::util::DisplayNode;
+
+    #[test]
+    fn pattern_translate() {
+        let a = Pattern::Identifier(Identifier::from_str_unchecked("a"));
+        let b = Pattern::Identifier(Identifier::from_str_unchecked("b"));
+        let c = Pattern::Identifier(Identifier::from_str_unchecked("c"));
+        let env = Pattern::array([a.clone(), b.clone(), c.clone()]);
+
+        let target_expr = [
+            (a.clone(), "take take iden"),
+            (b.clone(), "take drop iden"),
+            (c.clone(), "drop iden"),
+            (Pattern::product(a.clone(), b.clone()), "take iden"),
+            (
+                Pattern::product(a.clone(), c.clone()),
+                "pair (take take iden) (drop iden)",
+            ),
+            (
+                Pattern::product(b.clone(), a.clone()),
+                "take pair (drop iden) (take iden)",
+            ),
+            (
+                Pattern::product(b.clone(), c.clone()),
+                "pair (take drop iden) (drop iden)",
+            ),
+            (
+                Pattern::product(c.clone(), a.clone()),
+                "pair (drop iden) (take take iden)",
+            ),
+            (
+                Pattern::product(c.clone(), b.clone()),
+                "pair (drop iden) (take drop iden)",
+            ),
+            (env.clone(), "iden"),
+            (
+                Pattern::product(Pattern::product(a.clone(), b.clone()), Pattern::Ignore),
+                "iden",
+            ),
+            (Pattern::product(Pattern::Ignore, c.clone()), "iden"),
+        ];
+
+        for (target, expected_expr) in target_expr {
+            let expr = env.translate(&target).unwrap();
+            assert_eq!(expected_expr, &DisplayNode::from(expr.as_ref()).to_string());
+        }
     }
 }

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -1,8 +1,8 @@
 use crate::array::{DirectedTree, Direction};
-use crate::parse::{Identifier, Pattern, WitnessName};
+use crate::parse::{Identifier, Pattern};
 use crate::{named::ProgExt, ProgNode};
 
-/// Tracker of variable bindings and witness names.
+/// Tracker of variable bindings.
 ///
 /// Internally there is a stack of scopes.
 /// A new scope is pushed for each (nested) block expression.
@@ -11,7 +11,6 @@ use crate::{named::ProgExt, ProgNode};
 #[derive(Debug, Clone)]
 pub struct GlobalScope {
     variables: Vec<Vec<Pattern>>,
-    witnesses: Vec<Vec<WitnessName>>,
 }
 
 impl Default for GlobalScope {
@@ -25,14 +24,12 @@ impl GlobalScope {
     pub fn new() -> Self {
         GlobalScope {
             variables: vec![Vec::new()],
-            witnesses: vec![Vec::new()],
         }
     }
 
     /// Pushes a new scope to the stack.
     pub fn push_scope(&mut self) {
         self.variables.push(Vec::new());
-        self.witnesses.push(Vec::new());
     }
 
     /// Pops the latest scope from the stack.
@@ -42,17 +39,11 @@ impl GlobalScope {
     /// Panics if the stack is empty.
     pub fn pop_scope(&mut self) {
         self.variables.pop().expect("Popping scope zero");
-        self.witnesses.pop().expect("Popping scope zero");
     }
 
     /// Pushes a new variable to the latest scope.
     pub fn insert(&mut self, pattern: Pattern) {
         self.variables.last_mut().unwrap().push(pattern);
-    }
-
-    /// Pushes a new witness to the latest scope.
-    pub fn insert_witness(&mut self, key: WitnessName) {
-        self.witnesses.last_mut().unwrap().push(key);
     }
 
     /// Get a Simplicity expression that returns the value of the given `identifier`.

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,93 @@
+use std::fmt;
+
+use simplicity::dag::{Dag, DagLike, NoSharing};
+use simplicity::node;
+use simplicity::node::Inner;
+
+pub struct DisplayInner<'a, M: node::Marker>(&'a node::Node<M>);
+
+impl<'a, M: node::Marker> From<&'a node::Node<M>> for DisplayInner<'a, M> {
+    fn from(node: &'a node::Node<M>) -> Self {
+        Self(node)
+    }
+}
+
+impl<'a, M: node::Marker> fmt::Display for DisplayInner<'a, M> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.0.inner() {
+            Inner::Iden => f.write_str("iden"),
+            Inner::Unit => f.write_str("unit"),
+            Inner::InjL(_) => f.write_str("injl"),
+            Inner::InjR(_) => f.write_str("injr"),
+            Inner::Take(_) => f.write_str("take"),
+            Inner::Drop(_) => f.write_str("drop"),
+            Inner::Comp(_, _) => f.write_str("comp"),
+            Inner::Case(_, _) => f.write_str("case"),
+            Inner::AssertL(_, _) => f.write_str("assertl"),
+            Inner::AssertR(_, _) => f.write_str("assertr"),
+            Inner::Pair(_, _) => f.write_str("pair"),
+            Inner::Disconnect(_, _) => f.write_str("disconnect"),
+            Inner::Witness(_) => f.write_str("witness"),
+            Inner::Fail(_) => f.write_str("fail"),
+            Inner::Jet(jet) => write!(f, "jet_{jet}"),
+            Inner::Word(value) => write!(f, "const {value}"),
+        }
+    }
+}
+
+impl<'a, M: node::Marker> fmt::Debug for DisplayInner<'a, M> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, f)
+    }
+}
+
+pub struct DisplayNode<'a, M: node::Marker>(&'a node::Node<M>);
+
+impl<'a, M: node::Marker> From<&'a node::Node<M>> for DisplayNode<'a, M> {
+    fn from(node: &'a node::Node<M>) -> Self {
+        Self(node)
+    }
+}
+
+impl<'a, M: node::Marker> fmt::Display for DisplayNode<'a, M>
+where
+    &'a node::Node<M>: DagLike,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for data in self.0.verbose_pre_order_iter::<NoSharing>() {
+            match data.n_children_yielded {
+                1 => {
+                    if let Dag::Binary(..) = data.node.inner().as_dag() {
+                        f.write_str(") (")?;
+                    } else {
+                        debug_assert!(matches!(data.node.inner().as_dag(), Dag::Unary(..)));
+                    }
+                }
+                2 => {
+                    debug_assert!(matches!(data.node.inner().as_dag(), Dag::Binary(..)));
+                    f.write_str(")")?;
+                }
+                n => {
+                    debug_assert!(n == 0, "Combinators are nullary, unary or binary");
+                    write!(f, "{}", DisplayInner::from(data.node))?;
+                    match data.node.inner().as_dag() {
+                        Dag::Unary(..) => f.write_str(" ")?,
+                        Dag::Binary(..) => f.write_str(" (")?,
+                        _ => {}
+                    }
+                }
+            };
+        }
+
+        Ok(())
+    }
+}
+
+impl<'a, M: node::Marker> fmt::Debug for DisplayNode<'a, M>
+where
+    &'a node::Node<M>: DagLike,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, f)
+    }
+}


### PR DESCRIPTION
Enable the scope to track environment values of arbitrary shape (in particular without an initial unit value). This makes it possible to create scopes for functions that expect a specific input type (the function's environment). Compute Simplicity expressions that translate between Simplicity values. The translation expression is compressed.

This is the first step to keep the Simplicity target program and its memory footprint small.