### PR TITLE
Tuple values

### DIFF
--- a/example_progs/tuple.simf
+++ b/example_progs/tuple.simf
@@ -1,0 +1,14 @@
+let a: () = ();
+let b: (u32,) = (1,);
+let c: (u32,u32) = (2,3);
+let d: (u32,u32,u32) = (4,5,6);
+let (): () = a;
+let (e,): (u32,) = b;
+let (f,g): (u32,u32) = c;
+let (h,i,j): (u32,u32,u32) = d;
+jet_verify(jet_eq_32(e,1));
+jet_verify(jet_eq_32(f,2));
+jet_verify(jet_eq_32(g,3));
+jet_verify(jet_eq_32(h,4));
+jet_verify(jet_eq_32(i,5));
+jet_verify(jet_eq_32(j,6));

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -77,10 +77,7 @@ impl Call {
     ) -> Result<ProgNode, RichError> {
         match &self.name {
             CallName::Jet(name) => {
-                let args = match self.args.is_empty() {
-                    true => SingleExpressionInner::Unit,
-                    false => SingleExpressionInner::Array(self.args.clone()),
-                };
+                let args = SingleExpressionInner::Tuple(self.args.clone());
                 // TODO: Pass the jet source type here.
                 // FIXME: Constructing pairs should never fail because when Simfony is translated to
                 // Simplicity the input type is variable. However, the fact that pairs always unify
@@ -138,7 +135,6 @@ impl SingleExpressionInner {
         span: Span,
     ) -> Result<ProgNode, RichError> {
         let expr = match self {
-            SingleExpressionInner::Unit => ProgNode::unit(),
             SingleExpressionInner::Left(l) => {
                 let l = l.eval(scope, None)?;
                 ProgNode::injl(&l)
@@ -150,14 +146,6 @@ impl SingleExpressionInner {
             }
             SingleExpressionInner::False => ProgNode::_false(),
             SingleExpressionInner::True => ProgNode::_true(),
-            SingleExpressionInner::Product(l, r) => {
-                let l = l.eval(scope, None)?;
-                let r = r.eval(scope, None)?;
-                // FIXME: Constructing pairs should never fail because when Simfony is translated to
-                // Simplicity the input type is variable. However, the fact that pairs always unify
-                // is hard to prove at the moment, while Simfony lacks a type system.
-                ProgNode::pair(&l, &r).with_span(span)?
-            }
             SingleExpressionInner::UnsignedInteger(decimal) => {
                 let reqd_ty = reqd_ty
                     .cloned()
@@ -184,6 +172,17 @@ impl SingleExpressionInner {
             SingleExpressionInner::Call(call) => call.eval(scope, reqd_ty)?,
             SingleExpressionInner::Expression(expression) => expression.eval(scope, reqd_ty)?,
             SingleExpressionInner::Match(match_) => match_.eval(scope, reqd_ty)?,
+            SingleExpressionInner::Tuple(elements) => {
+                // Type checking is annoying when reqd_ty can be None
+                // TODO: Type-check this code once reqd_ty is an explicit &ResolvedType
+                let nodes: Vec<Result<ProgNode, RichError>> =
+                    elements.iter().map(|e| e.eval(scope, None)).collect();
+                let tree = BTreeSlice::from_slice(&nodes);
+                tree.fold(|res_a, res_b| {
+                    res_a.and_then(|a| res_b.and_then(|b| ProgNode::pair(&a, &b).with_span(span)))
+                })
+                .unwrap_or_else(|| Ok(ProgNode::unit()))?
+            }
             SingleExpressionInner::Array(elements) => {
                 let el_type = match reqd_ty.map(ResolvedType::as_inner) {
                     Some(TypeInner::Array(el_type, size)) => {

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -244,7 +244,7 @@ impl SingleExpressionInner {
             expr.arrow()
                 .target
                 .unify(&StructuralType::from(reqd_ty).to_unfinalized(), "")
-                .map_err(|_| Error::TypeValueMismatch(reqd_ty.clone()))
+                .map_err(|e| Error::CannotCompile(e.to_string()))
                 .with_span(span)?;
         }
         Ok(expr)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,6 +172,7 @@ mod tests {
         _test_progs("./example_progs/sighash_all_anyprevoutanyscript.simf");
         _test_progs("./example_progs/sighash_none.simf");
         _test_progs("./example_progs/test.simf");
+        _test_progs("./example_progs/tuple.simf");
         _test_progs("./example_progs/unwrap.simf");
     }
 

--- a/src/minimal.pest
+++ b/src/minimal.pest
@@ -29,25 +29,22 @@ false_pattern     = @{ "false" }
 true_pattern      = @{ "true" }
 match_pattern     =  { left_pattern | right_pattern | none_pattern | some_pattern | false_pattern | true_pattern }
 
-unit_type         = @{ "()" }
 sum_type          =  { "Either<" ~ ty ~ "," ~ ty ~ ">" }
-product_type      =  { "(" ~ ty ~ "," ~ ty ~ ")" }
 option_type       =  { "Option<" ~ ty ~ ">" }
 boolean_type      = @{ "bool" }
 unsigned_type     = @{ "u128" | "u256" | "u16" | "u32" | "u64" | "u1" | "u2" | "u4" | "u8" }
+tuple_type        =  { "(" ~ ((ty ~ ",")+ ~ ty?)? ~ ")" }
 array_size        = @{ ASCII_DIGIT+ }
 array_type        =  { "[" ~ ty ~ ";" ~ array_size ~ "]" }
 list_bound        = @{ ASCII_DIGIT+ }
 list_type         =  { "List<" ~ ty ~ "," ~ list_bound ~ ">" }
-ty                =  { unit_type | sum_type | product_type | option_type | boolean_type | unsigned_type | array_type | list_type | identifier }
+ty                =  { sum_type | option_type | boolean_type | unsigned_type | tuple_type |  array_type | list_type | identifier }
 type_alias        =  { "type" ~ identifier ~ "=" ~ ty }
 
 expression        =  { block_expression | single_expression }
 block_expression  =  { "{" ~ (statement ~ ";")* ~ expression ~ "}" }
-unit_expr         = @{ "()" }
 left_expr         =  { "Left(" ~ expression ~ ")" }
 right_expr        =  { "Right(" ~ expression ~ ")" }
-product_expr      =  { "(" ~ expression ~ "," ~ expression ~ ")" }
 none_expr         = @{ "None" }
 some_expr         =  { "Some(" ~ expression ~ ")" }
 false_expr        = @{ "false" }
@@ -62,6 +59,7 @@ witness_expr      =  { "witness(\"" ~ witness_name ~ "\")" }
 variable_expr     =  { identifier }
 match_arm         =  { match_pattern ~ "=>" ~ (single_expression ~ "," | block_expression ~ ","?) }
 match_expr        =  { "match" ~ expression ~ "{" ~ match_arm ~ match_arm ~ "}" }
+tuple_expr        =  { "(" ~ ((expression ~ ",")+ ~ expression?)? ~ ")" }
 array_expr        =  { "[" ~ (expression ~ ("," ~ expression)* ~ ","?)? ~ "]" }
 list_expr         =  { "list![" ~ (expression ~ ("," ~ expression)* ~ ","?)? ~ "]" }
-single_expression =  { unit_expr | left_expr | right_expr | product_expr | none_expr | some_expr | false_expr | true_expr | call_expr | match_expr | array_expr | list_expr | bit_string | byte_string | unsigned_integer | witness_expr | variable_expr | "(" ~ expression ~ ")" }
+single_expression =  { left_expr | right_expr | none_expr | some_expr | false_expr | true_expr | call_expr | match_expr | tuple_expr | array_expr | list_expr | bit_string | byte_string | unsigned_integer | witness_expr | variable_expr | "(" ~ expression ~ ")" }

--- a/src/minimal.pest
+++ b/src/minimal.pest
@@ -16,9 +16,9 @@ reserved          = @{ jet | builtin_type }
 
 variable_pattern  =  { identifier }
 ignore_pattern    = @{ "_" }
-product_pattern   =  { "(" ~ pattern ~ "," ~ pattern ~ ")" }
+tuple_pattern     =  { "(" ~ ((pattern ~ ",")+ ~ pattern?)? ~ ")" }
 array_pattern     =  { "[" ~ (pattern ~ ("," ~ pattern)* ~ ","?)? ~ "]" }
-pattern           =  { ignore_pattern | product_pattern | array_pattern | variable_pattern }
+pattern           =  { ignore_pattern | tuple_pattern | array_pattern | variable_pattern }
 assignment        =  { "let" ~ pattern ~ ":" ~ ty ~ "=" ~ expression }
 
 left_pattern      =  { "Left(" ~ identifier ~ ")" }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -307,14 +307,10 @@ pub struct SingleExpression {
 /// The kind of single expression.
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub enum SingleExpressionInner {
-    /// Unit literal expression
-    Unit,
     /// Left wrapper expression
     Left(Arc<Expression>),
     /// Right wrapper expression
     Right(Arc<Expression>),
-    /// Product wrapper expression
-    Product(Arc<Expression>, Arc<Expression>),
     /// None literal expression
     None,
     /// Some wrapper expression
@@ -339,6 +335,8 @@ pub enum SingleExpressionInner {
     Expression(Arc<Expression>),
     /// Match expression over a sum type
     Match(Match),
+    /// Tuple wrapper expression
+    Tuple(Arc<[Expression]>),
     /// Array wrapper expression
     Array(Arc<[Expression]>),
     /// List wrapper expression
@@ -775,7 +773,6 @@ impl PestParse for SingleExpression {
         let inner_pair = pair.into_inner().next().unwrap();
 
         let inner = match inner_pair.as_rule() {
-            Rule::unit_expr => SingleExpressionInner::Unit,
             Rule::left_expr => {
                 let l = inner_pair.into_inner().next().unwrap();
                 SingleExpressionInner::Left(Expression::parse(l).map(Arc::new)?)
@@ -783,15 +780,6 @@ impl PestParse for SingleExpression {
             Rule::right_expr => {
                 let r = inner_pair.into_inner().next().unwrap();
                 SingleExpressionInner::Right(Expression::parse(r).map(Arc::new)?)
-            }
-            Rule::product_expr => {
-                let mut product_pair = inner_pair.into_inner();
-                let l = product_pair.next().unwrap();
-                let r = product_pair.next().unwrap();
-                SingleExpressionInner::Product(
-                    Expression::parse(l).map(Arc::new)?,
-                    Expression::parse(r).map(Arc::new)?,
-                )
             }
             Rule::none_expr => SingleExpressionInner::None,
             Rule::some_expr => {
@@ -818,10 +806,16 @@ impl PestParse for SingleExpression {
                 SingleExpressionInner::Expression(Expression::parse(inner_pair).map(Arc::new)?)
             }
             Rule::match_expr => Match::parse(inner_pair).map(SingleExpressionInner::Match)?,
+            Rule::tuple_expr => inner_pair
+                .clone()
+                .into_inner()
+                .map(Expression::parse)
+                .collect::<Result<Arc<[Expression]>, _>>()
+                .map(SingleExpressionInner::Tuple)?,
             Rule::array_expr => inner_pair
                 .clone()
                 .into_inner()
-                .map(|inner| Expression::parse(inner))
+                .map(Expression::parse)
                 .collect::<Result<Arc<[Expression]>, _>>()
                 .map(SingleExpressionInner::Array)?,
             Rule::list_expr => {
@@ -1031,7 +1025,6 @@ impl PestParse for AliasedType {
                     let identifier = Identifier::parse(data.node.0)?;
                     output.push(Item::Type(AliasedType::alias(identifier)));
                 }
-                Rule::unit_type => output.push(Item::Type(AliasedType::unit())),
                 Rule::unsigned_type => {
                     let uint_ty = UIntType::parse(data.node.0)?;
                     output.push(Item::Type(AliasedType::from(uint_ty)));
@@ -1041,17 +1034,22 @@ impl PestParse for AliasedType {
                     let l = output.pop().unwrap().unwrap_type();
                     output.push(Item::Type(AliasedType::either(l, r)));
                 }
-                Rule::product_type => {
-                    let r = output.pop().unwrap().unwrap_type();
-                    let l = output.pop().unwrap().unwrap_type();
-                    output.push(Item::Type(AliasedType::product(l, r)));
-                }
                 Rule::option_type => {
                     let r = output.pop().unwrap().unwrap_type();
                     output.push(Item::Type(AliasedType::option(r)));
                 }
                 Rule::boolean_type => {
                     output.push(Item::Type(AliasedType::boolean()));
+                }
+                Rule::tuple_type => {
+                    let size = data.node.n_children();
+                    let elements: Vec<AliasedType> = output
+                        .split_off(output.len() - size)
+                        .into_iter()
+                        .map(Item::unwrap_type)
+                        .collect();
+                    debug_assert_eq!(elements.len(), size);
+                    output.push(Item::Type(AliasedType::tuple(elements)));
                 }
                 Rule::array_type => {
                     let size = output.pop().unwrap().unwrap_size();
@@ -1135,8 +1133,7 @@ impl<'a> TreeLike for TyPair<'a> {
     fn as_node(&self) -> Tree<Self> {
         let mut it = self.0.clone().into_inner();
         match self.0.as_rule() {
-            Rule::unit_type
-            | Rule::boolean_type
+            Rule::boolean_type
             | Rule::unsigned_type
             | Rule::array_size
             | Rule::list_bound
@@ -1145,11 +1142,12 @@ impl<'a> TreeLike for TyPair<'a> {
                 let l = it.next().unwrap();
                 Tree::Unary(TyPair(l))
             }
-            Rule::sum_type | Rule::product_type | Rule::array_type | Rule::list_type => {
+            Rule::sum_type | Rule::array_type | Rule::list_type => {
                 let l = it.next().unwrap();
                 let r = it.next().unwrap();
                 Tree::Binary(TyPair(l), TyPair(r))
             }
+            Rule::tuple_type => Tree::Nary(it.map(TyPair).collect()),
             _ => unreachable!("Corrupt grammar"),
         }
     }

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -427,12 +427,7 @@ impl From<&Pattern> for BasePattern {
             match data.node {
                 Pattern::Identifier(i) => output.push(Self::Identifier(i.clone())),
                 Pattern::Ignore => output.push(Self::Ignore),
-                Pattern::Product(_, _) => {
-                    let r = output.pop().unwrap();
-                    let l = output.pop().unwrap();
-                    output.push(Self::product(l, r));
-                }
-                Pattern::Array(elements) => {
+                Pattern::Tuple(elements) | Pattern::Array(elements) => {
                     let size = elements.len();
                     let elements = &output[output.len() - size..];
                     debug_assert_eq!(elements.len(), size);


### PR DESCRIPTION
Depends on #51 

Make tuple values constructible in the Simfony grammar. Remove units and products as they are subsumed by tuples (0-tuples and 2-tuples, respectively). Add tuple patterns.