### PR TITLE
Add tuples

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -555,3 +555,31 @@ impl StructuralType {
         simplicity::types::Type::from(self.0.clone())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_type() {
+        let unit = ResolvedType::unit();
+        assert_eq!("()", &unit.to_string());
+        let singleton = ResolvedType::tuple([ResolvedType::from(UIntType::U1)]);
+        assert_eq!("(u1,)", &singleton.to_string());
+        let pair = ResolvedType::tuple([
+            ResolvedType::from(UIntType::U1),
+            ResolvedType::from(UIntType::U8),
+        ]);
+        assert_eq!("(u1, u8)", &pair.to_string());
+        let triple = ResolvedType::tuple([
+            ResolvedType::from(UIntType::U1),
+            ResolvedType::from(UIntType::U8),
+            ResolvedType::from(UIntType::U16),
+        ]);
+        assert_eq!("(u1, u8, u16)", &triple.to_string());
+        let array = ResolvedType::array(ResolvedType::unit(), NonZeroUsize::new(3).unwrap());
+        assert_eq!("[(); 3]", &array.to_string());
+        let list = ResolvedType::list(ResolvedType::unit(), NonZeroPow2Usize::TWO);
+        assert_eq!("List<(), 2>", &list.to_string());
+    }
+}

--- a/src/value.rs
+++ b/src/value.rs
@@ -668,6 +668,21 @@ mod tests {
 
     #[test]
     fn display_value() {
+        let unit = Value::unit();
+        assert_eq!("()", &unit.to_string());
+        let singleton = Value::tuple([Value::from(UIntValue::U1(1))]);
+        assert_eq!("(1,)", &singleton.to_string());
+        let pair = Value::tuple([
+            Value::from(UIntValue::U1(1)),
+            Value::from(UIntValue::U8(42)),
+        ]);
+        assert_eq!("(1, 42)", &pair.to_string());
+        let triple = Value::tuple([
+            Value::from(UIntValue::U1(1)),
+            Value::from(UIntValue::U8(42)),
+            Value::from(UIntValue::U16(1337)),
+        ]);
+        assert_eq!("(1, 42, 1337)", &triple.to_string());
         let array = Value::array([Value::unit(), Value::unit(), Value::unit()]).unwrap();
         assert_eq!("[(), (), ()]", &array.to_string());
         let list = Value::list([Value::unit()], NonZeroPow2Usize::TWO).unwrap();


### PR DESCRIPTION
Add tuple types and values. We need tuples to represent function arguments, which have heterogeneous types. Up to this point, we abused arrays for this purpose, because tuple and arrays have the same Simplicity structure. When we give Simfony proper types, this hack will no longer work.

Tuples subsume unit and product: Unit is the empty tuple and a product is a 2-tuple. For now, keep the grammar as before, which means only 0-tuples and 2-tuples are allowed.

Depends on #49 