### PR TITLE
Parse with errors

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -512,25 +512,29 @@ mod tests {
                 Pattern::product(a.clone(), b.clone()),
             ),
             // [a] = a
-            (Pattern::array([a.clone()]), a.clone()),
+            (Pattern::array([a.clone()]).unwrap(), a.clone()),
             // [[a]] = a
-            (Pattern::array([Pattern::array([a.clone()])]), a.clone()),
+            (
+                Pattern::array([Pattern::array([a.clone()]).unwrap()]).unwrap(),
+                a.clone(),
+            ),
             // [a b] = (a, b)
             (
-                Pattern::array([a.clone(), b.clone()]),
+                Pattern::array([a.clone(), b.clone()]).unwrap(),
                 Pattern::product(a.clone(), b.clone()),
             ),
             // [a b c] = ((a, b), c)
             (
-                Pattern::array([a.clone(), b.clone(), c.clone()]),
+                Pattern::array([a.clone(), b.clone(), c.clone()]).unwrap(),
                 Pattern::product(Pattern::product(a.clone(), b.clone()), c.clone()),
             ),
             // [[a, b], [c, d]] = ((a, b), (c, d))
             (
                 Pattern::array([
-                    Pattern::array([a.clone(), b.clone()]),
-                    Pattern::array([c.clone(), d.clone()]),
-                ]),
+                    Pattern::array([a.clone(), b.clone()]).unwrap(),
+                    Pattern::array([c.clone(), d.clone()]).unwrap(),
+                ])
+                .unwrap(),
                 Pattern::product(Pattern::product(a, b), Pattern::product(c, d)),
             ),
         ];

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,240 @@
+use std::fmt;
+use std::sync::Arc;
+
+use simplicity::elements;
+
+use crate::parse::{Position, Span};
+use crate::Rule;
+
+/// Helper trait to convert `Result<T, E>` into `Result<T, RichError>`.
+pub trait WithSpan<T> {
+    /// Update the result with the affected span.
+    fn with_span<S: Into<Span>>(self, span: S) -> Result<T, RichError>;
+}
+
+impl<T, E: Into<Error>> WithSpan<T> for Result<T, E> {
+    fn with_span<S: Into<Span>>(self, span: S) -> Result<T, RichError> {
+        self.map_err(|e| e.into().with_span(span.into()))
+    }
+}
+
+/// Helper trait to update `Result<A, RichError>` with the the affected source file.
+pub trait WithFile<T> {
+    /// Update the result with the affected source file.
+    ///
+    /// Enable pretty errors.
+    fn with_file<F: Into<Arc<str>>>(self, file: F) -> Result<T, RichError>;
+}
+
+impl<T> WithFile<T> for Result<T, RichError> {
+    fn with_file<F: Into<Arc<str>>>(self, file: F) -> Result<T, RichError> {
+        self.map_err(|e| e.with_file(file.into()))
+    }
+}
+
+/// An error enriched with context.
+///
+/// Records _what_ happened and _where_.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct RichError {
+    /// The error that occurred.
+    error: Error,
+    /// Area that the error spans inside the file.
+    span: Span,
+    /// File in which the error occurred.
+    ///
+    /// Required to print pretty errors.
+    file: Option<Arc<str>>,
+}
+
+impl RichError {
+    /// Create a new error with context.
+    pub fn new(error: Error, span: Span) -> RichError {
+        RichError {
+            error,
+            span,
+            file: None,
+        }
+    }
+
+    /// Add the source file where the error occurred.
+    ///
+    /// Enable pretty errors.
+    pub fn with_file(self, file: Arc<str>) -> Self {
+        Self {
+            error: self.error,
+            span: self.span,
+            file: Some(file),
+        }
+    }
+}
+
+impl fmt::Display for RichError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let start_line_index = self.span.start.line.get() - 1;
+        let end_line_index = self.span.end.line.get() - 1;
+        let line_num_width = self.span.end.line.get().to_string().len();
+        writeln!(f, "{:width$} |", " ", width = line_num_width)?;
+
+        if let Some(ref file) = self.file {
+            let mut lines = file.lines().skip(start_line_index).peekable();
+            let start_line_len = lines.peek().map(|l| l.len()).unwrap_or(0);
+            for (relative_line_index, line_str) in lines
+                .take(end_line_index - start_line_index + 1)
+                .enumerate()
+            {
+                let line_num = start_line_index + relative_line_index + 1;
+                writeln!(f, "{line_num:line_num_width$} | {line_str}")?;
+            }
+            let (underline_start, underline_length) = if self.span.is_multiline() {
+                (0, start_line_len)
+            } else {
+                (
+                    self.span.start.col.get(),
+                    self.span.end.col.get() - self.span.start.col.get(),
+                )
+            };
+            write!(f, "{:width$} |", " ", width = line_num_width)?;
+            write!(f, "{:width$}", " ", width = underline_start)?;
+            write!(f, "{:^<width$} ", "", width = underline_length)?;
+            write!(f, "{}", self.error)
+        } else {
+            let start_line_num = self.span.end.line.get();
+            write!(f, "{start_line_num} | {}", self.error)
+        }
+    }
+}
+
+impl std::error::Error for RichError {}
+
+impl From<RichError> for String {
+    fn from(error: RichError) -> Self {
+        error.to_string()
+    }
+}
+
+impl From<pest::error::Error<Rule>> for RichError {
+    fn from(error: pest::error::Error<Rule>) -> Self {
+        let description = error.variant.message().to_string();
+        let (start, end) = match error.line_col {
+            pest::error::LineColLocation::Pos((line, col)) => {
+                (Position::new(line, col), Position::new(line, col + 1))
+            }
+            pest::error::LineColLocation::Span((line, col), (line_end, col_end)) => {
+                (Position::new(line, col), Position::new(line_end, col_end))
+            }
+        };
+        let span = Span::new(start, end);
+        Self::new(Error::Grammar(description), span)
+    }
+}
+
+/// An individual error.
+///
+/// Records _what_ happened but not where.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub enum Error {
+    ArraySizeZero,
+    ListBoundPow2,
+    BitStringPow2,
+    HexStringPow2,
+    CannotParse(String),
+    Grammar(String),
+    UnmatchedPattern(String),
+}
+
+#[rustfmt::skip]
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::ArraySizeZero => write!(
+                f,
+                "Array size must be positive: 1, 2, 3, 4, 5, ..."
+            ),
+            Error::ListBoundPow2 => write!(
+                f,
+                "List bound must be a power of two greater one: 2, 4, 8, 16, 32, ..."
+            ),
+            Error::BitStringPow2 => write!(
+                f,
+                "Length of bit string must be a power of two: 1, 2, 4, 8, 16, ..."
+            ),
+            Error::HexStringPow2 => write!(
+                f,
+                "Length of hex string must be a power of two: 1, 2, 4, 8, 16, ..."
+            ),
+            Error::CannotParse(description) => write!(
+                f,
+                "Cannot parse: {description}"
+            ),
+            Error::Grammar(description) => write!(
+                f,
+                "Grammar error: {description}"
+            ),
+            Error::UnmatchedPattern(pattern) => write!(
+                f,
+                "Pattern `{pattern}` not covered in match"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl Error {
+    /// Update the error with the affected span.
+    pub fn with_span<S: Into<Span>>(self, span: S) -> RichError {
+        RichError::new(self, span.into())
+    }
+}
+
+impl From<elements::hex::Error> for Error {
+    fn from(error: elements::hex::Error) -> Self {
+        Self::CannotParse(error.to_string())
+    }
+}
+
+impl From<std::num::ParseIntError> for Error {
+    fn from(error: std::num::ParseIntError) -> Self {
+        Self::CannotParse(error.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FILE: &str = r#"let a1: List<u32, 2> = None;
+let x: u32 = Left(
+    Right(0)
+);
+"#;
+
+    #[test]
+    fn display_single_line() {
+        let error = Error::ListBoundPow2
+            .with_span(Span::new(Position::new(1, 14), Position::new(1, 20)))
+            .with_file(Arc::from(FILE));
+        let expected = r#"
+  |
+1 | let a1: List<u32, 2> = None;
+  |              ^^^^^^ List bound must be a power of two greater one: 2, 4, 8, 16, 32, ..."#;
+        assert_eq!(&expected[1..], &error.to_string());
+    }
+
+    #[test]
+    fn display_multi_line() {
+        let error = Error::CannotParse(
+            "Expected value of type `u32`, got `Either<Either<_, u32>, _>`".to_string(),
+        )
+        .with_span(Span::new(Position::new(2, 21), Position::new(4, 2)))
+        .with_file(Arc::from(FILE));
+        let expected = r#"
+  |
+2 | let x: u32 = Left(
+3 |     Right(0)
+4 | );
+  | ^^^^^^^^^^^^^^^^^^ Cannot parse: Expected value of type `u32`, got `Either<Either<_, u32>, _>`"#;
+        assert_eq!(&expected[1..], &error.to_string());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub type ProgNode = Arc<named::NamedConstructNode>;
 mod array;
 pub mod compile;
 pub mod dummy_env;
+pub mod error;
 pub mod named;
 pub mod num;
 pub mod parse;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@ pub fn _compile(file: &Path) -> Result<Arc<Node<Named<Commit<Elements>>>>, Strin
     let file = Arc::from(std::fs::read_to_string(file).unwrap());
     let simfony_program = IdentParser::parse(Rule::program, &file)
         .map_err(RichError::from)
-        .map(|mut pairs| Program::parse(pairs.next().unwrap()))
+        .and_then(|mut pairs| Program::parse(pairs.next().unwrap()))
         .with_file(file.clone())?;
 
     let mut scope = GlobalScope::new();
@@ -182,7 +182,7 @@ mod tests {
         for pair in pairs {
             for inner_pair in pair.into_inner() {
                 match inner_pair.as_rule() {
-                    Rule::statement => stmts.push(Statement::parse(inner_pair)),
+                    Rule::statement => stmts.push(Statement::parse(inner_pair).unwrap()),
                     Rule::EOI => {}
                     _ => unreachable!(),
                 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ pub extern crate simplicity;
 pub use simplicity::elements;
 
 use crate::{
+    error::{RichError, WithFile},
     named::{NamedCommitNode, NamedExt},
     parse::{PestParse, Program},
     scope::GlobalScope,
@@ -36,25 +37,27 @@ use crate::{
 #[grammar = "minimal.pest"]
 pub struct IdentParser;
 
-pub fn _compile(file: &Path) -> Arc<Node<Named<Commit<Elements>>>> {
-    let file = std::fs::read_to_string(file).unwrap();
-    let mut pairs = IdentParser::parse(Rule::program, &file).unwrap_or_else(|e| panic!("{}", e));
-
-    let prog = Program::parse(pairs.next().unwrap());
+pub fn _compile(file: &Path) -> Result<Arc<Node<Named<Commit<Elements>>>>, String> {
+    let file = Arc::from(std::fs::read_to_string(file).unwrap());
+    let simfony_program = IdentParser::parse(Rule::program, &file)
+        .map_err(RichError::from)
+        .map(|mut pairs| Program::parse(pairs.next().unwrap()))
+        .with_file(file.clone())?;
 
     let mut scope = GlobalScope::new();
-    let simplicity_prog = prog.eval(&mut scope);
-    simplicity_prog
+    let simplicity_named_commit = simfony_program.eval(&mut scope);
+    let simplicity_redeem = simplicity_named_commit
         .finalize_types_main()
-        .expect("Type check error")
+        .expect("Type check error");
+    Ok(simplicity_redeem)
 }
 
-pub fn compile(file: &Path) -> CommitNode<Elements> {
-    let node = _compile(file);
-    Arc::try_unwrap(node.to_commit_node()).unwrap()
+pub fn compile(file: &Path) -> Result<CommitNode<Elements>, String> {
+    let simplicity_named_commit = _compile(file)?;
+    Ok(Arc::try_unwrap(simplicity_named_commit.to_commit_node()).unwrap())
 }
 
-pub fn satisfy(prog: &Path, wit_file: &Path) -> RedeemNode<Elements> {
+pub fn satisfy(prog: &Path, wit_file: &Path) -> Result<RedeemNode<Elements>, String> {
     #[derive(serde::Serialize, serde::Deserialize)]
     #[serde(transparent)]
     struct WitFileData {
@@ -127,19 +130,19 @@ pub fn satisfy(prog: &Path, wit_file: &Path) -> RedeemNode<Elements> {
         }
     }
 
-    let commit_node = _compile(prog);
-    let simplicity_prog =
-        Arc::<_>::try_unwrap(commit_node).expect("Only one reference to commit node");
+    let simplicity_named_commit = _compile(prog)?;
+    let simplicity_named_commit =
+        Arc::<_>::try_unwrap(simplicity_named_commit).expect("Only one reference to commit node");
 
     let file = std::fs::File::open(wit_file).expect("Error opening witness file");
     let rdr = std::io::BufReader::new(file);
     let mut wit_data: WitFileData =
         serde_json::from_reader(rdr).expect("Error reading witness file");
 
-    let redeem_prog = simplicity_prog
+    let simplicity_redeem = simplicity_named_commit
         .convert::<NoSharing, Redeem<Elements>, _>(&mut wit_data)
         .unwrap();
-    Arc::try_unwrap(redeem_prog).unwrap()
+    Ok(Arc::try_unwrap(simplicity_redeem).unwrap())
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,16 @@ use simfony::{compile, satisfy};
 
 use std::env;
 
+// Directly returning Result<(), String> prints the error using Debug
+// Add indirection via run() to print errors using Display
 fn main() {
+    if let Err(error) = run() {
+        eprintln!("{error}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), String> {
     // Get the command-line arguments as a Vec<String>.
     let args: Vec<String> = env::args().collect();
 
@@ -14,7 +23,7 @@ fn main() {
         println!("Usage: {} <prog.simpl> [sig.wit (optional)]", args[0]);
         println!("If no witness file is provided, the program will be compiled and printed.");
         println!("If a witness file is provided, the program will be satisfied and printed.");
-        return;
+        return Ok(());
     }
 
     // Extract the first argument (arg1).
@@ -25,13 +34,15 @@ fn main() {
     if args.len() >= 3 {
         let witness_file = &args[2];
         let wit_path = std::path::Path::new(witness_file);
-        let res = satisfy(prog_path, wit_path);
+        let res = satisfy(prog_path, wit_path)?;
         let redeem_bytes = res.encode_to_vec();
         println!("{}", Base64Display::new(&redeem_bytes, &STANDARD));
     } else {
         // No second argument is provided. Just compile the program.
-        let prog = compile(prog_path);
+        let prog = compile(prog_path)?;
         let res = prog.encode_to_vec();
         println!("{}", Base64Display::new(&res, &STANDARD));
     }
+
+    Ok(())
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -539,7 +539,7 @@ impl fmt::Display for Type {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for data in self.verbose_pre_order_iter() {
             match data.node {
-                Type::Unit => f.write_str("1")?,
+                Type::Unit => f.write_str("()")?,
                 Type::Either(_, _) => match data.n_children_yielded {
                     0 => f.write_str("Either<")?,
                     1 => f.write_str(",")?,

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -550,7 +550,7 @@ impl fmt::Display for Type {
                 },
                 Type::Product(_, _) => match data.n_children_yielded {
                     0 => f.write_str("(")?,
-                    1 => f.write_str(",")?,
+                    1 => f.write_str(", ")?,
                     n => {
                         debug_assert!(n == 2);
                         f.write_str(")")?;

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -12,6 +12,7 @@ use simplicity::types::Type as SimType;
 use simplicity::Value;
 
 use crate::array::{BTreeSlice, BinaryTree, Partition};
+use crate::error::{Error, RichError, WithSpan};
 use crate::num::NonZeroPow2Usize;
 use crate::Rule;
 
@@ -124,12 +125,17 @@ impl Pattern {
     }
 
     /// Construct an array pattern.
-    pub fn array<I: IntoIterator<Item = Self>>(array: I) -> Self {
+    ///
+    /// ## Error
+    ///
+    /// The array is empty.
+    pub fn array<I: IntoIterator<Item = Self>>(array: I) -> Result<Self, Error> {
         let inner: Arc<_> = array.into_iter().collect();
         if inner.is_empty() {
-            panic!("Array must not be empty");
+            Err(Error::ArraySizeZero)
+        } else {
+            Ok(Self::Array(inner))
         }
-        Self::Array(inner)
     }
 
     /// Create an equivalent pattern that corresponds to the Simplicity base types.
@@ -723,39 +729,39 @@ impl fmt::Display for UIntType {
     }
 }
 
-pub trait PestParse {
-    fn parse(pair: pest::iterators::Pair<Rule>) -> Self;
+pub trait PestParse: Sized {
+    fn parse(pair: pest::iterators::Pair<Rule>) -> Result<Self, RichError>;
 }
 
 impl PestParse for Program {
-    fn parse(pair: pest::iterators::Pair<Rule>) -> Self {
+    fn parse(pair: pest::iterators::Pair<Rule>) -> Result<Self, RichError> {
         assert!(matches!(pair.as_rule(), Rule::program));
         let mut stmts = Vec::new();
         for inner_pair in pair.into_inner() {
             match inner_pair.as_rule() {
-                Rule::statement => stmts.push(Statement::parse(inner_pair)),
+                Rule::statement => stmts.push(Statement::parse(inner_pair)?),
                 Rule::EOI => (),
                 _ => unreachable!(),
             };
         }
-        Program { statements: stmts }
+        Ok(Program { statements: stmts })
     }
 }
 
 impl PestParse for Statement {
-    fn parse(pair: pest::iterators::Pair<Rule>) -> Self {
+    fn parse(pair: pest::iterators::Pair<Rule>) -> Result<Self, RichError> {
         assert!(matches!(pair.as_rule(), Rule::statement));
         let inner_pair = pair.into_inner().next().unwrap();
         match inner_pair.as_rule() {
-            Rule::assignment => Statement::Assignment(Assignment::parse(inner_pair)),
-            Rule::func_call => Statement::FuncCall(FuncCall::parse(inner_pair)),
-            x => panic!("{:?}", x),
+            Rule::assignment => Assignment::parse(inner_pair).map(Statement::Assignment),
+            Rule::func_call => FuncCall::parse(inner_pair).map(Statement::FuncCall),
+            _ => unreachable!("Corrupt grammar"),
         }
     }
 }
 
 impl PestParse for Pattern {
-    fn parse(pair: pest::iterators::Pair<Rule>) -> Self {
+    fn parse(pair: pest::iterators::Pair<Rule>) -> Result<Self, RichError> {
         assert!(matches!(pair.as_rule(), Rule::pattern));
         let pair = PatternPair(pair);
         let mut output = vec![];
@@ -764,7 +770,7 @@ impl PestParse for Pattern {
             match data.node.0.as_rule() {
                 Rule::pattern => {}
                 Rule::variable_pattern => {
-                    let identifier = Identifier::parse(data.node.0.into_inner().next().unwrap());
+                    let identifier = Identifier::parse(data.node.0.into_inner().next().unwrap())?;
                     output.push(Pattern::Identifier(identifier));
                 }
                 Rule::ignore_pattern => {
@@ -778,78 +784,79 @@ impl PestParse for Pattern {
                 Rule::array_pattern => {
                     assert!(0 < data.node.n_children(), "Array must be nonempty");
                     let children = output.split_off(output.len() - data.node.n_children());
-                    output.push(Pattern::Array(children.into_iter().collect()));
+                    let array = Pattern::array(children).with_span(&data.node.0)?;
+                    output.push(array);
                 }
                 _ => unreachable!("Corrupt grammar"),
             }
         }
 
         debug_assert!(output.len() == 1);
-        output.pop().unwrap()
+        Ok(output.pop().unwrap())
     }
 }
 
 impl PestParse for Identifier {
-    fn parse(pair: pest::iterators::Pair<Rule>) -> Self {
+    fn parse(pair: pest::iterators::Pair<Rule>) -> Result<Self, RichError> {
         assert!(matches!(pair.as_rule(), Rule::identifier));
         let identifier = Arc::from(pair.as_str());
-        Identifier(identifier)
+        Ok(Identifier(identifier))
     }
 }
 
 impl PestParse for Assignment {
-    fn parse(pair: pest::iterators::Pair<Rule>) -> Self {
+    fn parse(pair: pest::iterators::Pair<Rule>) -> Result<Self, RichError> {
         assert!(matches!(pair.as_rule(), Rule::assignment));
         let source_text = Arc::from(pair.as_str());
         let span = Span::from(&pair);
         let mut inner_pair = pair.into_inner();
-        let pattern = Pattern::parse(inner_pair.next().unwrap());
+        let pattern = Pattern::parse(inner_pair.next().unwrap())?;
         let reqd_ty = if let Rule::ty = inner_pair.peek().unwrap().as_rule() {
-            Some(Type::parse(inner_pair.next().unwrap()))
+            Some(Type::parse(inner_pair.next().unwrap())?)
         } else {
             None
         };
-        let expression = Expression::parse(inner_pair.next().unwrap());
-        Assignment {
+        let expression = Expression::parse(inner_pair.next().unwrap())?;
+        Ok(Assignment {
             pattern,
             ty: reqd_ty,
             expression,
             source_text,
             span,
-        }
+        })
     }
 }
 
 impl PestParse for FuncCall {
-    fn parse(pair: pest::iterators::Pair<Rule>) -> Self {
+    fn parse(pair: pest::iterators::Pair<Rule>) -> Result<Self, RichError> {
         assert!(matches!(pair.as_rule(), Rule::func_call));
         let source_text = Arc::from(pair.as_str());
         let span = Span::from(&pair);
         let inner_pair = pair.into_inner().next().unwrap();
 
-        let func_type = FuncType::parse(inner_pair.clone());
+        let func_type = FuncType::parse(inner_pair.clone())?;
         let inner_inner = inner_pair.into_inner();
         let mut args = Vec::new();
         for inner_inner_pair in inner_inner {
             match inner_inner_pair.as_rule() {
-                Rule::expression => args.push(Expression::parse(inner_inner_pair)),
+                Rule::expression => args.push(Expression::parse(inner_inner_pair)?),
                 Rule::jet => {}
                 _ => unreachable!("Corrupt grammar"),
             }
         }
 
-        FuncCall {
+        Ok(FuncCall {
             func_type,
             args: args.into_iter().collect(),
             source_text,
             span,
-        }
+        })
     }
 }
 
 impl PestParse for FuncType {
-    fn parse(pair: pest::iterators::Pair<Rule>) -> Self {
-        match pair.as_rule() {
+    fn parse(pair: pest::iterators::Pair<Rule>) -> Result<Self, RichError> {
+        let ret = match pair.as_rule() {
             Rule::jet_expr => {
                 let jet_pair = pair.into_inner().next().unwrap();
                 let jet_name = jet_pair.as_str().strip_prefix("jet_").unwrap();
@@ -858,19 +865,20 @@ impl PestParse for FuncType {
             Rule::unwrap_left_expr => FuncType::UnwrapLeft,
             Rule::unwrap_right_expr => FuncType::UnwrapRight,
             Rule::unwrap_expr => FuncType::Unwrap,
-            rule => panic!("Cannot parse rule: {:?}", rule),
-        }
+            _ => unreachable!("Corrupt grammar"),
+        };
+        Ok(ret)
     }
 }
 
 impl PestParse for Expression {
-    fn parse(pair: pest::iterators::Pair<Rule>) -> Self {
+    fn parse(pair: pest::iterators::Pair<Rule>) -> Result<Self, RichError> {
         let source_text = Arc::from(pair.as_str());
         let span = Span::from(&pair);
         let pair = match pair.as_rule() {
             Rule::expression => pair.into_inner().next().unwrap(),
             Rule::block_expression | Rule::single_expression => pair,
-            rule => panic!("Cannot parse rule: {:?}", rule),
+            _ => unreachable!("Corrupt grammar"),
         };
 
         let inner = match pair.as_rule() {
@@ -878,27 +886,27 @@ impl PestParse for Expression {
                 let mut stmts = Vec::new();
                 let mut inner_pair = pair.into_inner();
                 while let Some(Rule::statement) = inner_pair.peek().map(|x| x.as_rule()) {
-                    stmts.push(Statement::parse(inner_pair.next().unwrap()));
+                    stmts.push(Statement::parse(inner_pair.next().unwrap())?);
                 }
-                let expr = Expression::parse(inner_pair.next().unwrap());
+                let expr = Expression::parse(inner_pair.next().unwrap())?;
                 ExpressionInner::BlockExpression(stmts, Arc::new(expr))
             }
             Rule::single_expression => {
-                ExpressionInner::SingleExpression(SingleExpression::parse(pair))
+                ExpressionInner::SingleExpression(SingleExpression::parse(pair)?)
             }
             _ => unreachable!("Corrupt grammar"),
         };
 
-        Expression {
+        Ok(Expression {
             inner,
             source_text,
             span,
-        }
+        })
     }
 }
 
 impl PestParse for SingleExpression {
-    fn parse(pair: pest::iterators::Pair<Rule>) -> Self {
+    fn parse(pair: pest::iterators::Pair<Rule>) -> Result<Self, RichError> {
         assert!(matches!(pair.as_rule(), Rule::single_expression));
 
         let source_text: Arc<str> = Arc::from(pair.as_str());
@@ -909,59 +917,83 @@ impl PestParse for SingleExpression {
             Rule::unit_expr => SingleExpressionInner::Unit,
             Rule::left_expr => {
                 let l = inner_pair.into_inner().next().unwrap();
-                SingleExpressionInner::Left(Arc::new(Expression::parse(l)))
+                SingleExpressionInner::Left(Expression::parse(l).map(Arc::new)?)
             }
             Rule::right_expr => {
                 let r = inner_pair.into_inner().next().unwrap();
-                SingleExpressionInner::Right(Arc::new(Expression::parse(r)))
+                SingleExpressionInner::Right(Expression::parse(r).map(Arc::new)?)
             }
             Rule::product_expr => {
                 let mut product_pair = inner_pair.into_inner();
                 let l = product_pair.next().unwrap();
                 let r = product_pair.next().unwrap();
                 SingleExpressionInner::Product(
-                    Arc::new(Expression::parse(l)),
-                    Arc::new(Expression::parse(r)),
+                    Expression::parse(l).map(Arc::new)?,
+                    Expression::parse(r).map(Arc::new)?,
                 )
             }
             Rule::none_expr => SingleExpressionInner::None,
             Rule::some_expr => {
                 let r = inner_pair.into_inner().next().unwrap();
-                SingleExpressionInner::Some(Arc::new(Expression::parse(r)))
+                SingleExpressionInner::Some(Expression::parse(r).map(Arc::new)?)
             }
             Rule::false_expr => SingleExpressionInner::False,
             Rule::true_expr => SingleExpressionInner::True,
-            Rule::func_call => SingleExpressionInner::FuncCall(FuncCall::parse(inner_pair)),
-            Rule::bit_string => SingleExpressionInner::BitString(Bits::parse(inner_pair)),
-            Rule::byte_string => SingleExpressionInner::ByteString(Bytes::parse(inner_pair)),
+            Rule::func_call => SingleExpressionInner::FuncCall(FuncCall::parse(inner_pair)?),
+            Rule::bit_string => SingleExpressionInner::BitString(Bits::parse(inner_pair)?),
+            Rule::byte_string => SingleExpressionInner::ByteString(Bytes::parse(inner_pair)?),
             Rule::unsigned_integer => {
-                SingleExpressionInner::UnsignedInteger(UnsignedDecimal::parse(inner_pair))
+                SingleExpressionInner::UnsignedInteger(UnsignedDecimal::parse(inner_pair)?)
             }
             Rule::witness_expr => {
                 let witness_pair = inner_pair.into_inner().next().unwrap();
-                SingleExpressionInner::Witness(WitnessName::parse(witness_pair))
+                SingleExpressionInner::Witness(WitnessName::parse(witness_pair)?)
             }
             Rule::variable_expr => {
                 let identifier_pair = inner_pair.into_inner().next().unwrap();
-                SingleExpressionInner::Variable(Identifier::parse(identifier_pair))
+                SingleExpressionInner::Variable(Identifier::parse(identifier_pair)?)
             }
             Rule::expression => {
-                SingleExpressionInner::Expression(Arc::new(Expression::parse(inner_pair)))
+                SingleExpressionInner::Expression(Expression::parse(inner_pair).map(Arc::new)?)
             }
             Rule::match_expr => {
                 let mut it = inner_pair.into_inner();
-                let scrutinee = Arc::new(Expression::parse(it.next().unwrap()));
-                let first_arm = MatchArm::parse(it.next().unwrap());
-                let second_arm = MatchArm::parse(it.next().unwrap());
+                let scrutinee_pair = it.next().unwrap();
+                let scrutinee = Expression::parse(scrutinee_pair.clone()).map(Arc::new)?;
+                let first_arm = MatchArm::parse(it.next().unwrap())?;
+                let second_arm = MatchArm::parse(it.next().unwrap())?;
 
                 let (left, right) = match (&first_arm.pattern, &second_arm.pattern) {
                     (MatchPattern::Left(..), MatchPattern::Right(..)) => (first_arm, second_arm),
+                    (MatchPattern::Left(..), _) => {
+                        return Err(Error::UnmatchedPattern("Right".to_string()))
+                            .with_span(&scrutinee_pair)
+                    }
                     (MatchPattern::Right(..), MatchPattern::Left(..)) => (second_arm, first_arm),
+                    (MatchPattern::Right(..), _) => {
+                        return Err(Error::UnmatchedPattern("Left".to_string()))
+                            .with_span(&scrutinee_pair)
+                    }
                     (MatchPattern::None, MatchPattern::Some(..)) => (first_arm, second_arm),
+                    (MatchPattern::None, _) => {
+                        return Err(Error::UnmatchedPattern("Some".to_string()))
+                            .with_span(&scrutinee_pair)
+                    }
                     (MatchPattern::Some(..), MatchPattern::None) => (second_arm, first_arm),
+                    (MatchPattern::Some(..), _) => {
+                        return Err(Error::UnmatchedPattern("None".to_string()))
+                            .with_span(&scrutinee_pair)
+                    }
                     (MatchPattern::False, MatchPattern::True) => (first_arm, second_arm),
+                    (MatchPattern::False, _) => {
+                        return Err(Error::UnmatchedPattern("true".to_string()))
+                            .with_span(&scrutinee_pair)
+                    }
                     (MatchPattern::True, MatchPattern::False) => (second_arm, first_arm),
-                    _ => panic!("Non-exhaustive match expression"),
+                    (MatchPattern::True, _) => {
+                        return Err(Error::UnmatchedPattern("false".to_string()))
+                            .with_span(&scrutinee_pair)
+                    }
                 };
 
                 SingleExpressionInner::Match {
@@ -972,47 +1004,50 @@ impl PestParse for SingleExpression {
             }
             Rule::array_expr => {
                 let elements: Arc<_> = inner_pair
+                    .clone()
                     .into_inner()
                     .map(|inner| Expression::parse(inner))
-                    .collect();
-                assert!(!elements.is_empty(), "Array must be nonempty");
+                    .collect::<Result<Arc<_>, _>>()?;
+                if elements.is_empty() {
+                    return Err(Error::ArraySizeZero).with_span(&inner_pair);
+                }
                 SingleExpressionInner::Array(elements)
             }
             Rule::list_expr => {
-                let elements: Arc<_> = inner_pair
+                let elements = inner_pair
                     .into_inner()
                     .map(|inner| Expression::parse(inner))
-                    .collect();
+                    .collect::<Result<Arc<_>, _>>()?;
                 SingleExpressionInner::List(elements)
             }
             _ => unreachable!("Corrupt grammar"),
         };
 
-        SingleExpression {
+        Ok(SingleExpression {
             inner,
             source_text,
             span,
-        }
+        })
     }
 }
 
 impl PestParse for UnsignedDecimal {
-    fn parse(pair: pest::iterators::Pair<Rule>) -> Self {
+    fn parse(pair: pest::iterators::Pair<Rule>) -> Result<Self, RichError> {
         assert!(matches!(pair.as_rule(), Rule::unsigned_integer));
         let decimal = Arc::from(pair.as_str());
-        Self(decimal)
+        Ok(Self(decimal))
     }
 }
 
 impl PestParse for Bits {
-    fn parse(pair: pest::iterators::Pair<Rule>) -> Self {
+    fn parse(pair: pest::iterators::Pair<Rule>) -> Result<Self, RichError> {
         assert!(matches!(pair.as_rule(), Rule::bit_string));
         let bit_string = pair.as_str();
-        assert_eq!(&bit_string[0..2], "0b");
+        debug_assert!(&bit_string[0..2] == "0b");
 
         let bits = &bit_string[2..];
         if !bits.len().is_power_of_two() {
-            panic!("Length of bit strings must be a power of two");
+            return Err(Error::BitStringPow2).with_span(&pair);
         }
 
         let byte_len = (bits.len() + 7) / 8;
@@ -1030,7 +1065,7 @@ impl PestParse for Bits {
             bytes.push(byte);
         }
 
-        match bits.len() {
+        let ret = match bits.len() {
             1 => {
                 debug_assert!(bytes[0] < 2);
                 Bits::U1(bytes[0])
@@ -1044,56 +1079,60 @@ impl PestParse for Bits {
                 Bits::U4(bytes[0])
             }
             _ => Bits::Long(bytes.into_iter().collect()),
-        }
+        };
+        Ok(ret)
     }
 }
 
 impl PestParse for Bytes {
-    fn parse(pair: pest::iterators::Pair<Rule>) -> Self {
+    fn parse(pair: pest::iterators::Pair<Rule>) -> Result<Self, RichError> {
         assert!(matches!(pair.as_rule(), Rule::byte_string));
         let hex_string = pair.as_str();
-        assert_eq!(&hex_string[0..2], "0x");
+        debug_assert!(&hex_string[0..2] == "0x");
 
         let hex_digits = &hex_string[2..];
         if !hex_digits.len().is_power_of_two() {
-            panic!("Length of hex strings must be a power of two");
+            return Err(Error::HexStringPow2).with_span(&pair);
         }
 
-        let bytes = Vec::<u8>::from_hex(hex_digits).unwrap();
-        Bytes(bytes.into_iter().collect())
+        Vec::<u8>::from_hex(hex_digits)
+            .map_err(Error::from)
+            .with_span(&pair)
+            .map(Arc::from)
+            .map(Bytes)
     }
 }
 
 impl PestParse for WitnessName {
-    fn parse(pair: pest::iterators::Pair<Rule>) -> Self {
+    fn parse(pair: pest::iterators::Pair<Rule>) -> Result<Self, RichError> {
         assert!(matches!(pair.as_rule(), Rule::witness_name));
         let name = Arc::from(pair.as_str());
-        WitnessName(name)
+        Ok(Self(name))
     }
 }
 
 impl PestParse for MatchArm {
-    fn parse(pair: pest::iterators::Pair<Rule>) -> Self {
+    fn parse(pair: pest::iterators::Pair<Rule>) -> Result<Self, RichError> {
         assert!(matches!(pair.as_rule(), Rule::match_arm));
         let mut it = pair.into_inner();
-        let pattern = MatchPattern::parse(it.next().unwrap());
-        let expression = Arc::new(Expression::parse(it.next().unwrap()));
-        MatchArm {
+        let pattern = MatchPattern::parse(it.next().unwrap())?;
+        let expression = Expression::parse(it.next().unwrap()).map(Arc::new)?;
+        Ok(MatchArm {
             pattern,
             expression,
-        }
+        })
     }
 }
 
 impl PestParse for MatchPattern {
-    fn parse(pair: pest::iterators::Pair<Rule>) -> Self {
+    fn parse(pair: pest::iterators::Pair<Rule>) -> Result<Self, RichError> {
         assert!(matches!(pair.as_rule(), Rule::match_pattern));
         let inner_pair = pair.into_inner().next().unwrap();
         let rule = inner_pair.as_rule();
-        match rule {
+        let ret = match rule {
             Rule::left_pattern | Rule::right_pattern | Rule::some_pattern => {
                 let identifier_pair = inner_pair.into_inner().next().unwrap();
-                let identifier = Identifier::parse(identifier_pair);
+                let identifier = Identifier::parse(identifier_pair)?;
 
                 match rule {
                     Rule::left_pattern => MatchPattern::Left(identifier),
@@ -1106,12 +1145,13 @@ impl PestParse for MatchPattern {
             Rule::false_pattern => MatchPattern::False,
             Rule::true_pattern => MatchPattern::True,
             _ => unreachable!("Corrupt grammar"),
-        }
+        };
+        Ok(ret)
     }
 }
 
 impl PestParse for Type {
-    fn parse(pair: pest::iterators::Pair<Rule>) -> Self {
+    fn parse(pair: pest::iterators::Pair<Rule>) -> Result<Self, RichError> {
         enum Item {
             Type(Type),
             Size(NonZeroUsize),
@@ -1149,7 +1189,7 @@ impl PestParse for Type {
             match data.node.0.as_rule() {
                 Rule::unit_type => output.push(Item::Type(Type::Unit)),
                 Rule::unsigned_type => {
-                    let uint_ty = UIntType::parse(data.node.0);
+                    let uint_ty = UIntType::parse(data.node.0)?;
                     output.push(Item::Type(Type::UInt(uint_ty)));
                 }
                 Rule::sum_type => {
@@ -1178,7 +1218,8 @@ impl PestParse for Type {
                     let size_str = data.node.0.as_str();
                     let size = size_str
                         .parse::<NonZeroUsize>()
-                        .expect("Array size must be nonzero");
+                        .map_err(|_| Error::ArraySizeZero)
+                        .with_span(&data.node.0)?;
                     output.push(Item::Size(size));
                 }
                 Rule::list_type => {
@@ -1190,7 +1231,8 @@ impl PestParse for Type {
                     let bound_str = data.node.0.as_str();
                     let bound = bound_str
                         .parse::<NonZeroPow2Usize>()
-                        .expect("List bound must be a power of two greater than 1");
+                        .map_err(|_| Error::ListBoundPow2)
+                        .with_span(&data.node.0)?;
                     output.push(Item::Bound(bound));
                 }
                 Rule::ty => {}
@@ -1199,14 +1241,14 @@ impl PestParse for Type {
         }
 
         debug_assert!(output.len() == 1);
-        output.pop().unwrap().unwrap_type()
+        Ok(output.pop().unwrap().unwrap_type())
     }
 }
 
 impl PestParse for UIntType {
-    fn parse(pair: pest::iterators::Pair<Rule>) -> Self {
+    fn parse(pair: pest::iterators::Pair<Rule>) -> Result<Self, RichError> {
         assert!(matches!(pair.as_rule(), Rule::unsigned_type));
-        match pair.as_str() {
+        let ret = match pair.as_str() {
             "u1" => UIntType::U1,
             "u2" => UIntType::U2,
             "u4" => UIntType::U4,
@@ -1217,7 +1259,8 @@ impl PestParse for UIntType {
             "u128" => UIntType::U128,
             "u256" => UIntType::U256,
             _ => unreachable!("Corrupt grammar"),
-        }
+        };
+        Ok(ret)
     }
 }
 


### PR DESCRIPTION
Add infrastructure for relaying pretty errors to the user. Enable errors during parsing (the compiler still panics). Avoid unwraps.

Format the error messages similar to how the rust compiler does it.

```
  |
1 | let a1: List<u32, 2> = None;
  |              ^^^^^^ List bound must be a power of two greater one: 2, 4, 8, 16, 32, ...
```

Support multi-line errors.

```
  |
2 | let x: u32 = Left(
3 |     Right(0)
4 | );
  | ^^^^^^^^^^^^^^^^^^ Type mismatch: Expected value of type `u32`, got `Either<Either<_, u32>, _>`
```

An error (`RichError`) consists of an error variant (`Error`) and a context (spanned area inside a file). During parsing we attach the line/column position of the affected area. The parser works on local chunks and doesn't have access to the entire file. When parsing is done, we attach the entire file to enable pretty printing. [The human encoding follows the same approach](https://github.com/BlockstreamResearch/rust-simplicity/blob/8f25e8e89407ce29e33124995928e61661775222/simpcli/src/main.rs#L80).

Supersedes #27 