### PR TITLE
Some error improvements

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -31,7 +31,7 @@ fn eval_blk(
         Statement::Assignment(assignment) => {
             let expr = assignment.expression.eval(scope, assignment.ty.as_ref());
             scope.insert(assignment.pattern.clone());
-            let left = ProgNode::pair(&expr, &ProgNode::iden()).unwrap();
+            let left = ProgNode::pair_iden(&expr);
             let right = eval_blk(stmts, scope, index + 1, last_expr);
             ProgNode::comp(&left, &right).unwrap()
         }
@@ -72,14 +72,14 @@ impl FuncCall {
                         // println!("jet: {}", jet.arrow());
                         ProgNode::comp(&param, &jet).unwrap()
                     }
-                    None => ProgNode::comp(&ProgNode::unit(), &jet).unwrap(),
+                    None => ProgNode::unit_comp(&jet),
                 }
             }
             FuncType::BuiltIn(..) => unimplemented!("Builtins are not supported yet"),
             FuncType::UnwrapLeft => {
                 debug_assert!(self.args.len() == 1);
                 let b = self.args[0].eval(scope, None);
-                let left_and_unit = ProgNode::pair(&b, &ProgNode::unit()).unwrap();
+                let left_and_unit = ProgNode::pair_unit(&b);
                 let fail_cmr = Cmr::fail(FailEntropy::ZERO);
                 let take_iden = ProgNode::take(&ProgNode::iden());
                 let get_inner = ProgNode::assertl(&take_iden, fail_cmr).unwrap();
@@ -88,7 +88,7 @@ impl FuncCall {
             FuncType::UnwrapRight | FuncType::Unwrap => {
                 debug_assert!(self.args.len() == 1);
                 let c = self.args[0].eval(scope, None);
-                let right_and_unit = ProgNode::pair(&c, &ProgNode::unit()).unwrap();
+                let right_and_unit = ProgNode::pair_unit(&c);
                 let fail_cmr = Cmr::fail(FailEntropy::ZERO);
                 let take_iden = ProgNode::take(&ProgNode::iden());
                 let get_inner = ProgNode::assertr(fail_cmr, &take_iden).unwrap();
@@ -138,15 +138,15 @@ impl SingleExpressionInner {
                     .to_uint()
                     .expect("Not an integer type");
                 let value = ty.parse_decimal(decimal);
-                ProgNode::comp(&ProgNode::unit(), &ProgNode::const_word(value)).unwrap()
+                ProgNode::unit_comp(&ProgNode::const_word(value))
             }
             SingleExpressionInner::BitString(bits) => {
                 let value = bits.to_simplicity();
-                ProgNode::comp(&ProgNode::unit(), &ProgNode::const_word(value)).unwrap()
+                ProgNode::unit_comp(&ProgNode::const_word(value))
             }
             SingleExpressionInner::ByteString(bytes) => {
                 let value = bytes.to_simplicity();
-                ProgNode::comp(&ProgNode::unit(), &ProgNode::const_word(value)).unwrap()
+                ProgNode::unit_comp(&ProgNode::const_word(value))
             }
             SingleExpressionInner::Witness(name) => {
                 scope.insert_witness(name.clone());
@@ -187,7 +187,7 @@ impl SingleExpressionInner {
 
                 // TODO: Enforce target type A + B for m_expr
                 let scrutinized_input = scrutinee.eval(scope, None);
-                let input = ProgNode::pair(&scrutinized_input, &ProgNode::iden()).unwrap();
+                let input = ProgNode::pair_iden(&scrutinized_input);
                 let output = ProgNode::case(&l_compiled, &r_compiled).unwrap();
                 ProgNode::comp(&input, &output).unwrap()
             }

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -1,14 +1,14 @@
 //! Compile the parsed ast into a simplicity program
 
-use std::{str::FromStr, sync::Arc};
+use std::str::FromStr;
 
-use simplicity::{jet::Elements, node, Cmr, FailEntropy};
+use simplicity::{jet::Elements, Cmr, FailEntropy};
 
 use crate::array::{BTreeSlice, Partition};
 use crate::num::NonZeroPow2Usize;
 use crate::parse::{Pattern, SingleExpressionInner, UIntType};
 use crate::{
-    named::{ConstructExt, NamedConstructNode, ProgExt},
+    named::{ConstructExt, ProgExt},
     parse::{Expression, ExpressionInner, FuncCall, FuncType, Program, Statement, Type},
     scope::GlobalScope,
     ProgNode,
@@ -23,7 +23,7 @@ fn eval_blk(
     if index >= stmts.len() {
         return match last_expr {
             Some(expr) => expr.eval(scope, None),
-            None => Arc::new(NamedConstructNode::_new(node::Inner::Unit).unwrap()),
+            None => ProgNode::unit(),
         };
     }
     match &stmts[index] {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,9 +145,10 @@ pub fn satisfy(prog: &Path, wit_file: &Path) -> RedeemNode<Elements> {
 mod tests {
     use base64::display::Base64Display;
     use base64::engine::general_purpose::STANDARD;
+    use simplicity::node::{CoreConstructible as _, JetConstructible as _};
     use simplicity::{encode, BitMachine, BitWriter, Cmr, Value};
 
-    use crate::{named::ProgExt, parse::Statement, *};
+    use crate::{parse::Statement, *};
 
     #[test]
     fn test_progs() {
@@ -254,15 +255,15 @@ mod tests {
         let inp = ProgNode::const_word(Value::u32(10));
         let node = ProgNode::jet(Elements::ParseLock);
         println!("l1: {}", node.arrow());
-        let node = ProgNode::comp(inp, node);
+        let node = ProgNode::comp(&inp, &node).unwrap();
         println!("l2: {}", node.arrow());
-        let node = ProgNode::pair(node, ProgNode::unit());
+        let node = ProgNode::pair(&node, &ProgNode::unit()).unwrap();
         println!("l3: {}", node.arrow());
-        let later_operation = ProgNode::take(ProgNode::unit());
+        let later_operation = ProgNode::take(&ProgNode::unit());
         println!("l4: {}", later_operation.arrow());
-        let assert_node = ProgNode::assertl(later_operation, Cmr::unit());
+        let assert_node = ProgNode::assertl(&later_operation, Cmr::unit()).unwrap();
         println!("l5: {}", assert_node.arrow());
-        let comp = ProgNode::comp(node, assert_node);
+        let comp = ProgNode::comp(&node, &assert_node).unwrap();
         println!("l6: {}", comp.arrow());
         // let node2 = ProgNode::assert(&node, Cmr::unit()).unwrap();
         // println!("l3: {}", node2.arrow());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@ pub fn satisfy(prog: &Path, wit_file: &Path) -> RedeemNode<Elements> {
     }
 
     impl Converter<Named<Commit<Elements>>, Redeem<Elements>> for WitFileData {
-        type Error = ();
+        type Error = std::convert::Infallible;
 
         fn convert_witness(
             &mut self,
@@ -190,7 +190,7 @@ mod tests {
         struct MyConverter;
 
         impl Converter<Named<Commit<Elements>>, Redeem<Elements>> for MyConverter {
-            type Error = ();
+            type Error = std::convert::Infallible;
 
             fn convert_witness(
                 &mut self,

--- a/src/named.rs
+++ b/src/named.rs
@@ -145,36 +145,8 @@ impl node::Marker for Named<Construct<Elements>> {
     }
 }
 
-pub trait ProgExt: Sized {
-    fn unit() -> Self;
-
-    fn iden() -> Self;
-
-    fn pair(a: Self, b: Self) -> Self;
-
-    fn injl(a: Self) -> Self;
-
-    fn injr(a: Self) -> Self;
-
-    fn take(a: Self) -> Self;
-
-    fn drop_(a: Self) -> Self;
-
-    fn comp(a: Self, b: Self) -> Self;
-
-    fn case(a: Self, b: Self) -> Self;
-
-    fn assertl(a: Self, b: Cmr) -> Self;
-
-    fn assertr(a: Cmr, b: Self) -> Self;
-
+pub trait ProgExt: CoreConstructible + Sized {
     fn witness(ident: Arc<str>) -> Self;
-
-    fn fail(entropy: FailEntropy) -> Self;
-
-    fn jet(jet: Elements) -> Self;
-
-    fn const_word(v: Arc<Value>) -> Self;
 
     fn o() -> SelectorBuilder<Self> {
         SelectorBuilder::default().o()
@@ -185,11 +157,11 @@ pub trait ProgExt: Sized {
     }
 
     fn _false() -> Self {
-        Self::injl(Self::unit())
+        Self::injl(&Self::unit())
     }
 
     fn _true() -> Self {
-        Self::injr(Self::unit())
+        Self::injr(&Self::unit())
     }
 }
 
@@ -223,8 +195,8 @@ impl<P: ProgExt> SelectorBuilder<P> {
         let mut ret = P::iden();
         for bit in self.selection.into_iter().rev() {
             match bit {
-                false => ret = P::take(ret),
-                true => ret = P::drop_(ret),
+                false => ret = P::take(&ret),
+                true => ret = P::drop_(&ret),
             }
         }
 
@@ -233,50 +205,6 @@ impl<P: ProgExt> SelectorBuilder<P> {
 }
 
 impl ProgExt for ProgNode {
-    fn unit() -> Self {
-        CoreConstructible::unit()
-    }
-
-    fn iden() -> Self {
-        CoreConstructible::iden()
-    }
-
-    fn pair(a: Self, b: Self) -> Self {
-        CoreConstructible::pair(&a, &b).unwrap() // FIXME
-    }
-
-    fn injl(a: Self) -> Self {
-        CoreConstructible::injl(&a)
-    }
-
-    fn injr(a: Self) -> Self {
-        CoreConstructible::injr(&a)
-    }
-
-    fn take(a: Self) -> Self {
-        CoreConstructible::take(&a)
-    }
-
-    fn drop_(a: Self) -> Self {
-        CoreConstructible::drop_(&a)
-    }
-
-    fn comp(a: Self, b: Self) -> Self {
-        CoreConstructible::comp(&a, &b).unwrap() // FIXME
-    }
-
-    fn case(a: Self, b: Self) -> Self {
-        CoreConstructible::case(&a, &b).unwrap() // FIXME
-    }
-
-    fn assertl(a: Self, b: Cmr) -> Self {
-        CoreConstructible::assertl(&a, b).unwrap() // FIXME
-    }
-
-    fn assertr(a: Cmr, b: Self) -> Self {
-        CoreConstructible::assertr(a, &b).unwrap() // FIXME
-    }
-
     fn witness(ident: Arc<str>) -> Self {
         Arc::new(
             NamedConstructNode::new(
@@ -288,18 +216,6 @@ impl ProgExt for ProgNode {
             )
             .unwrap(),
         )
-    }
-
-    fn fail(entropy: FailEntropy) -> Self {
-        CoreConstructible::fail(entropy)
-    }
-
-    fn jet(jet: Elements) -> Self {
-        JetConstructible::jet(jet)
-    }
-
-    fn const_word(v: Arc<Value>) -> Self {
-        CoreConstructible::const_word(v)
     }
 }
 

--- a/src/named.rs
+++ b/src/named.rs
@@ -4,7 +4,9 @@ use simplicity::jet::{Elements, Jet};
 use simplicity::node::{
     self, Commit, CommitData, CommitNode, Converter, Inner, NoDisconnect, NoWitness, Node,
 };
-use simplicity::node::{Construct, ConstructData, Constructible};
+use simplicity::node::{
+    Construct, ConstructData, Constructible, CoreConstructible, JetConstructible,
+};
 use simplicity::types;
 use simplicity::types::arrow::{Arrow, FinalArrow};
 use simplicity::{encode, FailEntropy, Value};
@@ -232,47 +234,47 @@ impl<P: ProgExt> SelectorBuilder<P> {
 
 impl ProgExt for ProgNode {
     fn unit() -> Self {
-        Arc::new(NamedConstructNode::_new(Inner::Unit).unwrap())
+        CoreConstructible::unit()
     }
 
     fn iden() -> Self {
-        Arc::new(NamedConstructNode::_new(Inner::Iden).unwrap())
+        CoreConstructible::iden()
     }
 
     fn pair(a: Self, b: Self) -> Self {
-        Arc::new(NamedConstructNode::_new(Inner::Pair(a, b)).unwrap())
+        CoreConstructible::pair(&a, &b).unwrap() // FIXME
     }
 
     fn injl(a: Self) -> Self {
-        Arc::new(NamedConstructNode::_new(Inner::InjL(a)).unwrap())
+        CoreConstructible::injl(&a)
     }
 
     fn injr(a: Self) -> Self {
-        Arc::new(NamedConstructNode::_new(Inner::InjR(a)).unwrap())
+        CoreConstructible::injr(&a)
     }
 
     fn take(a: Self) -> Self {
-        Arc::new(NamedConstructNode::_new(Inner::Take(a)).unwrap())
+        CoreConstructible::take(&a)
     }
 
     fn drop_(a: Self) -> Self {
-        Arc::new(NamedConstructNode::_new(Inner::Drop(a)).unwrap())
+        CoreConstructible::drop_(&a)
     }
 
     fn comp(a: Self, b: Self) -> Self {
-        Arc::new(NamedConstructNode::_new(Inner::Comp(a, b)).unwrap())
+        CoreConstructible::comp(&a, &b).unwrap() // FIXME
     }
 
     fn case(a: Self, b: Self) -> Self {
-        Arc::new(NamedConstructNode::_new(Inner::Case(a, b)).unwrap())
+        CoreConstructible::case(&a, &b).unwrap() // FIXME
     }
 
     fn assertl(a: Self, b: Cmr) -> Self {
-        Arc::new(NamedConstructNode::_new(Inner::AssertL(a, b)).unwrap())
+        CoreConstructible::assertl(&a, b).unwrap() // FIXME
     }
 
     fn assertr(a: Cmr, b: Self) -> Self {
-        Arc::new(NamedConstructNode::_new(Inner::AssertR(a, b)).unwrap())
+        CoreConstructible::assertr(a, &b).unwrap() // FIXME
     }
 
     fn witness(ident: Arc<str>) -> Self {
@@ -289,15 +291,15 @@ impl ProgExt for ProgNode {
     }
 
     fn fail(entropy: FailEntropy) -> Self {
-        Arc::new(NamedConstructNode::_new(Inner::Fail(entropy)).unwrap())
+        CoreConstructible::fail(entropy)
     }
 
     fn jet(jet: Elements) -> Self {
-        Arc::new(NamedConstructNode::_new(Inner::Jet(jet)).unwrap())
+        JetConstructible::jet(jet)
     }
 
     fn const_word(v: Arc<Value>) -> Self {
-        Arc::new(NamedConstructNode::_new(Inner::Word(v)).unwrap())
+        CoreConstructible::const_word(v)
     }
 }
 
@@ -353,6 +355,66 @@ pub trait ConstructExt: Sized {
     fn finalize_types_inner(&self, for_main: bool) -> Result<Arc<NamedCommitNode>, ErrorSet>;
 }
 
+fn unnamed_data(construct_data: ConstructData<Elements>) -> NamedConstructData {
+    NamedConstructData {
+        internal: construct_data,
+        name: Arc::from("NOT NAMED YET!"),
+        position: Position::default(),
+        user_source_types: Arc::new([]),
+        user_target_types: Arc::new([]),
+    }
+}
+
+impl CoreConstructible for NamedConstructData {
+    fn unit() -> Self {
+        unnamed_data(ConstructData::unit())
+    }
+    fn iden() -> Self {
+        unnamed_data(ConstructData::iden())
+    }
+    fn injl(inner: &Self) -> Self {
+        unnamed_data(ConstructData::injl(&inner.internal))
+    }
+    fn injr(inner: &Self) -> Self {
+        unnamed_data(ConstructData::injr(&inner.internal))
+    }
+    fn take(inner: &Self) -> Self {
+        unnamed_data(ConstructData::take(&inner.internal))
+    }
+    fn drop_(inner: &Self) -> Self {
+        unnamed_data(ConstructData::drop_(&inner.internal))
+    }
+    fn comp(left: &Self, right: &Self) -> Result<Self, types::Error> {
+        ConstructData::comp(&left.internal, &right.internal).map(unnamed_data)
+    }
+    fn case(left: &Self, right: &Self) -> Result<Self, types::Error> {
+        ConstructData::case(&left.internal, &right.internal).map(unnamed_data)
+    }
+
+    fn assertl(left: &Self, right: Cmr) -> Result<Self, types::Error> {
+        ConstructData::assertl(&left.internal, right).map(unnamed_data)
+    }
+    fn assertr(left: Cmr, right: &Self) -> Result<Self, types::Error> {
+        ConstructData::assertr(left, &right.internal).map(unnamed_data)
+    }
+    fn pair(left: &Self, right: &Self) -> Result<Self, types::Error> {
+        ConstructData::pair(&left.internal, &right.internal).map(unnamed_data)
+    }
+
+    fn fail(entropy: FailEntropy) -> Self {
+        unnamed_data(ConstructData::fail(entropy))
+    }
+    fn const_word(value: Arc<Value>) -> Self {
+        unnamed_data(ConstructData::const_word(value))
+    }
+}
+
+impl JetConstructible<Elements> for NamedConstructData {
+    fn jet(j: Elements) -> Self {
+        unnamed_data(ConstructData::jet(j))
+    }
+}
+
 impl ConstructExt for NamedConstructNode {
     /// Construct a named construct node from parts.
     fn _new(
@@ -365,14 +427,7 @@ impl ConstructExt for NamedConstructNode {
                 .map_disconnect(|_| &None)
                 .copy_witness(),
         )?;
-        let named_data = NamedConstructData {
-            internal: construct_data,
-            name: Arc::from("NOT NAMED YET!"),
-            position: Position::default(),
-            user_source_types: Arc::new([]),
-            user_target_types: Arc::new([]),
-        };
-        Ok(Node::from_parts(inner, named_data))
+        Ok(Node::from_parts(inner, unnamed_data(construct_data)))
     }
 
     /// Construct a named construct node from parts.

--- a/src/named.rs
+++ b/src/named.rs
@@ -81,7 +81,7 @@ impl NamedExt for NamedCommitNode {
         struct Forgetter;
 
         impl Converter<Named<Commit<Elements>>, Commit<Elements>> for Forgetter {
-            type Error = ();
+            type Error = std::convert::Infallible;
             fn convert_witness(
                 &mut self,
                 _: &PostOrderIterItem<&NamedCommitNode>,

--- a/src/named.rs
+++ b/src/named.rs
@@ -163,6 +163,18 @@ pub trait ProgExt: CoreConstructible + Sized {
     fn _true() -> Self {
         Self::injr(&Self::unit())
     }
+
+    fn unit_comp(&self) -> Self {
+        Self::comp(&Self::unit(), self).unwrap() // composing with unit always typechecks
+    }
+
+    fn pair_iden(&self) -> Self {
+        Self::pair(self, &Self::iden()).unwrap() // pairing with iden always typechecks
+    }
+
+    fn pair_unit(&self) -> Self {
+        Self::pair(self, &Self::unit()).unwrap() // pairing with unit always typechecks
+    }
 }
 
 #[derive(Debug, Clone, Hash)]

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -1,6 +1,7 @@
 use crate::array::{DirectedTree, Direction};
 use crate::parse::{Identifier, Pattern, WitnessName};
-use crate::{named::ProgExt, ProgNode};
+use crate::ProgNode;
+use simplicity::node::CoreConstructible as _;
 
 /// Tracker of variable bindings and witness names.
 ///
@@ -112,9 +113,9 @@ impl GlobalScope {
             {
                 pos += pattern_pos;
 
-                expr = ProgNode::take(expr);
+                expr = ProgNode::take(&expr);
                 for _ in 0..pos {
-                    expr = ProgNode::drop_(expr);
+                    expr = ProgNode::drop_(&expr);
                 }
 
                 return expr;
@@ -149,8 +150,8 @@ impl Pattern {
         let mut output = ProgNode::iden();
         while let Some(direction) = path.pop() {
             match direction {
-                Direction::Left => output = ProgNode::take(output),
-                Direction::Right => output = ProgNode::drop_(output),
+                Direction::Left => output = ProgNode::take(&output),
+                Direction::Right => output = ProgNode::drop_(&output),
                 Direction::Down => unreachable!("There are no unary patterns"),
                 Direction::Index(..) => unreachable!("Base patterns exclude arrays"),
             }


### PR DESCRIPTION
Mostly, moves `unwrap`s out of hiding into the compiler where they belong. I did not vet that any of the remaining unwrap()s are actually correct. But I was able to eliminate a ton of them that I was sure *were* correct.