### PR TITLE
Type module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,7 +462,7 @@ dependencies = [
 [[package]]
 name = "simplicity-lang"
 version = "0.2.0"
-source = "git+https://github.com/BlockstreamResearch/rust-simplicity?rev=8f25e8e89407ce29e33124995928e61661775222#8f25e8e89407ce29e33124995928e61661775222"
+source = "git+https://github.com/BlockstreamResearch/rust-simplicity?rev=497b88fec845b3080b61b3939074b59fe24d6dec#497b88fec845b3080b61b3939074b59fe24d6dec"
 dependencies = [
  "bitcoin",
  "bitcoin_hashes",
@@ -478,7 +478,7 @@ dependencies = [
 [[package]]
 name = "simplicity-sys"
 version = "0.2.0"
-source = "git+https://github.com/BlockstreamResearch/rust-simplicity?rev=8f25e8e89407ce29e33124995928e61661775222#8f25e8e89407ce29e33124995928e61661775222"
+source = "git+https://github.com/BlockstreamResearch/rust-simplicity?rev=497b88fec845b3080b61b3939074b59fe24d6dec#497b88fec845b3080b61b3939074b59fe24d6dec"
 dependencies = [
  "bitcoin_hashes",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ pest = "2.1.3"
 pest_derive = "2.7.1"
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.105"
-simplicity-lang = { git = "https://github.com/BlockstreamResearch/rust-simplicity", rev = "8f25e8e89407ce29e33124995928e61661775222" }
+simplicity-lang = { git = "https://github.com/BlockstreamResearch/rust-simplicity", rev = "497b88fec845b3080b61b3939074b59fe24d6dec" }
 miniscript = "11.0.0"
 
 [target.wasm32-unknown-unknown.dependencies]

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -7,13 +7,14 @@ use simplicity::{jet::Elements, Cmr, FailEntropy};
 
 use crate::array::{BTreeSlice, Partition};
 use crate::num::NonZeroPow2Usize;
-use crate::parse::{Pattern, SingleExpressionInner, Span, UIntType};
+use crate::parse::{Pattern, SingleExpressionInner, Span};
 use crate::scope::BasePattern;
 use crate::{
     error::{Error, RichError, WithSpan},
     named::{ConstructExt, ProgExt},
-    parse::{Expression, ExpressionInner, FuncCall, FuncType, Program, Statement, Type},
+    parse::{Expression, ExpressionInner, FuncCall, FuncType, Program, Statement},
     scope::GlobalScope,
+    types::{Type, UIntType},
     ProgNode,
 };
 

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -14,7 +14,7 @@ use crate::{
     named::{ConstructExt, ProgExt},
     parse::{Expression, ExpressionInner, FuncCall, FuncType, Program, Statement},
     scope::GlobalScope,
-    types::{ResolvedType, UIntType},
+    types::{ResolvedType, TypeConstructible, UIntType},
     ProgNode,
 };
 
@@ -151,7 +151,7 @@ impl SingleExpressionInner {
             SingleExpressionInner::UnsignedInteger(decimal) => {
                 let reqd_ty = reqd_ty
                     .cloned()
-                    .unwrap_or(ResolvedType::UInt(UIntType::U32));
+                    .unwrap_or(ResolvedType::uint(UIntType::U32));
                 let ty = reqd_ty
                     .to_uint()
                     .ok_or(Error::TypeValueMismatch(reqd_ty))

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -152,9 +152,8 @@ impl SingleExpressionInner {
                 let reqd_ty = reqd_ty
                     .cloned()
                     .unwrap_or(ResolvedType::uint(UIntType::U32));
-                let ty = reqd_ty
-                    .to_uint()
-                    .ok_or(Error::TypeValueMismatch(reqd_ty))
+                let ty = UIntType::try_from(&reqd_ty)
+                    .map_err(|_| Error::TypeValueMismatch(reqd_ty))
                     .with_span(span)?;
                 let value = ty.parse_decimal(decimal).with_span(span)?;
                 ProgNode::unit_comp(&ProgNode::const_word(value))

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -14,7 +14,7 @@ use crate::{
     named::{ConstructExt, ProgExt},
     parse::{Expression, ExpressionInner, FuncCall, FuncType, Program, Statement},
     scope::GlobalScope,
-    types::{ResolvedType, StructuralType, TypeConstructible, UIntType},
+    types::{ResolvedType, StructuralType, TypeConstructible, TypeInner, UIntType},
     ProgNode,
 };
 
@@ -206,10 +206,15 @@ impl SingleExpressionInner {
                 ProgNode::comp(&input, &output).with_span(span)?
             }
             SingleExpressionInner::Array(elements) => {
-                let el_type = if let Some(ResolvedType::Array(ty, _)) = reqd_ty {
-                    Some(ty.as_ref())
-                } else {
-                    None
+                let el_type = match reqd_ty.map(ResolvedType::as_inner) {
+                    Some(TypeInner::Array(el_type, size)) => {
+                        if size.get() != elements.len() {
+                            return Err(Error::TypeValueMismatch(reqd_ty.unwrap().clone()))
+                                .with_span(span);
+                        }
+                        Some(el_type.as_ref())
+                    }
+                    _ => None,
                 };
                 // FIXME: Constructing pairs should never fail because when Simfony is translated to
                 // Simplicity the input type is variable. However, the fact that pairs always unify
@@ -222,22 +227,19 @@ impl SingleExpressionInner {
                 })?
             }
             SingleExpressionInner::List(elements) => {
-                let el_type = if let Some(ResolvedType::List(ty, _)) = reqd_ty {
-                    Some(ty.as_ref())
-                } else {
-                    None
+                let el_type = match reqd_ty.map(ResolvedType::as_inner) {
+                    Some(TypeInner::List(el_type, _)) => Some(el_type.as_ref()),
+                    _ => None,
                 };
                 let nodes: Vec<Result<ProgNode, RichError>> =
                     elements.iter().map(|e| e.eval(scope, el_type)).collect();
-                let bound = if let Some(list_type @ ResolvedType::List(_, bound)) = reqd_ty {
-                    if bound.get() <= nodes.len() {
-                        return Err(Error::TypeValueMismatch(list_type.clone())).with_span(span);
-                    }
-                    *bound
-                } else {
-                    NonZeroPow2Usize::next(elements.len().saturating_add(1))
+                let bound = match reqd_ty.map(ResolvedType::as_inner) {
+                    Some(TypeInner::List(_, bound)) => *bound,
+                    _ => NonZeroPow2Usize::next(elements.len().saturating_add(1)),
                 };
-
+                if bound.get() <= nodes.len() {
+                    return Err(Error::TypeValueMismatch(reqd_ty.unwrap().clone())).with_span(span);
+                }
                 // FIXME: Constructing pairs should never fail because when Simfony is translated to
                 // Simplicity the input type is variable. However, the fact that pairs always unify
                 // is hard to prove at the moment, while Simfony lacks a type system.

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -14,7 +14,7 @@ use crate::{
     named::{ConstructExt, ProgExt},
     parse::{Expression, ExpressionInner, FuncCall, FuncType, Program, Statement},
     scope::GlobalScope,
-    types::{ResolvedType, TypeConstructible, UIntType},
+    types::{ResolvedType, StructuralType, TypeConstructible, UIntType},
     ProgNode,
 };
 
@@ -266,7 +266,7 @@ impl SingleExpressionInner {
         if let Some(reqd_ty) = reqd_ty {
             expr.arrow()
                 .target
-                .unify(&reqd_ty.to_simplicity(), "")
+                .unify(&StructuralType::from(reqd_ty).to_unfinalized(), "")
                 .map_err(|_| Error::TypeValueMismatch(reqd_ty.clone()))
                 .with_span(span)?;
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,7 +3,8 @@ use std::sync::Arc;
 
 use simplicity::elements;
 
-use crate::parse::{Identifier, Position, Span, Type, UIntType};
+use crate::parse::{Identifier, Position, Span};
+use crate::types::{Type, UIntType};
 use crate::Rule;
 
 /// Helper trait to convert `Result<T, E>` into `Result<T, RichError>`.

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use simplicity::elements;
 
 use crate::parse::{Identifier, Position, Span};
-use crate::types::{Type, UIntType};
+use crate::types::{ResolvedType, UIntType};
 use crate::Rule;
 
 /// Helper trait to convert `Result<T, E>` into `Result<T, RichError>`.
@@ -147,7 +147,7 @@ pub enum Error {
     // The compiler can only be this precise if it knows a type system at least as expressive as Simplicity's
     CannotCompile(String),
     JetDoesNotExist(Arc<str>),
-    TypeValueMismatch(Type),
+    TypeValueMismatch(ResolvedType),
     InvalidDecimal(UIntType),
     UndefinedVariable(Identifier),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub mod named;
 pub mod num;
 pub mod parse;
 pub mod scope;
+mod types;
 
 use std::{collections::HashMap, path::Path, sync::Arc};
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -7,12 +7,11 @@ use std::sync::Arc;
 
 use miniscript::iter::{Tree, TreeLike};
 use simplicity::elements::hex::FromHex;
-
 use simplicity::Value;
 
 use crate::error::{Error, RichError, WithSpan};
 use crate::num::NonZeroPow2Usize;
-use crate::types::{ResolvedType, UIntType};
+use crate::types::{ResolvedType, TypeConstructible, UIntType};
 use crate::Rule;
 
 /// Position of an object inside a file.
@@ -925,32 +924,32 @@ impl PestParse for ResolvedType {
 
         for data in pair.post_order_iter() {
             match data.node.0.as_rule() {
-                Rule::unit_type => output.push(Item::Type(ResolvedType::Unit)),
+                Rule::unit_type => output.push(Item::Type(ResolvedType::unit())),
                 Rule::unsigned_type => {
                     let uint_ty = UIntType::parse(data.node.0)?;
-                    output.push(Item::Type(ResolvedType::UInt(uint_ty)));
+                    output.push(Item::Type(ResolvedType::uint(uint_ty)));
                 }
                 Rule::sum_type => {
                     let r = output.pop().unwrap().unwrap_type();
                     let l = output.pop().unwrap().unwrap_type();
-                    output.push(Item::Type(ResolvedType::Either(Arc::new(l), Arc::new(r))));
+                    output.push(Item::Type(ResolvedType::either(l, r)));
                 }
                 Rule::product_type => {
                     let r = output.pop().unwrap().unwrap_type();
                     let l = output.pop().unwrap().unwrap_type();
-                    output.push(Item::Type(ResolvedType::Product(Arc::new(l), Arc::new(r))));
+                    output.push(Item::Type(ResolvedType::product(l, r)));
                 }
                 Rule::option_type => {
                     let r = output.pop().unwrap().unwrap_type();
-                    output.push(Item::Type(ResolvedType::Option(Arc::new(r))));
+                    output.push(Item::Type(ResolvedType::option(r)));
                 }
                 Rule::boolean_type => {
-                    output.push(Item::Type(ResolvedType::Boolean));
+                    output.push(Item::Type(ResolvedType::boolean()));
                 }
                 Rule::array_type => {
                     let size = output.pop().unwrap().unwrap_size();
                     let el = output.pop().unwrap().unwrap_type();
-                    output.push(Item::Type(ResolvedType::Array(Arc::new(el), size)));
+                    output.push(Item::Type(ResolvedType::array(el, size)));
                 }
                 Rule::array_size => {
                     let size_str = data.node.0.as_str();
@@ -963,7 +962,7 @@ impl PestParse for ResolvedType {
                 Rule::list_type => {
                     let bound = output.pop().unwrap().unwrap_bound();
                     let el = output.pop().unwrap().unwrap_type();
-                    output.push(Item::Type(ResolvedType::List(Arc::new(el), bound)));
+                    output.push(Item::Type(ResolvedType::list(el, bound)));
                 }
                 Rule::list_bound => {
                     let bound_str = data.node.0.as_str();

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,19 +1,18 @@
 //! This module contains the parsing code to convert the
 //! tokens into an AST.
 
-use std::collections::HashMap;
 use std::fmt;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 use miniscript::iter::{Tree, TreeLike};
 use simplicity::elements::hex::FromHex;
-use simplicity::types::Type as SimType;
+
 use simplicity::Value;
 
-use crate::array::{BTreeSlice, Partition};
 use crate::error::{Error, RichError, WithSpan};
 use crate::num::NonZeroPow2Usize;
+use crate::types::{Type, UIntType};
 use crate::Rule;
 
 /// Position of an object inside a file.
@@ -445,229 +444,7 @@ impl MatchPattern {
     }
 }
 
-/// A Simphony type.
-#[derive(Debug, PartialEq, Eq, Hash, Clone)]
-#[non_exhaustive]
-pub enum Type {
-    Unit,
-    Either(Arc<Self>, Arc<Self>),
-    Product(Arc<Self>, Arc<Self>),
-    Option(Arc<Self>),
-    Boolean,
-    UInt(UIntType),
-    Array(Arc<Self>, NonZeroUsize),
-    List(Arc<Self>, NonZeroPow2Usize),
-}
-
-/// Normalized unsigned integer type.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
-pub enum UIntType {
-    U1,
-    U2,
-    U4,
-    U8,
-    U16,
-    U32,
-    U64,
-    U128,
-    U256,
-}
-
-impl<'a> TreeLike for &'a Type {
-    fn as_node(&self) -> Tree<Self> {
-        match self {
-            Type::Unit | Type::Boolean | Type::UInt(..) => Tree::Nullary,
-            Type::Option(l) | Type::Array(l, _) | Type::List(l, _) => Tree::Unary(l),
-            Type::Either(l, r) | Type::Product(l, r) => Tree::Binary(l, r),
-        }
-    }
-}
-
-impl Type {
-    /// Convert the type into a normalized unsigned integer type.
-    /// Return the empty value if the conversion failed.
-    pub fn to_uint(&self) -> Option<UIntType> {
-        let mut integer_type = HashMap::<&Type, UIntType>::new();
-        for data in self.post_order_iter() {
-            match data.node {
-                Type::Unit => {}
-                Type::Either(l, r) => match (l.as_ref(), r.as_ref()) {
-                    (Type::Unit, Type::Unit) => {
-                        integer_type.insert(data.node, UIntType::U1);
-                    }
-                    _ => return None,
-                },
-                Type::Product(l, r) => {
-                    let uint_l = integer_type.get(l.as_ref())?;
-                    let uint_r = integer_type.get(r.as_ref())?;
-                    if uint_l != uint_r {
-                        return None;
-                    }
-                    let uint_ty = uint_l.double()?;
-                    integer_type.insert(data.node, uint_ty);
-                }
-                Type::Option(r) => match r.as_ref() {
-                    // Option<1> = u1
-                    Type::Unit => {
-                        integer_type.insert(data.node, UIntType::U1);
-                    }
-                    _ => return None,
-                },
-                Type::Boolean => {
-                    integer_type.insert(data.node, UIntType::U1);
-                }
-                Type::UInt(ty) => {
-                    integer_type.insert(data.node, *ty);
-                }
-                Type::Array(el, size) => {
-                    if !size.is_power_of_two() {
-                        return None;
-                    }
-
-                    let mut uint = *integer_type.get(el.as_ref())?;
-                    for _ in 0..size.trailing_zeros() {
-                        match uint.double() {
-                            Some(doubled_uint) => uint = doubled_uint,
-                            None => return None,
-                        }
-                    }
-                    integer_type.insert(data.node, uint);
-                }
-                Type::List(el, bound) => match (el.as_ref(), *bound) {
-                    // List<1, 2> = Option<1> = u1
-                    (Type::Unit, NonZeroPow2Usize::TWO) => {
-                        integer_type.insert(data.node, UIntType::U1);
-                    }
-                    _ => return None,
-                },
-            }
-        }
-
-        integer_type.remove(self)
-    }
-
-    /// Convert the type into a Simplicity type.
-    pub fn to_simplicity(&self) -> SimType {
-        let mut output = vec![];
-
-        for data in self.post_order_iter() {
-            match data.node {
-                Type::Unit => output.push(SimType::unit()),
-                Type::Either(_, _) => {
-                    let r = output.pop().unwrap();
-                    let l = output.pop().unwrap();
-                    output.push(SimType::sum(l, r));
-                }
-                Type::Product(_, _) => {
-                    let r = output.pop().unwrap();
-                    let l = output.pop().unwrap();
-                    output.push(SimType::product(l, r));
-                }
-                Type::Option(_) => {
-                    let r = output.pop().unwrap();
-                    output.push(SimType::sum(SimType::unit(), r));
-                }
-                Type::Boolean => {
-                    output.push(SimType::two_two_n(0));
-                }
-                Type::UInt(ty) => output.push(ty.to_simplicity()),
-                Type::Array(_, size) => {
-                    let el = output.pop().unwrap();
-                    // Cheap clone because SimType consists of Arcs
-                    let el_vector = vec![el; size.get()];
-                    let tree = BTreeSlice::from_slice(&el_vector);
-                    output.push(tree.fold(SimType::product));
-                }
-                Type::List(_, bound) => {
-                    let el = output.pop().unwrap();
-                    // Cheap clone because SimType consists of Arcs
-                    let el_vector = vec![el; bound.get() - 1];
-                    let partition = Partition::from_slice(&el_vector, bound.get() / 2);
-                    debug_assert!(partition.is_complete());
-                    let process = |block: &[SimType]| -> SimType {
-                        debug_assert!(!block.is_empty());
-                        let tree = BTreeSlice::from_slice(block);
-                        let array = tree.fold(SimType::product);
-                        SimType::sum(SimType::unit(), array)
-                    };
-                    output.push(partition.fold(process, SimType::product));
-                }
-            }
-        }
-
-        debug_assert!(output.len() == 1);
-        output.pop().unwrap()
-    }
-}
-
-impl fmt::Display for Type {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for data in self.verbose_pre_order_iter() {
-            match data.node {
-                Type::Unit => f.write_str("()")?,
-                Type::Either(_, _) => match data.n_children_yielded {
-                    0 => f.write_str("Either<")?,
-                    1 => f.write_str(",")?,
-                    n => {
-                        debug_assert!(n == 2);
-                        f.write_str(">")?;
-                    }
-                },
-                Type::Product(_, _) => match data.n_children_yielded {
-                    0 => f.write_str("(")?,
-                    1 => f.write_str(", ")?,
-                    n => {
-                        debug_assert!(n == 2);
-                        f.write_str(")")?;
-                    }
-                },
-                Type::Option(_) => match data.n_children_yielded {
-                    0 => f.write_str("Option<")?,
-                    n => {
-                        debug_assert!(n == 1);
-                        f.write_str(">")?;
-                    }
-                },
-                Type::Boolean => f.write_str("bool")?,
-                Type::UInt(ty) => write!(f, "{ty}")?,
-                Type::Array(_, size) => match data.n_children_yielded {
-                    0 => f.write_str("[")?,
-                    n => {
-                        debug_assert!(n == 1);
-                        write!(f, "; {size}]")?;
-                    }
-                },
-                Type::List(_, bound) => match data.n_children_yielded {
-                    0 => f.write_str("List<")?,
-                    n => {
-                        debug_assert!(n == 1);
-                        write!(f, ", {bound}>")?;
-                    }
-                },
-            }
-        }
-
-        Ok(())
-    }
-}
-
 impl UIntType {
-    /// Double the bit width of the type.
-    /// Return the empty value upon overflow.
-    pub fn double(&self) -> Option<Self> {
-        match self {
-            UIntType::U1 => Some(UIntType::U2),
-            UIntType::U2 => Some(UIntType::U4),
-            UIntType::U4 => Some(UIntType::U8),
-            UIntType::U8 => Some(UIntType::U16),
-            UIntType::U16 => Some(UIntType::U32),
-            UIntType::U32 => Some(UIntType::U64),
-            UIntType::U64 => Some(UIntType::U128),
-            UIntType::U128 => Some(UIntType::U256),
-            UIntType::U256 => None,
-        }
-    }
-
     /// Parse a decimal string for the type.
     pub fn parse_decimal(&self, decimal: &UnsignedDecimal) -> Result<Arc<Value>, Error> {
         if let UIntType::U128 | UIntType::U256 = self {
@@ -685,37 +462,6 @@ impl UIntType {
             _ => unreachable!("Covered by outer match"),
         }
         .map_err(Error::from)
-    }
-
-    /// Convert the type into a Simplicity type.
-    pub fn to_simplicity(&self) -> SimType {
-        match self {
-            UIntType::U1 => SimType::two_two_n(0),
-            UIntType::U2 => SimType::two_two_n(1),
-            UIntType::U4 => SimType::two_two_n(2),
-            UIntType::U8 => SimType::two_two_n(3),
-            UIntType::U16 => SimType::two_two_n(4),
-            UIntType::U32 => SimType::two_two_n(5),
-            UIntType::U64 => SimType::two_two_n(6),
-            UIntType::U128 => SimType::two_two_n(7),
-            UIntType::U256 => SimType::two_two_n(8),
-        }
-    }
-}
-
-impl fmt::Display for UIntType {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            UIntType::U1 => f.write_str("u1"),
-            UIntType::U2 => f.write_str("u2"),
-            UIntType::U4 => f.write_str("u4"),
-            UIntType::U8 => f.write_str("u8"),
-            UIntType::U16 => f.write_str("u16"),
-            UIntType::U32 => f.write_str("u32"),
-            UIntType::U64 => f.write_str("u64"),
-            UIntType::U128 => f.write_str("u128"),
-            UIntType::U256 => f.write_str("u256"),
-        }
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -86,6 +86,67 @@ impl fmt::Display for UIntType {
     }
 }
 
+/// Various type constructors.
+pub trait TypeConstructible: Sized {
+    /// Create the unit type.
+    fn unit() -> Self;
+
+    /// Create a sum of the given `left` and `right` types.
+    fn either(left: Self, right: Self) -> Self;
+
+    /// Create a product of the given `left` and `right` types.
+    fn product(left: Self, right: Self) -> Self;
+
+    /// Create an option of the given `inner` type.
+    fn option(inner: Self) -> Self;
+
+    /// Create the Boolean type.
+    fn boolean() -> Self;
+
+    /// Create an unsigned `integer` type.
+    fn uint(integer: UIntType) -> Self;
+
+    /// Create an array with `size` many values of the `element` type.
+    fn array(element: Self, size: NonZeroUsize) -> Self;
+
+    /// Create a list with less than `bound` many values of the `element` type.
+    fn list(element: Self, bound: NonZeroPow2Usize) -> Self;
+}
+
+impl TypeConstructible for ResolvedType {
+    fn unit() -> Self {
+        Self::Unit
+    }
+
+    fn either(left: Self, right: Self) -> Self {
+        Self::Either(Arc::new(left), Arc::new(right))
+    }
+
+    fn product(left: Self, right: Self) -> Self {
+        Self::Product(Arc::new(left), Arc::new(right))
+    }
+
+    fn option(inner: Self) -> Self {
+        Self::Option(Arc::new(inner))
+    }
+
+    fn boolean() -> Self {
+        Self::Boolean
+    }
+
+    fn uint(integer: UIntType) -> Self {
+        Self::UInt(integer)
+    }
+
+    fn array(element: Self, size: NonZeroUsize) -> Self {
+        Self::Array(Arc::new(element), size)
+    }
+
+    fn list(element: Self, bound: NonZeroPow2Usize) -> Self {
+        Self::List(Arc::new(element), bound)
+    }
+}
+
 impl<'a> TreeLike for &'a ResolvedType {
     fn as_node(&self) -> Tree<Self> {
         match self {

--- a/src/types.rs
+++ b/src/types.rs
@@ -22,17 +22,26 @@ pub enum ResolvedType {
     List(Arc<Self>, NonZeroPow2Usize),
 }
 
-/// Normalized unsigned integer type.
+/// Unsigned integer type.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
 pub enum UIntType {
+    /// 1-bit unsigned integer
     U1,
+    /// 2-bit unsigned integer
     U2,
+    /// 4-bit unsigned integer
     U4,
+    /// 8-bit unsigned integer
     U8,
+    /// 16-bit unsigned integer
     U16,
+    /// 32-bit unsigned integer
     U32,
+    /// 64-bit unsigned integer
     U64,
+    /// 128-bit unsigned integer
     U128,
+    /// 256-bit unsigned integer
     U256,
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,0 +1,265 @@
+use std::collections::HashMap;
+use std::fmt;
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+
+use miniscript::iter::{Tree, TreeLike};
+use simplicity::types::Type as SimType;
+
+use crate::array::{BTreeSlice, Partition};
+use crate::num::NonZeroPow2Usize;
+
+/// A Simphony type.
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+#[non_exhaustive]
+pub enum Type {
+    Unit,
+    Either(Arc<Self>, Arc<Self>),
+    Product(Arc<Self>, Arc<Self>),
+    Option(Arc<Self>),
+    Boolean,
+    UInt(UIntType),
+    Array(Arc<Self>, NonZeroUsize),
+    List(Arc<Self>, NonZeroPow2Usize),
+}
+
+/// Normalized unsigned integer type.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
+pub enum UIntType {
+    U1,
+    U2,
+    U4,
+    U8,
+    U16,
+    U32,
+    U64,
+    U128,
+    U256,
+}
+
+impl UIntType {
+    /// Double the bit width of the type.
+    /// Return the empty value upon overflow.
+    pub fn double(&self) -> Option<Self> {
+        match self {
+            UIntType::U1 => Some(UIntType::U2),
+            UIntType::U2 => Some(UIntType::U4),
+            UIntType::U4 => Some(UIntType::U8),
+            UIntType::U8 => Some(UIntType::U16),
+            UIntType::U16 => Some(UIntType::U32),
+            UIntType::U32 => Some(UIntType::U64),
+            UIntType::U64 => Some(UIntType::U128),
+            UIntType::U128 => Some(UIntType::U256),
+            UIntType::U256 => None,
+        }
+    }
+
+    /// Convert the type into a Simplicity type.
+    pub fn to_simplicity(self) -> SimType {
+        match self {
+            UIntType::U1 => SimType::two_two_n(0),
+            UIntType::U2 => SimType::two_two_n(1),
+            UIntType::U4 => SimType::two_two_n(2),
+            UIntType::U8 => SimType::two_two_n(3),
+            UIntType::U16 => SimType::two_two_n(4),
+            UIntType::U32 => SimType::two_two_n(5),
+            UIntType::U64 => SimType::two_two_n(6),
+            UIntType::U128 => SimType::two_two_n(7),
+            UIntType::U256 => SimType::two_two_n(8),
+        }
+    }
+}
+
+impl fmt::Display for UIntType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            UIntType::U1 => f.write_str("u1"),
+            UIntType::U2 => f.write_str("u2"),
+            UIntType::U4 => f.write_str("u4"),
+            UIntType::U8 => f.write_str("u8"),
+            UIntType::U16 => f.write_str("u16"),
+            UIntType::U32 => f.write_str("u32"),
+            UIntType::U64 => f.write_str("u64"),
+            UIntType::U128 => f.write_str("u128"),
+            UIntType::U256 => f.write_str("u256"),
+        }
+    }
+}
+
+impl<'a> TreeLike for &'a Type {
+    fn as_node(&self) -> Tree<Self> {
+        match self {
+            Type::Unit | Type::Boolean | Type::UInt(..) => Tree::Nullary,
+            Type::Option(l) | Type::Array(l, _) | Type::List(l, _) => Tree::Unary(l),
+            Type::Either(l, r) | Type::Product(l, r) => Tree::Binary(l, r),
+        }
+    }
+}
+
+impl Type {
+    /// Convert the type into a normalized unsigned integer type.
+    /// Return the empty value if the conversion failed.
+    pub fn to_uint(&self) -> Option<UIntType> {
+        let mut integer_type = HashMap::<&Type, UIntType>::new();
+        for data in self.post_order_iter() {
+            match data.node {
+                Type::Unit => {}
+                Type::Either(l, r) => match (l.as_ref(), r.as_ref()) {
+                    (Type::Unit, Type::Unit) => {
+                        integer_type.insert(data.node, UIntType::U1);
+                    }
+                    _ => return None,
+                },
+                Type::Product(l, r) => {
+                    let uint_l = integer_type.get(l.as_ref())?;
+                    let uint_r = integer_type.get(r.as_ref())?;
+                    if uint_l != uint_r {
+                        return None;
+                    }
+                    let uint_ty = uint_l.double()?;
+                    integer_type.insert(data.node, uint_ty);
+                }
+                Type::Option(r) => match r.as_ref() {
+                    // Option<1> = u1
+                    Type::Unit => {
+                        integer_type.insert(data.node, UIntType::U1);
+                    }
+                    _ => return None,
+                },
+                Type::Boolean => {
+                    integer_type.insert(data.node, UIntType::U1);
+                }
+                Type::UInt(ty) => {
+                    integer_type.insert(data.node, *ty);
+                }
+                Type::Array(el, size) => {
+                    if !size.is_power_of_two() {
+                        return None;
+                    }
+
+                    let mut uint = *integer_type.get(el.as_ref())?;
+                    for _ in 0..size.trailing_zeros() {
+                        match uint.double() {
+                            Some(doubled_uint) => uint = doubled_uint,
+                            None => return None,
+                        }
+                    }
+                    integer_type.insert(data.node, uint);
+                }
+                Type::List(el, bound) => match (el.as_ref(), *bound) {
+                    // List<1, 2> = Option<1> = u1
+                    (Type::Unit, NonZeroPow2Usize::TWO) => {
+                        integer_type.insert(data.node, UIntType::U1);
+                    }
+                    _ => return None,
+                },
+            }
+        }
+
+        integer_type.remove(self)
+    }
+
+    /// Convert the type into a Simplicity type.
+    pub fn to_simplicity(&self) -> SimType {
+        let mut output = vec![];
+
+        for data in self.post_order_iter() {
+            match data.node {
+                Type::Unit => output.push(SimType::unit()),
+                Type::Either(_, _) => {
+                    let r = output.pop().unwrap();
+                    let l = output.pop().unwrap();
+                    output.push(SimType::sum(l, r));
+                }
+                Type::Product(_, _) => {
+                    let r = output.pop().unwrap();
+                    let l = output.pop().unwrap();
+                    output.push(SimType::product(l, r));
+                }
+                Type::Option(_) => {
+                    let r = output.pop().unwrap();
+                    output.push(SimType::sum(SimType::unit(), r));
+                }
+                Type::Boolean => {
+                    output.push(SimType::two_two_n(0));
+                }
+                Type::UInt(ty) => output.push(ty.to_simplicity()),
+                Type::Array(_, size) => {
+                    let el = output.pop().unwrap();
+                    // Cheap clone because SimType consists of Arcs
+                    let el_vector = vec![el; size.get()];
+                    let tree = BTreeSlice::from_slice(&el_vector);
+                    output.push(tree.fold(SimType::product));
+                }
+                Type::List(_, bound) => {
+                    let el = output.pop().unwrap();
+                    // Cheap clone because SimType consists of Arcs
+                    let el_vector = vec![el; bound.get() - 1];
+                    let partition = Partition::from_slice(&el_vector, bound.get() / 2);
+                    debug_assert!(partition.is_complete());
+                    let process = |block: &[SimType]| -> SimType {
+                        debug_assert!(!block.is_empty());
+                        let tree = BTreeSlice::from_slice(block);
+                        let array = tree.fold(SimType::product);
+                        SimType::sum(SimType::unit(), array)
+                    };
+                    output.push(partition.fold(process, SimType::product));
+                }
+            }
+        }
+
+        debug_assert!(output.len() == 1);
+        output.pop().unwrap()
+    }
+}
+
+impl fmt::Display for Type {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for data in self.verbose_pre_order_iter() {
+            match data.node {
+                Type::Unit => f.write_str("()")?,
+                Type::Either(_, _) => match data.n_children_yielded {
+                    0 => f.write_str("Either<")?,
+                    1 => f.write_str(",")?,
+                    n => {
+                        debug_assert!(n == 2);
+                        f.write_str(">")?;
+                    }
+                },
+                Type::Product(_, _) => match data.n_children_yielded {
+                    0 => f.write_str("(")?,
+                    1 => f.write_str(", ")?,
+                    n => {
+                        debug_assert!(n == 2);
+                        f.write_str(")")?;
+                    }
+                },
+                Type::Option(_) => match data.n_children_yielded {
+                    0 => f.write_str("Option<")?,
+                    n => {
+                        debug_assert!(n == 1);
+                        f.write_str(">")?;
+                    }
+                },
+                Type::Boolean => f.write_str("bool")?,
+                Type::UInt(ty) => write!(f, "{ty}")?,
+                Type::Array(_, size) => match data.n_children_yielded {
+                    0 => f.write_str("[")?,
+                    n => {
+                        debug_assert!(n == 1);
+                        write!(f, "; {size}]")?;
+                    }
+                },
+                Type::List(_, bound) => match data.n_children_yielded {
+                    0 => f.write_str("List<")?,
+                    n => {
+                        debug_assert!(n == 1);
+                        write!(f, ", {bound}>")?;
+                    }
+                },
+            }
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Move types into their separate module. Rename `Type` to `ResolvedType` to better reflect its function in face of future aliased types. Introduce `StructuralType` to represent Simplicity types in the code base. Implement `From` and `TryFrom` to inter-type conversions. Introduce `TypeInner` to handle type primitives of both resolved and future aliased types.