### PR TITLE
Infallible assertions

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -85,10 +85,7 @@ impl FuncCall {
                 let b = self.args[0].eval(scope, None)?;
                 let left_and_unit = ProgNode::pair_unit(&b);
                 let fail_cmr = Cmr::fail(FailEntropy::ZERO);
-                let take_iden = ProgNode::take(&ProgNode::iden());
-                // FIXME: Assertions never fail to unify
-                // Fix upstream
-                let get_inner = ProgNode::assertl(&take_iden, fail_cmr).unwrap();
+                let get_inner = ProgNode::assertl_take(&ProgNode::iden(), fail_cmr);
                 ProgNode::comp(&left_and_unit, &get_inner).with_span(self.span)
             }
             FuncType::UnwrapRight | FuncType::Unwrap => {
@@ -96,10 +93,7 @@ impl FuncCall {
                 let c = self.args[0].eval(scope, None)?;
                 let right_and_unit = ProgNode::pair_unit(&c);
                 let fail_cmr = Cmr::fail(FailEntropy::ZERO);
-                let take_iden = ProgNode::take(&ProgNode::iden());
-                // FIXME: Assertions never fail to unify
-                // Fix upstream
-                let get_inner = ProgNode::assertr(fail_cmr, &take_iden).unwrap();
+                let get_inner = ProgNode::assertr_take(fail_cmr, &ProgNode::iden());
                 ProgNode::comp(&right_and_unit, &get_inner).with_span(self.span)
             }
         }

--- a/src/named.rs
+++ b/src/named.rs
@@ -179,6 +179,26 @@ pub trait ProgExt: CoreConstructible + Sized {
     fn pair_unit(&self) -> Self {
         Self::pair(self, &Self::unit()).unwrap() // pairing with unit always typechecks
     }
+
+    /// `assertl (take s) cmr` always type checks.
+    fn assertl_take(&self, cmr: Cmr) -> Self {
+        Self::assertl(&Self::take(self), cmr).unwrap()
+    }
+
+    /// `assertl (drop s) cmr` always type checks.
+    fn assertl_drop(&self, cmr: Cmr) -> Self {
+        Self::assertl(&Self::drop_(self), cmr).unwrap()
+    }
+
+    /// `assertr cmr (drop s)` always type checks.
+    fn assertr_take(cmr: Cmr, right: &Self) -> Self {
+        Self::assertr(cmr, &Self::take(right)).unwrap()
+    }
+
+    /// `assertr cmr (take s)` always type checks.
+    fn assertr_drop(cmr: Cmr, right: &Self) -> Self {
+        Self::assertr(cmr, &Self::drop_(right)).unwrap()
+    }
 }
 
 /// Builder of expressions that contain


### PR DESCRIPTION
Introduce infallible assertions and use them in the compiler.

It turns out, assertions _can_ fail if the source type of the child is a unit or sum type. No upstream fix is needed.