### PR TITLE
Generalize Scope

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,7 +462,7 @@ dependencies = [
 [[package]]
 name = "simplicity-lang"
 version = "0.2.0"
-source = "git+https://github.com/BlockstreamResearch/rust-simplicity?rev=e3866e82001f8b62f0bdcd65dc2d0ec56462d5d7#e3866e82001f8b62f0bdcd65dc2d0ec56462d5d7"
+source = "git+https://github.com/BlockstreamResearch/rust-simplicity?rev=8f25e8e89407ce29e33124995928e61661775222#8f25e8e89407ce29e33124995928e61661775222"
 dependencies = [
  "bitcoin",
  "bitcoin_hashes",
@@ -478,7 +478,7 @@ dependencies = [
 [[package]]
 name = "simplicity-sys"
 version = "0.2.0"
-source = "git+https://github.com/BlockstreamResearch/rust-simplicity?rev=e3866e82001f8b62f0bdcd65dc2d0ec56462d5d7#e3866e82001f8b62f0bdcd65dc2d0ec56462d5d7"
+source = "git+https://github.com/BlockstreamResearch/rust-simplicity?rev=8f25e8e89407ce29e33124995928e61661775222#8f25e8e89407ce29e33124995928e61661775222"
 dependencies = [
  "bitcoin_hashes",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ pest = "2.1.3"
 pest_derive = "2.7.1"
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.105"
-simplicity-lang = { git = "https://github.com/BlockstreamResearch/rust-simplicity", rev = "e3866e82001f8b62f0bdcd65dc2d0ec56462d5d7" }
+simplicity-lang = { git = "https://github.com/BlockstreamResearch/rust-simplicity", rev = "8f25e8e89407ce29e33124995928e61661775222" }
 miniscript = "11.0.0"
 
 [target.wasm32-unknown-unknown.dependencies]

--- a/src/array.rs
+++ b/src/array.rs
@@ -330,85 +330,6 @@ impl<T: TreeLike + fmt::Display> fmt::Display for BinaryTree<T> {
     }
 }
 
-/// One step on a path from ancestor nodes to descendent nodes.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-pub enum Direction {
-    /// Go to the only child.
-    Down,
-    /// Go to the left child.
-    Left,
-    /// Go to the right child.
-    Right,
-    /// Go to the child at index `n`.
-    Index(usize),
-}
-
-/// A tree that labels each node with the path from root.
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub struct DirectedTree<T> {
-    /// Node
-    tree: T,
-    /// Path from root to the node
-    path: Vec<Direction>,
-}
-
-impl<T> From<T> for DirectedTree<T> {
-    fn from(tree: T) -> Self {
-        Self {
-            tree,
-            path: Vec::new(),
-        }
-    }
-}
-
-impl<T> DirectedTree<T> {
-    /// Extract the node and the path from root.
-    pub fn into_inner(self) -> (T, Vec<Direction>) {
-        (self.tree, self.path)
-    }
-}
-
-impl<T: TreeLike> DirectedTree<T> {
-    /// Find the first node (in pre-order) that satisfies the `predicate`.
-    ///
-    /// Return the node and the path from root to this node.
-    pub fn find<F>(self, predicate: F) -> Option<(T, Vec<Direction>)>
-    where
-        F: Fn(T) -> bool,
-    {
-        self.pre_order_iter()
-            .find(|node| predicate(node.tree.clone()))
-            .map(|node| node.into_inner())
-    }
-
-    fn go(&self, tree: T, direction: Direction) -> Self {
-        let mut path = Vec::with_capacity(self.path.len() + 1);
-        path.extend(&self.path);
-        path.push(direction);
-        Self { tree, path }
-    }
-}
-
-impl<T: TreeLike> TreeLike for DirectedTree<T> {
-    fn as_node(&self) -> Tree<Self> {
-        match self.tree.as_node() {
-            Tree::Nullary => Tree::Nullary,
-            Tree::Unary(l) => Tree::Unary(self.go(l, Direction::Down)),
-            Tree::Binary(l, r) => {
-                Tree::Binary(self.go(l, Direction::Left), self.go(r, Direction::Right))
-            }
-            Tree::Nary(ls) => {
-                let converted: Vec<_> = ls
-                    .iter()
-                    .enumerate()
-                    .map(|(index, tree)| self.go(tree.clone(), Direction::Index(index)))
-                    .collect();
-                Tree::Nary(Arc::from(converted.as_slice()))
-            }
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -465,35 +386,6 @@ mod tests {
             let partition = Partition::from_slice(&vector, block_len);
             let output = partition.fold(process, join);
             assert_eq!(&output, expected_output);
-        }
-    }
-
-    #[test]
-    fn find_path() {
-        use Direction::*;
-
-        let elements = vec![1, 2, 3, 4];
-        let tree = BTreeSlice::from_slice(&elements);
-        let directed_tree = DirectedTree::from(tree);
-
-        let target_path: [(&[u32], Option<Vec<Direction>>); 8] = [
-            (&[1, 2, 3, 4], Some(vec![])),
-            (&[1, 2], Some(vec![Left])),
-            (&[3, 4], Some(vec![Right])),
-            (&[1], Some(vec![Left, Left])),
-            (&[2], Some(vec![Left, Right])),
-            (&[3], Some(vec![Right, Left])),
-            (&[4], Some(vec![Right, Right])),
-            (&[], None),
-        ];
-
-        for (target, expected_path) in target_path {
-            let path = directed_tree
-                .clone()
-                .pre_order_iter()
-                .find(|node| node.tree.0 == target)
-                .map(|t| t.path);
-            assert_eq!(path, expected_path);
         }
     }
 

--- a/src/array.rs
+++ b/src/array.rs
@@ -413,6 +413,7 @@ impl<T: TreeLike> TreeLike for DirectedTree<T> {
 mod tests {
     use super::*;
     use crate::parse::{Identifier, Pattern};
+    use crate::scope::BasePattern;
 
     #[test]
     #[rustfmt::skip]
@@ -502,31 +503,35 @@ mod tests {
         let b = Pattern::Identifier(Identifier::from_str_unchecked("b"));
         let c = Pattern::Identifier(Identifier::from_str_unchecked("c"));
         let d = Pattern::Identifier(Identifier::from_str_unchecked("d"));
+        let a_ = BasePattern::Identifier(Identifier::from_str_unchecked("a"));
+        let b_ = BasePattern::Identifier(Identifier::from_str_unchecked("b"));
+        let c_ = BasePattern::Identifier(Identifier::from_str_unchecked("c"));
+        let d_ = BasePattern::Identifier(Identifier::from_str_unchecked("d"));
 
         let pattern_string = [
             // a = a
-            (a.clone(), a.clone()),
+            (a.clone(), a_.clone()),
             // (a, b) = (a, b)
             (
                 Pattern::product(a.clone(), b.clone()),
-                Pattern::product(a.clone(), b.clone()),
+                BasePattern::product(a_.clone(), b_.clone()),
             ),
             // [a] = a
-            (Pattern::array([a.clone()]).unwrap(), a.clone()),
+            (Pattern::array([a.clone()]).unwrap(), a_.clone()),
             // [[a]] = a
             (
                 Pattern::array([Pattern::array([a.clone()]).unwrap()]).unwrap(),
-                a.clone(),
+                a_.clone(),
             ),
             // [a b] = (a, b)
             (
                 Pattern::array([a.clone(), b.clone()]).unwrap(),
-                Pattern::product(a.clone(), b.clone()),
+                BasePattern::product(a_.clone(), b_.clone()),
             ),
             // [a b c] = ((a, b), c)
             (
                 Pattern::array([a.clone(), b.clone(), c.clone()]).unwrap(),
-                Pattern::product(Pattern::product(a.clone(), b.clone()), c.clone()),
+                BasePattern::product(BasePattern::product(a_.clone(), b_.clone()), c_.clone()),
             ),
             // [[a, b], [c, d]] = ((a, b), (c, d))
             (
@@ -535,12 +540,12 @@ mod tests {
                     Pattern::array([c.clone(), d.clone()]).unwrap(),
                 ])
                 .unwrap(),
-                Pattern::product(Pattern::product(a, b), Pattern::product(c, d)),
+                BasePattern::product(BasePattern::product(a_, b_), BasePattern::product(c_, d_)),
             ),
         ];
 
         for (pattern, expected_base_pattern) in pattern_string {
-            let base_pattern = pattern.to_base();
+            let base_pattern = BasePattern::from(&pattern);
             assert_eq!(expected_base_pattern, base_pattern);
         }
     }

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -8,6 +8,7 @@ use simplicity::{jet::Elements, Cmr, FailEntropy};
 use crate::array::{BTreeSlice, Partition};
 use crate::num::NonZeroPow2Usize;
 use crate::parse::{Pattern, SingleExpressionInner, Span, UIntType};
+use crate::scope::BasePattern;
 use crate::{
     error::{Error, RichError, WithSpan},
     named::{ConstructExt, ProgExt},
@@ -168,7 +169,7 @@ impl SingleExpressionInner {
                 ProgNode::witness(name.as_inner().clone())
             }
             SingleExpressionInner::Variable(identifier) => scope
-                .get(identifier)
+                .get(&BasePattern::Identifier(identifier.clone()))
                 .ok_or(Error::UndefinedVariable(identifier.clone()))
                 .with_span(span)?,
             SingleExpressionInner::FuncCall(call) => call.eval(scope, reqd_ty)?,

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -164,10 +164,7 @@ impl SingleExpressionInner {
                 let value = bytes.to_simplicity();
                 ProgNode::unit_comp(&ProgNode::const_word(value))
             }
-            SingleExpressionInner::Witness(name) => {
-                scope.insert_witness(name.clone());
-                ProgNode::witness(name.as_inner().clone())
-            }
+            SingleExpressionInner::Witness(name) => ProgNode::witness(name.as_inner().clone()),
             SingleExpressionInner::Variable(identifier) => scope
                 .get(&BasePattern::Identifier(identifier.clone()))
                 .ok_or(Error::UndefinedVariable(identifier.clone()))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ pub use simplicity::elements;
 use crate::{
     error::{RichError, WithFile},
     named::{NamedCommitNode, NamedExt},
-    parse::{PestParse, Program},
+    parse::{Pattern, PestParse, Program},
     scope::GlobalScope,
 };
 
@@ -44,7 +44,7 @@ pub fn _compile(file: &Path) -> Result<Arc<Node<Named<Commit<Elements>>>>, Strin
         .and_then(|mut pairs| Program::parse(pairs.next().unwrap()))
         .with_file(file.clone())?;
 
-    let mut scope = GlobalScope::new();
+    let mut scope = GlobalScope::new(Pattern::Ignore);
     let simplicity_named_commit = simfony_program.eval(&mut scope).with_file(file)?;
     let simplicity_redeem = simplicity_named_commit
         .finalize_types_main()

--- a/src/named.rs
+++ b/src/named.rs
@@ -255,6 +255,16 @@ impl<P: ProgExt> SelectorBuilder<P> {
 pub struct PairBuilder<P>(P);
 
 impl<P: ProgExt> PairBuilder<P> {
+    /// Take the expression.
+    pub fn take(self) -> Self {
+        Self(P::take(&self.0))
+    }
+
+    /// Drop the expression.
+    pub fn drop_(self) -> Self {
+        Self(P::drop_(&self.0))
+    }
+
     /// Pair two expressions.
     ///
     /// ## Left-associative:

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -11,7 +11,7 @@ use simplicity::elements::hex::FromHex;
 use simplicity::types::Type as SimType;
 use simplicity::Value;
 
-use crate::array::{BTreeSlice, BinaryTree, Partition};
+use crate::array::{BTreeSlice, Partition};
 use crate::error::{Error, RichError, WithSpan};
 use crate::num::NonZeroPow2Usize;
 use crate::Rule;
@@ -136,37 +136,6 @@ impl Pattern {
         } else {
             Ok(Self::Array(inner))
         }
-    }
-
-    /// Create an equivalent pattern that corresponds to the Simplicity base types.
-    ///
-    /// ## Base patterns
-    ///
-    /// - Identifier
-    /// - Ignore
-    /// - Product
-    pub fn to_base(&self) -> Self {
-        let binary = BinaryTree::from_tree(self);
-        let mut to_base = HashMap::new();
-
-        for data in binary.clone().post_order_iter() {
-            match data.node.as_node() {
-                Tree::Nullary => {
-                    let pattern = (*data.node.as_normal().unwrap()).clone();
-                    to_base.insert(data.node, pattern);
-                }
-                Tree::Binary(l, r) => {
-                    let l_converted = to_base.get(&l).unwrap().clone();
-                    let r_converted = to_base.get(&r).unwrap().clone();
-                    let pattern = Pattern::Product(Arc::new(l_converted), Arc::new(r_converted));
-                    to_base.insert(data.node, pattern);
-                }
-                Tree::Unary(..) => unreachable!("There are no unary patterns"),
-                Tree::Nary(..) => unreachable!("Binary trees have no arrays"),
-            }
-        }
-
-        to_base.remove(&binary).unwrap()
     }
 }
 

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -412,3 +412,34 @@ impl Pattern {
             .map(PairBuilder::get)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn translate_pattern() {
+        let a = BasePattern::Identifier(Identifier::from_str_unchecked("a"));
+        let b = BasePattern::Identifier(Identifier::from_str_unchecked("b"));
+        let c = BasePattern::Identifier(Identifier::from_str_unchecked("c"));
+        let env = BasePattern::product(BasePattern::product(a.clone(), b.clone()), c.clone());
+
+        let target_expr = [
+            (a.clone(), "OOH"),
+            (b.clone(), "OIH"),
+            (c.clone(), "IH"),
+            (BasePattern::product(a.clone(), b.clone()), "OH"),
+            (BasePattern::product(a.clone(), c.clone()), "OOH & IH"),
+            (BasePattern::product(b.clone(), a.clone()), "take (IH & OH)"),
+            (BasePattern::product(b.clone(), c.clone()), "OIH & IH"),
+            (BasePattern::product(c.clone(), a.clone()), "IH & OOH"),
+            (BasePattern::product(c.clone(), b.clone()), "IH & OIH"),
+            (env.clone(), "iden"),
+        ];
+
+        for (target, expected_expr) in target_expr {
+            let expr = env.translate(&target).unwrap();
+            assert_eq!(expected_expr, &expr.display_expr().to_string());
+        }
+    }
+}

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -225,6 +225,153 @@ impl BasePattern {
 
         true
     }
+
+    /// Get an iterator over all identifiers inside the pattern.
+    pub fn identifiers(&self) -> impl Iterator<Item = &Identifier> {
+        self.pre_order_iter().flat_map(BasePattern::as_identifier)
+    }
+
+    /// Check if all `identifiers` are contained inside the pattern.
+    pub fn contains_all<'a, I>(&self, mut identifiers: I) -> bool
+    where
+        I: Iterator<Item = &'a Identifier>,
+    {
+        identifiers.all(|id| self.contains(id))
+    }
+
+    /// Check if `self` covers the `other` pattern in terms of variable names.
+    ///
+    /// ## Coverage
+    ///
+    /// Pattern `p1` covers pattern `p2` if `p1` contains all variable names from `p2`.
+    pub fn covers(&self, other: &Self) -> bool {
+        self.contains_all(other.identifiers())
+    }
+
+    /// Check if the pattern is the ignore pattern.
+    pub fn is_ignore(&self) -> bool {
+        matches!(self, BasePattern::Ignore)
+    }
+
+    /// Check if the pattern contains an ignore pattern.
+    pub fn contains_ignore(&self) -> bool {
+        self.pre_order_iter().any(BasePattern::is_ignore)
+    }
+
+    /// Compute a Simplicity expression that takes as input a value that matches the `self` pattern
+    /// and that produces as output a value that matches the `to` pattern.
+    ///
+    /// ## Panics
+    ///
+    /// The `to` pattern contains ignore patterns: Every value matches the ignore pattern.
+    /// This means there are infinitely many translating expressions from `self` to `to`.
+    /// For instance, `iden`, `iden & iden`, `(iden & iden) & iden`, and so on.
+    /// We enforce a unique translation by banning ignore from the `to` pattern.
+    pub fn translate(&self, to: &Self) -> Option<ProgNode> {
+        #[derive(Debug, Clone)]
+        enum Task<'a> {
+            Translate(&'a BasePattern, &'a BasePattern),
+            MakeTake,
+            MakeDrop,
+            MakePair,
+        }
+
+        assert!(
+            !to.contains_ignore(),
+            "Ambiguous translation because `to` pattern contains ignore"
+        );
+        // Every variable in `to` needs a value which is extracted from `from`.
+        // If there are variables inside `to` that are not contained in `from`,
+        // then there is no translation from `from` to `to`.
+        if !self.covers(to) {
+            return None;
+        }
+
+        let mut stack = vec![Task::Translate(self, to)];
+        let mut output = vec![];
+
+        while let Some(task) = stack.pop() {
+            match task {
+                Task::Translate(from, to) => {
+                    debug_assert!(from.covers(to));
+
+                    match to {
+                        BasePattern::Ignore => {
+                            output.push(SelectorBuilder::default().h());
+                        }
+                        BasePattern::Identifier(to_id) => {
+                            output.push(from.get(to_id).map(SelectorBuilder::h)?);
+                        }
+                        BasePattern::Product(to_left, to_right) => {
+                            if to.subsumes(from) {
+                                // Every value that matches `from` also matches `to`.
+                                //
+                                // `iden` is the smallest expression that translates a value
+                                // that matches `from` into a value that matches `to`.
+                                //
+                                // The translated value is not always minimal with respect to
+                                // the pattern `to`. Here, we optimize for the size of the
+                                // translating expression and not for the size of the translated
+                                // value.
+                                output.push(SelectorBuilder::default().h());
+                            } else if let BasePattern::Product(from_left, from_right) = from {
+                                if from_right.covers(to) {
+                                    stack.push(Task::MakeDrop);
+                                    stack.push(Task::Translate(from_right, to));
+                                    continue;
+                                }
+                                if from_left.covers(to) {
+                                    stack.push(Task::MakeTake);
+                                    stack.push(Task::Translate(from_left, to));
+                                    continue;
+                                }
+
+                                stack.push(Task::MakePair);
+
+                                if from_right.covers(to_right) {
+                                    stack.push(Task::MakeDrop);
+                                    stack.push(Task::Translate(from_right, to_right));
+                                } else {
+                                    stack.push(Task::Translate(from, to_right));
+                                }
+                                if from_left.covers(to_left) {
+                                    stack.push(Task::MakeTake);
+                                    stack.push(Task::Translate(from_left, to_left));
+                                } else {
+                                    stack.push(Task::Translate(from, to_left));
+                                }
+                            } else {
+                                // Patterns contain no identifier duplicates.
+                                // The `to` pattern may not contain ignore patterns.
+                                // That is why, if the `to` pattern is a product,
+                                // then the `from` pattern must also be a product.
+                                // Otherwise, the `from` pattern would contain strictly fewer
+                                // variables than the `to` pattern, and there would be no
+                                // translation from `from` to `to`.
+                                unreachable!("The `from` pattern must be a product if the `to` pattern is a product");
+                            }
+                        }
+                    }
+                }
+                Task::MakeTake => {
+                    let translate = output.pop().unwrap();
+                    output.push(translate.take());
+                }
+                Task::MakeDrop => {
+                    let translate = output.pop().unwrap();
+                    output.push(translate.drop_());
+                }
+                Task::MakePair => {
+                    let translate_right = output.pop().unwrap();
+                    let translate_left = output.pop().unwrap();
+                    output.push(translate_left.pair(translate_right));
+                }
+            }
+        }
+
+        debug_assert_eq!(output.len(), 1);
+        output.pop().map(PairBuilder::get)
+    }
 }
 
 impl From<&Pattern> for BasePattern {

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -1,6 +1,6 @@
 use crate::array::BinaryTree;
 use crate::named::{PairBuilder, SelectorBuilder};
-use crate::parse::{Identifier, Pattern, WitnessName};
+use crate::parse::{Identifier, Pattern};
 use crate::ProgNode;
 use miniscript::iter::{Tree, TreeLike};
 use std::collections::HashMap;
@@ -15,7 +15,6 @@ use std::sync::Arc;
 #[derive(Debug, Clone)]
 pub struct GlobalScope {
     variables: Vec<Vec<Pattern>>,
-    witnesses: Vec<Vec<WitnessName>>,
 }
 
 impl GlobalScope {
@@ -23,14 +22,12 @@ impl GlobalScope {
     pub fn new(input: Pattern) -> Self {
         GlobalScope {
             variables: vec![vec![input]],
-            witnesses: vec![vec![]],
         }
     }
 
     /// Pushes a new scope to the stack.
     pub fn push_scope(&mut self) {
         self.variables.push(Vec::new());
-        self.witnesses.push(Vec::new());
     }
 
     /// Pops the latest scope from the stack.
@@ -40,17 +37,11 @@ impl GlobalScope {
     /// Panics if the stack is empty.
     pub fn pop_scope(&mut self) {
         self.variables.pop().expect("Popping scope zero");
-        self.witnesses.pop().expect("Popping scope zero");
     }
 
     /// Pushes a new variable to the latest scope.
     pub fn insert(&mut self, pattern: Pattern) {
         self.variables.last_mut().unwrap().push(pattern);
-    }
-
-    /// Pushes a new witness to the latest scope.
-    pub fn insert_witness(&mut self, key: WitnessName) {
-        self.witnesses.last_mut().unwrap().push(key);
     }
 
     /// Get a pattern that matches the input value.

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -193,6 +193,38 @@ impl BasePattern {
             }
         }
     }
+
+    /// Check if `self` subsumes the `other` pattern.
+    ///
+    /// ## Subsumption
+    ///
+    /// - Ignore: `_` subsumes every pattern.
+    /// - Identifier: `a` subsumes `b` iff `a` = `b`
+    /// - Product: `(a1, a2)` subsumes `(b1, b2)` iff `a1` subsumes `b1` and `a2` subsumes `b2`.
+    ///
+    /// ## Matching
+    ///
+    /// If value `v` matches pattern `p` and pattern `p'` subsumes `p`,
+    /// then `v` matches `p'`.
+    ///
+    /// The subsuming pattern is more general than the subsumed pattern.
+    pub fn subsumes(&self, other: &Self) -> bool {
+        let mut check_subsumes = vec![(self, other)];
+
+        while let Some((a, b)) = check_subsumes.pop() {
+            match (a, b) {
+                (BasePattern::Ignore, _) => {}
+                (BasePattern::Identifier(a_id), BasePattern::Identifier(b_id)) if a_id == b_id => {}
+                (BasePattern::Product(a1, a2), BasePattern::Product(b1, b2)) => {
+                    check_subsumes.push((a2, b2));
+                    check_subsumes.push((a1, b1));
+                }
+                _ => return false,
+            }
+        }
+
+        true
+    }
 }
 
 impl From<&Pattern> for BasePattern {


### PR DESCRIPTION
Generalize the scope to return values of multiple variables inside a pattern. We will use these values as function call arguments. The seeked value is returned by a Simplicity expression that is compressed.

Add supporting structs and documentation.

Supersedes #23