### PR TITLE
Recoverable errors

### DIFF
--- a/bitcoind-tests/Cargo.lock
+++ b/bitcoind-tests/Cargo.lock
@@ -36,18 +36,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
+name = "bech32"
+version = "0.10.0-beta"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98f7eed2b2781a6f0b5c903471d48e15f56fb4e1165df8a9a2337fd1a59d45ea"
+
+[[package]]
 name = "bitcoin"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e99ff7289b20a7385f66a0feda78af2fc119d28fb56aea8886a9cd0a4abdd75"
 dependencies = [
- "bech32",
+ "bech32 0.9.1",
  "bitcoin-private",
  "bitcoin_hashes 0.12.0",
  "hex_lit",
- "secp256k1",
+ "secp256k1 0.27.0",
  "serde",
 ]
+
+[[package]]
+name = "bitcoin"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c85783c2fe40083ea54a33aa2f0ba58831d90fcd190f5bdc47e74e84d2a96ae"
+dependencies = [
+ "bech32 0.10.0-beta",
+ "bitcoin-internals",
+ "bitcoin_hashes 0.13.0",
+ "hex-conservative",
+ "hex_lit",
+ "secp256k1 0.28.2",
+]
+
+[[package]]
+name = "bitcoin-internals"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9425c3bf7089c983facbae04de54513cce73b41c7f9ff8c845b54e7bc64ebbfb"
 
 [[package]]
 name = "bitcoin-private"
@@ -57,18 +83,22 @@ checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90064b8dee6815a6470d60bad07bbbaee885c0e12d04177138fa3291a01b7bc4"
-
-[[package]]
-name = "bitcoin_hashes"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
 dependencies = [
  "bitcoin-private",
  "serde",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1930a4dabfebb8d7d9992db18ebe3ae2876f0a305fab206fd168df931ede293b"
+dependencies = [
+ "bitcoin-internals",
+ "hex-conservative",
 ]
 
 [[package]]
@@ -91,7 +121,7 @@ dependencies = [
  "elementsd",
  "rand",
  "s-lang",
- "secp256k1",
+ "secp256k1 0.28.2",
 ]
 
 [[package]]
@@ -110,6 +140,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -117,9 +153,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "d32a725bc159af97c3e629873bb9f88fb8cf8a4867175f76dc987815ea07c83b"
 
 [[package]]
 name = "cfg-if"
@@ -147,7 +183,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581898ed9a83f31c64731b1d8ca2dfffcfec14edf1635afacd5234cddbde3a41"
 dependencies = [
- "bitcoin",
+ "bitcoin 0.30.1",
  "bitcoin-private",
  "serde",
  "serde_json",
@@ -190,14 +226,13 @@ checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "elements"
-version = "0.23.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686e85412860d3ac25988e55da4d65541714f1318bf10fd81711e08cbfdcf5b4"
+checksum = "dd6b8388053196e6b2702a45418078a654680ce9e1fd91799f51f67a40118ff5"
 dependencies = [
- "bitcoin",
+ "bitcoin 0.31.2",
  "secp256k1-zkp",
  "serde_json",
- "slip21",
 ]
 
 [[package]]
@@ -256,8 +291,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -305,6 +342,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
+name = "js-sys"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "jsonrpc"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -314,12 +360,6 @@ dependencies = [
  "serde",
  "serde_json",
 ]
-
-[[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
@@ -350,12 +390,13 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "miniscript"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1eb102b66b2127a872dbcc73095b7b47aeb9d92f7b03c2b2298253ffc82c7594"
+checksum = "86a23dd3ad145a980e231185d114399f25a0a307d2cd918010ddda6334323df9"
 dependencies = [
- "bitcoin",
- "bitcoin-private",
+ "bech32 0.10.0-beta",
+ "bitcoin 0.31.2",
+ "bitcoin-internals",
 ]
 
 [[package]]
@@ -525,13 +566,14 @@ name = "s-lang"
 version = "0.1.0"
 dependencies = [
  "base64 0.21.2",
+ "getrandom",
  "hex-conservative",
- "lazy_static",
+ "miniscript",
  "pest",
  "pest_derive",
  "serde",
  "serde_json",
- "simplicity",
+ "simplicity-lang",
 ]
 
 [[package]]
@@ -551,8 +593,19 @@ checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
 dependencies = [
  "bitcoin_hashes 0.12.0",
  "rand",
- "secp256k1-sys",
+ "secp256k1-sys 0.8.1",
  "serde",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.28.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24b59d129cdadea20aea4fb2352fa053712e5d713eee47d700cd4b2bc002f10"
+dependencies = [
+ "bitcoin_hashes 0.13.0",
+ "rand",
+ "secp256k1-sys 0.9.2",
 ]
 
 [[package]]
@@ -565,25 +618,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "secp256k1-zkp"
+name = "secp256k1-sys"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "026efcdacb95ee6aae5cc19144dc1549973eac36a4972700c28493de1ee5d69f"
+checksum = "e5d1746aae42c19d583c3c1a8c646bfad910498e2051c551a7f2e3c0c9fbb7eb"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "secp256k1-zkp"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4e48ef9c98bfbcb98bd15693ffa19676cb3e29426b75eda8b73c05cdd7959f8"
 dependencies = [
  "bitcoin-private",
  "rand",
- "secp256k1",
+ "secp256k1 0.28.2",
  "secp256k1-zkp-sys",
 ]
 
 [[package]]
 name = "secp256k1-zkp-sys"
-version = "0.8.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d03ab1ca75a18e1899e8d9b8d28b5998ae1ddcb42fec5956769718543293c723"
+checksum = "b4ead52f43074bae2ddbd1e0e66e6b170135e76117f5ea9916f33d7bd0b36e29"
 dependencies = [
  "cc",
- "secp256k1-sys",
+ "secp256k1-sys 0.9.2",
 ]
 
 [[package]]
@@ -629,14 +691,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "simplicity"
-version = "0.1.0"
-source = "git+https://github.com/BlockstreamResearch/rust-simplicity?rev=282ade747c50e6b8c97217791d9e930b7e56f73f#282ade747c50e6b8c97217791d9e930b7e56f73f"
+name = "simplicity-lang"
+version = "0.2.0"
+source = "git+https://github.com/BlockstreamResearch/rust-simplicity?rev=e3866e82001f8b62f0bdcd65dc2d0ec56462d5d7#e3866e82001f8b62f0bdcd65dc2d0ec56462d5d7"
 dependencies = [
- "bitcoin",
- "bitcoin_hashes 0.12.0",
+ "bitcoin 0.31.2",
+ "bitcoin_hashes 0.13.0",
  "byteorder",
  "elements",
+ "getrandom",
  "hex-conservative",
  "miniscript",
  "santiago",
@@ -645,21 +708,11 @@ dependencies = [
 
 [[package]]
 name = "simplicity-sys"
-version = "0.1.0"
-source = "git+https://github.com/BlockstreamResearch/rust-simplicity?rev=282ade747c50e6b8c97217791d9e930b7e56f73f#282ade747c50e6b8c97217791d9e930b7e56f73f"
+version = "0.2.0"
+source = "git+https://github.com/BlockstreamResearch/rust-simplicity?rev=e3866e82001f8b62f0bdcd65dc2d0ec56462d5d7#e3866e82001f8b62f0bdcd65dc2d0ec56462d5d7"
 dependencies = [
- "bitcoin_hashes 0.12.0",
+ "bitcoin_hashes 0.13.0",
  "cc",
- "libc",
-]
-
-[[package]]
-name = "slip21"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "516f52f3cec67962a9c414130251b512f2ff47f81980411ae01b6ce540b1ca6b"
-dependencies = [
- "bitcoin_hashes 0.11.0",
 ]
 
 [[package]]
@@ -735,6 +788,60 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "which"

--- a/bitcoind-tests/Cargo.toml
+++ b/bitcoind-tests/Cargo.toml
@@ -2,12 +2,12 @@
 name = "bitcoind-tests"
 version = "0.1.0"
 authors = ["sanket1729 <sanket1729@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-s-lang = { path = "../" }
+s-lang = { path = ".." }
 elementsd = { version = "0.8.0" }
 actual-rand = { package = "rand", version = "0.8.4" }
-secp256k1 = { version = "0.27.0", features = ["rand-std"] }
+secp256k1 = { version = "0.28.0", features = ["rand-std"] }

--- a/bitcoind-tests/tests/test_arith.rs
+++ b/bitcoind-tests/tests/test_arith.rs
@@ -5,6 +5,7 @@
 
 use std::path::Path;
 use std::str::FromStr;
+use std::sync::Arc;
 
 use ::secp256k1::XOnlyPublicKey;
 use s_lang::elements::taproot::{TaprootBuilder, LeafVersion};
@@ -35,12 +36,15 @@ fn get_vout(cl: &ElementsD, txid: Txid, value: u64, spk: Script) -> (OutPoint, T
 }
 
 pub fn test_simplicity(cl: &ElementsD, prog: &str, witness_file: &str) {
-    let prog = Path::new(prog);
+    let program_path = Path::new(prog);
     let witness_file = Path::new(witness_file);
     let secp = secp256k1::Secp256k1::new();
     let internal_key = XOnlyPublicKey::from_str("f5919fa64ce45f8306849072b26c1bfdd2937e6b81774796ff372bd1eb5362d2").unwrap();
 
-    let commit_prog = s_lang::compile(&prog);
+    let program_str = std::fs::read_to_string(program_path)
+        .map(Arc::<str>::from)
+        .unwrap();
+    let commit_prog = s_lang::compile(program_str.clone()).unwrap();
     let builder = TaprootBuilder::new();
     let script = elements::script::Script::from(commit_prog.cmr().as_ref().to_vec());
     let script_ver = (script, LeafVersion::from_u8(0xbe).unwrap());
@@ -72,7 +76,7 @@ pub fn test_simplicity(cl: &ElementsD, prog: &str, witness_file: &str) {
     psbt.add_output(psbt::Output::from_txout(out));
     let fee_out = TxOut::new_fee(3_000, witness_utxo.asset.explicit().unwrap());
     psbt.add_output(psbt::Output::from_txout(fee_out));
-    let redeem_prog = s_lang::satisfy(prog, witness_file);
+    let redeem_prog = s_lang::satisfy(program_str, witness_file).unwrap();
     psbt.inputs_mut()[0].final_script_witness =
     Some(vec![
         redeem_prog.encode_to_vec(),

--- a/src/array.rs
+++ b/src/array.rs
@@ -512,25 +512,29 @@ mod tests {
                 Pattern::product(a.clone(), b.clone()),
             ),
             // [a] = a
-            (Pattern::array([a.clone()]), a.clone()),
+            (Pattern::array([a.clone()]).unwrap(), a.clone()),
             // [[a]] = a
-            (Pattern::array([Pattern::array([a.clone()])]), a.clone()),
+            (
+                Pattern::array([Pattern::array([a.clone()]).unwrap()]).unwrap(),
+                a.clone(),
+            ),
             // [a b] = (a, b)
             (
-                Pattern::array([a.clone(), b.clone()]),
+                Pattern::array([a.clone(), b.clone()]).unwrap(),
                 Pattern::product(a.clone(), b.clone()),
             ),
             // [a b c] = ((a, b), c)
             (
-                Pattern::array([a.clone(), b.clone(), c.clone()]),
+                Pattern::array([a.clone(), b.clone(), c.clone()]).unwrap(),
                 Pattern::product(Pattern::product(a.clone(), b.clone()), c.clone()),
             ),
             // [[a, b], [c, d]] = ((a, b), (c, d))
             (
                 Pattern::array([
-                    Pattern::array([a.clone(), b.clone()]),
-                    Pattern::array([c.clone(), d.clone()]),
-                ]),
+                    Pattern::array([a.clone(), b.clone()]).unwrap(),
+                    Pattern::array([c.clone(), d.clone()]).unwrap(),
+                ])
+                .unwrap(),
                 Pattern::product(Pattern::product(a, b), Pattern::product(c, d)),
             ),
         ];

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,243 @@
+use std::fmt;
+use std::sync::Arc;
+
+use simplicity::elements;
+
+use crate::parse::{Identifier, Span, Type, UIntType};
+use crate::Rule;
+
+/// Helper trait to update a result with the affected span.
+pub trait WithSpan<T> {
+    /// Update the result with a span of the affected area in the source file.
+    fn with_span<S: Into<Span>>(self, span: S) -> Result<T, RichError>;
+}
+
+impl<T, E: Into<Error>> WithSpan<T> for Result<T, E> {
+    fn with_span<S: Into<Span>>(self, span: S) -> Result<T, RichError> {
+        self.map_err(|e| e.into().with_span(span.into()))
+    }
+}
+
+/// Helper trait to update a result with the affected source file.
+pub trait WithFile<T> {
+    /// Update the result with the source file.
+    ///
+    /// Required for pretty errors.
+    fn with_file<F: Into<Arc<str>>>(self, file: F) -> Result<T, RichError>;
+}
+
+impl<T> WithFile<T> for Result<T, RichError> {
+    fn with_file<F: Into<Arc<str>>>(self, file: F) -> Result<T, RichError> {
+        self.map_err(|e| e.with_file(file.into()))
+    }
+}
+
+/// An error enriched with context.
+///
+/// Records _what_ happened and _where_.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct RichError {
+    /// The error that occurred.
+    error: Error,
+    /// Area that the error spans inside the file.
+    span: Span,
+    /// File in which the error occurred.
+    ///
+    /// Required to print pretty errors.
+    file: Option<Arc<str>>,
+}
+
+impl RichError {
+    /// Create a new error with context.
+    pub fn new(error: Error, span: Span) -> RichError {
+        RichError {
+            error,
+            span,
+            file: None,
+        }
+    }
+
+    /// Add the file where the error occurred.
+    ///
+    /// Enable pretty errors.
+    pub fn with_file(self, file: Arc<str>) -> Self {
+        Self {
+            error: self.error,
+            span: self.span,
+            file: Some(file),
+        }
+    }
+}
+
+impl fmt::Display for RichError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let line = self.span.line.to_string();
+        writeln!(f, "{:width$} |", " ", width = line.len())?;
+
+        // FIXME: Handle objects that wrap lines
+        if let Some(ref file) = self.file {
+            if let Some(line_str) = file.lines().nth(self.span.line.get() - 1) {
+                writeln!(f, "{line} | {line_str}")?;
+                write!(f, "{:width$} |", " ", width = line.len())?;
+                write!(f, "{:width$}", " ", width = self.span.col.get())?;
+                write!(f, "{:^<width$} ", "", width = self.span.len.get())?;
+                return write!(f, "{}", self.error);
+            }
+        }
+
+        writeln!(f, "{line} | {}", self.error)?;
+        write!(f, "{:width$} |", " ", width = line.len())
+    }
+}
+
+impl std::error::Error for RichError {}
+
+impl From<RichError> for String {
+    fn from(error: RichError) -> Self {
+        error.to_string()
+    }
+}
+
+impl From<pest::error::Error<Rule>> for RichError {
+    fn from(error: pest::error::Error<Rule>) -> Self {
+        let description = error.variant.message().to_string();
+        let span = match error.line_col {
+            pest::error::LineColLocation::Pos((line, col)) => Span::new(line, col),
+            pest::error::LineColLocation::Span((line, col), (_, col_end)) => {
+                Span::new(line, col).with_len(std::cmp::max(1, col_end.saturating_sub(col)))
+            }
+        };
+
+        Self::new(Error::Grammar(description), span)
+    }
+}
+
+/// An individual error.
+///
+/// Records _what_ happened but not where.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub enum Error {
+    ArraySizeZero,
+    ListBoundPow2,
+    BitStringPow2,
+    HexStringPow2,
+    CannotParse(String),
+    Grammar(String),
+    // TODO: Remove this error once Simfony has a type system
+    CannotCompile(String),
+    JetDoesNotExist(Arc<str>),
+    TypeValueMismatch(Type),
+    InvalidDecimal(UIntType),
+    UnmatchedPattern(&'static str),
+    UndefinedVariable(Identifier),
+}
+
+#[rustfmt::skip]
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::ArraySizeZero => write!(
+                f,
+                "Array size must be positive: 1, 2, 3, 4, 5, ..."
+            ),
+            Error::ListBoundPow2 => write!(
+                f,
+                "List bound must be a power of two greater one: 2, 4, 8, 16, 32, ..."
+            ),
+            Error::BitStringPow2 => write!(
+                f,
+                "Length of bit string must be a power of two: 1, 2, 4, 8, 16, ..."
+            ),
+            Error::HexStringPow2 => write!(
+                f,
+                "Length of hex string must be a power of two: 1, 2, 4, 8, 16, ..."
+            ),
+            Error::CannotParse(description) => write!(
+                f,
+                "Cannot parse: {description}"
+            ),
+            Error::Grammar(description) => write!(
+                f,
+                "Grammar error: {description}"
+            ),
+            Error::CannotCompile(description) => write!(
+                f,
+                "Failed to compile to Simplicity: {description}"
+            ),
+            Error::JetDoesNotExist(name) => write!(
+                f,
+                "Jet `{name}` does not exist"
+            ),
+            Error::TypeValueMismatch(ty) => write!(
+                f,
+                "Value does not match the assigned type `{ty}`"
+            ),
+            Error::InvalidDecimal(ty) => write!(
+                f,
+                "Use bit strings or hex strings for values of type `{ty}`"
+            ),
+            Error::UnmatchedPattern(pattern) => write!(
+                f,
+                "Pattern `{pattern}` not covered in match"
+            ),
+            Error::UndefinedVariable(identifier) => write!(
+                f,
+                "Variable `{identifier}` is not defined"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl Error {
+    /// Enrich the error with a span.
+    pub fn with_span<S: Into<Span>>(self, span: S) -> RichError {
+        RichError::new(self, span.into())
+    }
+}
+
+impl From<elements::hex::Error> for Error {
+    fn from(error: elements::hex::Error) -> Self {
+        Self::CannotParse(error.to_string())
+    }
+}
+
+impl From<std::num::ParseIntError> for Error {
+    fn from(error: std::num::ParseIntError) -> Self {
+        Self::CannotParse(error.to_string())
+    }
+}
+
+impl From<simplicity::types::Error> for Error {
+    fn from(error: simplicity::types::Error) -> Self {
+        Self::CannotCompile(error.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FILE: &str = r#"let a1: List<u32, 2> = None;
+let b1: List<u32, 2> = Some(1);
+let c1: List<u32, 4> = (None, None);
+let a : u32 = 2;
+let b : (u16, (u8, (u4, (u2, (u1, Either<(), ()>))))) = 3;
+let (carry, res) = jet_add_32(a, b);
+let add_res = jet_add_32(10, 20);
+let (carry2, res3) = add_res;
+jet_verify(jet_eq_32(res3, 30));"#;
+
+    #[test]
+    fn display() {
+        let error = Error::ListBoundPow2
+            .with_span(Span::new(1, 14).with_len(6))
+            .with_file(Arc::from(FILE));
+        let expected = r#"
+  |
+1 | let a1: List<u32, 2> = None;
+  |              ^^^^^^ List bound must be a power of two: 1, 2, 4, 8, 16, ..."#;
+        assert_eq!(&expected[1..], &error.to_string());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub type ProgNode = Arc<named::NamedConstructNode>;
 mod array;
 pub mod compile;
 pub mod dummy_env;
+pub mod error;
 pub mod named;
 pub mod num;
 pub mod parse;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ pub fn compile_named(program: Arc<str>) -> Result<Arc<Node<Named<Commit<Elements
         .with_file(program.clone())?;
 
     let mut scope = GlobalScope::new();
-    let simplicity_program = simfony_program.eval(&mut scope);
+    let simplicity_program = simfony_program.eval(&mut scope).with_file(program)?;
     let named_commit = simplicity_program
         .finalize_types_main()
         .expect("Type check error");
@@ -237,15 +237,15 @@ mod tests {
         let inp = ProgNode::const_word(Value::u32(10));
         let node = ProgNode::jet(Elements::ParseLock);
         println!("l1: {}", node.arrow());
-        let node = ProgNode::comp(inp, node);
+        let node = ProgNode::comp(inp, node).unwrap();
         println!("l2: {}", node.arrow());
-        let node = ProgNode::pair(node, ProgNode::unit());
+        let node = ProgNode::pair(node, ProgNode::unit()).unwrap();
         println!("l3: {}", node.arrow());
         let later_operation = ProgNode::take(ProgNode::unit());
         println!("l4: {}", later_operation.arrow());
-        let assert_node = ProgNode::assertl(later_operation, Cmr::unit());
+        let assert_node = ProgNode::assertl(later_operation, Cmr::unit()).unwrap();
         println!("l5: {}", assert_node.arrow());
-        let comp = ProgNode::comp(node, assert_node);
+        let comp = ProgNode::comp(node, assert_node).unwrap();
         println!("l6: {}", comp.arrow());
         // let node2 = ProgNode::assert(&node, Cmr::unit()).unwrap();
         // println!("l3: {}", node2.arrow());

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,19 @@
+use std::env;
+use std::sync::Arc;
+
 use base64::display::Base64Display;
 use base64::engine::general_purpose::STANDARD;
 
 use s_lang::{compile, satisfy};
 
-use std::env;
-
 fn main() {
+    if let Err(error) = run() {
+        eprintln!("{error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), String> {
     // Get the command-line arguments as a Vec<String>.
     let args: Vec<String> = env::args().collect();
 
@@ -14,24 +22,29 @@ fn main() {
         println!("Usage: {} <prog.simpl> [sig.wit (optional)]", args[0]);
         println!("If no witness file is provided, the program will be compiled and printed.");
         println!("If a witness file is provided, the program will be satisfied and printed.");
-        return;
+        return Ok(());
     }
 
     // Extract the first argument (arg1).
-    let prog_file = &args[1];
-    let prog_path = std::path::Path::new(prog_file);
+    let program_file = &args[1];
+    let program_path = std::path::Path::new(program_file);
+    let program_str = std::fs::read_to_string(program_path)
+        .map(Arc::<str>::from)
+        .unwrap();
 
     // Check if a second argument (arg2) is provided.
     if args.len() >= 3 {
         let witness_file = &args[2];
         let wit_path = std::path::Path::new(witness_file);
-        let res = satisfy(prog_path, wit_path);
+        let res = satisfy(program_str, wit_path).unwrap();
         let redeem_bytes = res.encode_to_vec();
         println!("{}", Base64Display::new(&redeem_bytes, &STANDARD));
     } else {
         // No second argument is provided. Just compile the program.
-        let prog = compile(prog_path);
+        let prog = compile(program_str)?;
         let res = prog.encode_to_vec();
         println!("{}", Base64Display::new(&res, &STANDARD));
     }
+
+    Ok(())
 }

--- a/src/named.rs
+++ b/src/named.rs
@@ -148,7 +148,9 @@ pub trait ProgExt: Sized {
 
     fn iden() -> Self;
 
-    fn pair(a: Self, b: Self) -> Self;
+    // FIXME: Change back to -> Self
+    // Simfony needs a proper type system to ensure that the compiler never constructs invalid Simplicity
+    fn pair(a: Self, b: Self) -> Result<Self, types::Error>;
 
     fn injl(a: Self) -> Self;
 
@@ -158,13 +160,13 @@ pub trait ProgExt: Sized {
 
     fn drop_(a: Self) -> Self;
 
-    fn comp(a: Self, b: Self) -> Self;
+    fn comp(a: Self, b: Self) -> Result<Self, types::Error>;
 
-    fn case(a: Self, b: Self) -> Self;
+    fn case(a: Self, b: Self) -> Result<Self, types::Error>;
 
-    fn assertl(a: Self, b: Cmr) -> Self;
+    fn assertl(a: Self, b: Cmr) -> Result<Self, types::Error>;
 
-    fn assertr(a: Cmr, b: Self) -> Self;
+    fn assertr(a: Cmr, b: Self) -> Result<Self, types::Error>;
 
     fn witness(ident: Arc<str>) -> Self;
 
@@ -188,6 +190,10 @@ pub trait ProgExt: Sized {
 
     fn _true() -> Self {
         Self::injr(Self::unit())
+    }
+
+    fn pair_unwrap(a: Self, b: Self) -> Self {
+        Self::pair(a, b).unwrap()
     }
 }
 
@@ -239,8 +245,8 @@ impl ProgExt for ProgNode {
         Arc::new(NamedConstructNode::_new(Inner::Iden).unwrap())
     }
 
-    fn pair(a: Self, b: Self) -> Self {
-        Arc::new(NamedConstructNode::_new(Inner::Pair(a, b)).unwrap())
+    fn pair(a: Self, b: Self) -> Result<Self, types::Error> {
+        NamedConstructNode::_new(Inner::Pair(a, b)).map(Arc::new)
     }
 
     fn injl(a: Self) -> Self {
@@ -259,20 +265,20 @@ impl ProgExt for ProgNode {
         Arc::new(NamedConstructNode::_new(Inner::Drop(a)).unwrap())
     }
 
-    fn comp(a: Self, b: Self) -> Self {
-        Arc::new(NamedConstructNode::_new(Inner::Comp(a, b)).unwrap())
+    fn comp(a: Self, b: Self) -> Result<Self, types::Error> {
+        NamedConstructNode::_new(Inner::Comp(a, b)).map(Arc::new)
     }
 
-    fn case(a: Self, b: Self) -> Self {
-        Arc::new(NamedConstructNode::_new(Inner::Case(a, b)).unwrap())
+    fn case(a: Self, b: Self) -> Result<Self, types::Error> {
+        NamedConstructNode::_new(Inner::Case(a, b)).map(Arc::new)
     }
 
-    fn assertl(a: Self, b: Cmr) -> Self {
-        Arc::new(NamedConstructNode::_new(Inner::AssertL(a, b)).unwrap())
+    fn assertl(a: Self, b: Cmr) -> Result<Self, types::Error> {
+        NamedConstructNode::_new(Inner::AssertL(a, b)).map(Arc::new)
     }
 
-    fn assertr(a: Cmr, b: Self) -> Self {
-        Arc::new(NamedConstructNode::_new(Inner::AssertR(a, b)).unwrap())
+    fn assertr(a: Cmr, b: Self) -> Result<Self, types::Error> {
+        NamedConstructNode::_new(Inner::AssertR(a, b)).map(Arc::new)
     }
 
     fn witness(ident: Arc<str>) -> Self {

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -668,18 +668,22 @@ impl UIntType {
     }
 
     /// Parse a decimal string for the type.
-    pub fn parse_decimal(&self, decimal: &UnsignedDecimal) -> Arc<Value> {
-        match self {
-            UIntType::U1 => Value::u1(decimal.as_inner().parse::<u8>().unwrap()),
-            UIntType::U2 => Value::u2(decimal.as_inner().parse::<u8>().unwrap()),
-            UIntType::U4 => Value::u4(decimal.as_inner().parse::<u8>().unwrap()),
-            UIntType::U8 => Value::u8(decimal.as_inner().parse::<u8>().unwrap()),
-            UIntType::U16 => Value::u16(decimal.as_inner().parse::<u16>().unwrap()),
-            UIntType::U32 => Value::u32(decimal.as_inner().parse::<u32>().unwrap()),
-            UIntType::U64 => Value::u64(decimal.as_inner().parse::<u64>().unwrap()),
-            UIntType::U128 => panic!("Use bit or hex strings for u128"),
-            UIntType::U256 => panic!("Use bit or hex strings for u256"),
+    pub fn parse_decimal(&self, decimal: &UnsignedDecimal) -> Result<Arc<Value>, Error> {
+        if let UIntType::U128 | UIntType::U256 = self {
+            return Err(Error::InvalidDecimal(*self));
         }
+
+        match self {
+            UIntType::U1 => decimal.as_inner().parse::<u8>().map(Value::u1),
+            UIntType::U2 => decimal.as_inner().parse::<u8>().map(Value::u2),
+            UIntType::U4 => decimal.as_inner().parse::<u8>().map(Value::u4),
+            UIntType::U8 => decimal.as_inner().parse::<u8>().map(Value::u8),
+            UIntType::U16 => decimal.as_inner().parse::<u16>().map(Value::u16),
+            UIntType::U32 => decimal.as_inner().parse::<u32>().map(Value::u32),
+            UIntType::U64 => decimal.as_inner().parse::<u64>().map(Value::u64),
+            _ => unreachable!("Covered by outer match"),
+        }
+        .map_err(Error::from)
     }
 
     /// Convert the type into a Simplicity type.

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -539,7 +539,7 @@ impl fmt::Display for Type {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for data in self.verbose_pre_order_iter() {
             match data.node {
-                Type::Unit => f.write_str("1")?,
+                Type::Unit => f.write_str("()")?,
                 Type::Either(_, _) => match data.n_children_yielded {
                     0 => f.write_str("Either<")?,
                     1 => f.write_str(",")?,

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -550,7 +550,7 @@ impl fmt::Display for Type {
                 },
                 Type::Product(_, _) => match data.n_children_yielded {
                     0 => f.write_str("(")?,
-                    1 => f.write_str(",")?,
+                    1 => f.write_str(", ")?,
                     n => {
                         debug_assert!(n == 2);
                         f.write_str(")")?;


### PR DESCRIPTION
Replace panics with recoverable results. Print error messages in a similar way as the Rust compiler.

```text
  |
1 | let a1: [bool; 1] = 0x00;
  |                     ^^^^ Value does not match the assigned type `[bool; 1]`
```

Once Simfony has a type system, we can stop triggering low-level Simplicity errors. Users should never see Simplicity errors, much like Rust developers should never see Assembly errors.