### PR TITLE
Infallible pairs

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use either::Either;
 use simplicity::jet::Elements;
-use simplicity::node::{CoreConstructible as _, JetConstructible as _, WitnessConstructible as _};
+use simplicity::node::{CoreConstructible as _, JetConstructible as _};
 use simplicity::{Cmr, FailEntropy};
 
 use crate::array::{BTreeSlice, Partition};
@@ -143,7 +143,7 @@ impl Scope {
     /// ```
     ///
     /// The expression `drop (IOH & OH)` returns the seeked value.
-    pub fn get(&self, target: &BasePattern) -> Option<ProgNode> {
+    pub fn get(&self, target: &BasePattern) -> Option<PairBuilder<ProgNode>> {
         BasePattern::from(&self.get_input_pattern()).translate(target)
     }
 }
@@ -153,44 +153,47 @@ fn compile_blk(
     scope: &mut Scope,
     index: usize,
     last_expr: Option<&Expression>,
-) -> Result<ProgNode, RichError> {
+) -> Result<PairBuilder<ProgNode>, RichError> {
     if index >= stmts.len() {
         return match last_expr {
             Some(expr) => expr.compile(scope),
-            None => Ok(ProgNode::unit()),
+            None => Ok(PairBuilder::unit()),
         };
     }
     match &stmts[index] {
         Statement::Assignment(assignment) => {
             let expr = assignment.expression().compile(scope)?;
             scope.insert(assignment.pattern().clone());
-            let left = ProgNode::pair_iden(&expr);
+            let left = expr.pair(PairBuilder::iden());
             let right = compile_blk(stmts, scope, index + 1, last_expr)?;
-            ProgNode::comp(&left, &right).with_span(assignment)
+            left.comp(&right.get()).with_span(assignment)
         }
         Statement::Expression(expression) => {
             let left = expression.compile(scope)?;
             let right = compile_blk(stmts, scope, index + 1, last_expr)?;
-            combine_seq(&left, &right).with_span(expression)
+            combine_seq(left, right).with_span(expression)
         }
     }
 }
 
-fn combine_seq(a: &ProgNode, b: &ProgNode) -> Result<ProgNode, simplicity::types::Error> {
-    let pair = ProgNode::pair(a, b)?;
+fn combine_seq(
+    a: PairBuilder<ProgNode>,
+    b: PairBuilder<ProgNode>,
+) -> Result<PairBuilder<ProgNode>, simplicity::types::Error> {
+    let pair = a.pair(b);
     let drop_iden = ProgNode::drop_(&ProgNode::iden());
-    ProgNode::comp(&pair, &drop_iden)
+    pair.comp(&drop_iden)
 }
 
 impl Program {
     pub fn compile(&self) -> Result<ProgNode, RichError> {
         let mut scope = Scope::new(Pattern::Ignore);
-        self.main().compile(&mut scope)
+        self.main().compile(&mut scope).map(PairBuilder::get)
     }
 }
 
 impl Expression {
-    fn compile(&self, scope: &mut Scope) -> Result<ProgNode, RichError> {
+    fn compile(&self, scope: &mut Scope) -> Result<PairBuilder<ProgNode>, RichError> {
         match self.inner() {
             ExpressionInner::Block(stmts, expr) => {
                 scope.push_scope();
@@ -204,14 +207,14 @@ impl Expression {
 }
 
 impl SingleExpression {
-    fn compile(&self, scope: &mut Scope) -> Result<ProgNode, RichError> {
+    fn compile(&self, scope: &mut Scope) -> Result<PairBuilder<ProgNode>, RichError> {
         let expr = match self.inner() {
             SingleExpressionInner::Constant(value) => {
                 // FIXME: Handle values that are not powers of two (requires updated rust-simplicity API)
                 let value = StructuralValue::from(value);
-                ProgNode::unit_const_value(value.into())
+                PairBuilder::unit_const_value(value.into())
             }
-            SingleExpressionInner::Witness(name) => ProgNode::witness(name.clone()),
+            SingleExpressionInner::Witness(name) => PairBuilder::witness(name.clone()),
             SingleExpressionInner::Variable(identifier) => scope
                 .get(&BasePattern::Identifier(identifier.clone()))
                 .ok_or(Error::UndefinedVariable(identifier.clone()))
@@ -221,57 +224,43 @@ impl SingleExpression {
                 let compiled = elements
                     .iter()
                     .map(|e| e.compile(scope))
-                    .collect::<Vec<Result<ProgNode, RichError>>>();
+                    .collect::<Result<Vec<PairBuilder<ProgNode>>, RichError>>()?;
                 let tree = BTreeSlice::from_slice(&compiled);
-                // FIXME: Constructing pairs should never fail because when Simfony is translated to
-                // Simplicity the input type is variable. However, the fact that pairs always unify
-                // is hard to prove at the moment, while Simfony lacks a type system.
-                tree.fold(|res_a, res_b| {
-                    res_a.and_then(|a| res_b.and_then(|b| ProgNode::pair(&a, &b).with_span(self)))
-                })
-                .unwrap_or_else(|| Ok(ProgNode::unit()))?
+                tree.fold(PairBuilder::pair)
+                    .unwrap_or_else(PairBuilder::unit)
             }
             SingleExpressionInner::List(elements) => {
                 let compiled = elements
                     .iter()
                     .map(|e| e.compile(scope))
-                    .collect::<Vec<Result<ProgNode, RichError>>>();
+                    .collect::<Result<Vec<PairBuilder<ProgNode>>, RichError>>()?;
                 let bound = self.ty().as_list().unwrap().1;
-                // FIXME: Constructing pairs should never fail because when Simfony is translated to
-                // Simplicity the input type is variable. However, the fact that pairs always unify
-                // is hard to prove at the moment, while Simfony lacks a type system.
                 let partition = Partition::from_slice(&compiled, bound.get() / 2);
-                let process =
-                    |block: &[Result<ProgNode, RichError>]| -> Result<ProgNode, RichError> {
+                partition.fold(
+                    |block| {
                         let tree = BTreeSlice::from_slice(block);
-                        tree.fold(|res_a, res_b| {
-                            res_a.and_then(|a| {
-                                res_b.and_then(|b| ProgNode::pair(&a, &b).with_span(self))
-                            })
-                        })
-                        .map(|res| res.map(|array| ProgNode::injr(&array)))
-                        .unwrap_or_else(|| Ok(ProgNode::bit_false()))
-                    };
-
-                partition.fold(process, |res_a, res_b| {
-                    res_a.and_then(|a| res_b.and_then(|b| ProgNode::pair(&a, &b).with_span(self)))
-                })?
+                        match tree.fold(PairBuilder::pair) {
+                            None => PairBuilder::unit().injl(),
+                            Some(pair) => pair.injr(),
+                        }
+                    },
+                    PairBuilder::pair,
+                )
             }
-            SingleExpressionInner::Option(None) => ProgNode::injl(&ProgNode::unit()),
+            SingleExpressionInner::Option(None) => PairBuilder::unit().injl(),
             SingleExpressionInner::Either(Either::Left(inner)) => {
-                let compiled = inner.compile(scope)?;
-                ProgNode::injl(&compiled)
+                inner.compile(scope).map(PairBuilder::injl)?
             }
             SingleExpressionInner::Either(Either::Right(inner))
             | SingleExpressionInner::Option(Some(inner)) => {
-                let compiled = inner.compile(scope)?;
-                ProgNode::injr(&compiled)
+                inner.compile(scope).map(PairBuilder::injr)?
             }
             SingleExpressionInner::Call(call) => call.compile(scope)?,
             SingleExpressionInner::Match(match_) => match_.compile(scope)?,
         };
 
-        expr.cached_data()
+        expr.as_ref()
+            .cached_data()
             .arrow()
             .target
             .unify(&StructuralType::from(self.ty()).to_unfinalized(), "")
@@ -282,39 +271,39 @@ impl SingleExpression {
 }
 
 impl Call {
-    fn compile(&self, scope: &mut Scope) -> Result<ProgNode, RichError> {
+    fn compile(&self, scope: &mut Scope) -> Result<PairBuilder<ProgNode>, RichError> {
         let args_ast = SingleExpression::tuple(self.args().clone(), *self.as_ref());
         let args = args_ast.compile(scope)?;
 
         match self.name() {
             CallName::Jet(name) => {
                 let jet = ProgNode::jet(*name);
-                ProgNode::comp(&args, &jet).with_span(self)
+                args.comp(&jet).with_span(self)
             }
             CallName::UnwrapLeft(..) => {
-                let left_and_unit = ProgNode::pair_unit(&args);
+                let left_and_unit = args.pair(PairBuilder::unit());
                 let fail_cmr = Cmr::fail(FailEntropy::ZERO);
                 let get_inner = ProgNode::assertl_take(&ProgNode::iden(), fail_cmr);
-                ProgNode::comp(&left_and_unit, &get_inner).with_span(self)
+                left_and_unit.comp(&get_inner).with_span(self)
             }
             CallName::UnwrapRight(..) | CallName::Unwrap => {
-                let right_and_unit = ProgNode::pair_unit(&args);
+                let right_and_unit = args.pair(PairBuilder::unit());
                 let fail_cmr = Cmr::fail(FailEntropy::ZERO);
                 let get_inner = ProgNode::assertr_take(fail_cmr, &ProgNode::iden());
-                ProgNode::comp(&right_and_unit, &get_inner).with_span(self)
+                right_and_unit.comp(&get_inner).with_span(self)
             }
             CallName::IsNone(..) => {
-                let sum_and_unit = ProgNode::pair_unit(&args);
+                let sum_and_unit = args.pair(PairBuilder::unit());
                 let is_right = ProgNode::case_true_false();
-                ProgNode::comp(&sum_and_unit, &is_right).with_span(self)
+                sum_and_unit.comp(&is_right).with_span(self)
             }
             CallName::Assert => {
                 let jet = ProgNode::jet(Elements::Verify);
-                ProgNode::comp(&args, &jet).with_span(self)
+                args.comp(&jet).with_span(self)
             }
             CallName::Panic => {
                 // panic! ignores its arguments
-                Ok(ProgNode::fail(FailEntropy::ZERO))
+                Ok(PairBuilder::fail(FailEntropy::ZERO))
             }
             CallName::TypeCast(..) => {
                 // A cast converts between two structurally equal types.
@@ -326,13 +315,13 @@ impl Call {
             CallName::Custom(function) => {
                 let mut function_scope = Scope::new(function.params_pattern());
                 let body = function.body().compile(&mut function_scope)?;
-                ProgNode::comp(&args, &body).with_span(self)
+                args.comp(body.as_ref()).with_span(self)
             }
             CallName::Fold(function, bound) => {
                 let mut function_scope = Scope::new(function.params_pattern());
                 let body = function.body().compile(&mut function_scope)?;
-                let fold_body = list_fold(*bound, &body).with_span(self)?;
-                ProgNode::comp(&args, &fold_body).with_span(self)
+                let fold_body = list_fold(*bound, body.as_ref()).with_span(self)?;
+                args.comp(&fold_body).with_span(self)
             }
         }
     }
@@ -405,7 +394,7 @@ fn list_fold(bound: NonZeroPow2Usize, f: &ProgNode) -> Result<ProgNode, simplici
 }
 
 impl Match {
-    fn compile(&self, scope: &mut Scope) -> Result<ProgNode, RichError> {
+    fn compile(&self, scope: &mut Scope) -> Result<PairBuilder<ProgNode>, RichError> {
         scope.push_scope();
         scope.insert(
             self.left()
@@ -431,8 +420,8 @@ impl Match {
         scope.pop_scope();
 
         let scrutinee = self.scrutinee().compile(scope)?;
-        let input = ProgNode::pair_iden(&scrutinee);
-        let output = ProgNode::case(&left, &right).with_span(self)?;
-        ProgNode::comp(&input, &output).with_span(self)
+        let input = scrutinee.pair(PairBuilder::iden());
+        let output = ProgNode::case(left.as_ref(), right.as_ref()).with_span(self)?;
+        input.comp(&output).with_span(self)
     }
 }

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -209,7 +209,7 @@ impl SingleExpression {
             SingleExpressionInner::Constant(value) => {
                 // FIXME: Handle values that are not powers of two (requires updated rust-simplicity API)
                 let value = StructuralValue::from(value);
-                ProgNode::unit_comp(&ProgNode::const_word(value.into()))
+                ProgNode::unit_const_value(value.into())
             }
             SingleExpressionInner::Witness(name) => ProgNode::witness(name.clone()),
             SingleExpressionInner::Variable(identifier) => scope

--- a/src/named.rs
+++ b/src/named.rs
@@ -499,8 +499,8 @@ impl<P: CoreExt> PairBuilder<P> {
     /// ----------------
     /// comp s t : A → C
     /// ```
-    pub fn comp(self, other: &P) -> Result<Self, types::Error> {
-        P::comp(&self.0, other).map(Self)
+    pub fn comp<Q: std::borrow::Borrow<P>>(self, other: &Q) -> Result<Self, types::Error> {
+        P::comp(&self.0, other.borrow()).map(Self)
     }
 
     /// Pair two expressions.
@@ -573,13 +573,19 @@ impl<P: WitnessConstructible<WitnessName>> PairBuilder<P> {
 
 impl<P> PairBuilder<P> {
     /// Build the expression.
-    pub fn get(self) -> P {
+    pub fn build(self) -> P {
         self.0
     }
 }
 
 impl<P> AsRef<P> for PairBuilder<P> {
     fn as_ref(&self) -> &P {
+        &self.0
+    }
+}
+
+impl<P> std::borrow::Borrow<P> for PairBuilder<P> {
+    fn borrow(&self) -> &P {
         &self.0
     }
 }

--- a/src/named.rs
+++ b/src/named.rs
@@ -272,14 +272,6 @@ pub trait CoreExt: CoreConstructible + Sized {
         Self::comp(&Self::unit(), &Self::const_word(value)).unwrap()
     }
 
-    fn pair_iden(&self) -> Self {
-        Self::pair(self, &Self::iden()).unwrap() // pairing with iden always typechecks
-    }
-
-    fn pair_unit(&self) -> Self {
-        Self::pair(self, &Self::unit()).unwrap() // pairing with unit always typechecks
-    }
-
     /// `assertl (take s) cmr` always type checks.
     fn assertl_take(&self, cmr: Cmr) -> Self {
         Self::assertl(&Self::take(self), cmr).unwrap()

--- a/src/named.rs
+++ b/src/named.rs
@@ -256,8 +256,20 @@ pub trait CoreExt: CoreConstructible + Sized {
         SelectorBuilder::default().i()
     }
 
-    fn unit_comp(&self) -> Self {
-        Self::comp(&Self::unit(), self).unwrap() // composing with unit always typechecks
+    /// Compose a unit with a constant value.
+    ///
+    /// ## Infallibility
+    ///
+    /// `unit` produces the unit value, which is the input of the word jet `const v`.
+    ///
+    /// ```text
+    /// unit    : A → 1
+    /// const v : 1 → B
+    /// -------------------
+    /// comp unit (const v) : A → B
+    /// ```
+    fn unit_const_value(value: Arc<simplicity::Value>) -> Self {
+        Self::comp(&Self::unit(), &Self::const_word(value)).unwrap()
     }
 
     fn pair_iden(&self) -> Self {

--- a/src/named.rs
+++ b/src/named.rs
@@ -7,7 +7,7 @@ use simplicity::node::{
     NoDisconnect, NoWitness, Node, WitnessConstructible, WitnessData,
 };
 use simplicity::types::arrow::Arrow;
-use simplicity::{types, CommitNode};
+use simplicity::{types, CommitNode, FailEntropy};
 use simplicity::{Cmr, WitnessNode};
 
 use crate::parse::WitnessName;
@@ -245,7 +245,7 @@ impl<J> WitnessConstructible<WitnessName> for ConstructData<J> {
 /// More constructors for types that implement [`CoreConstructible`].
 pub trait CoreExt: CoreConstructible + Sized {
     fn h() -> PairBuilder<Self> {
-        PairBuilder(Self::iden())
+        PairBuilder::iden()
     }
 
     fn o() -> SelectorBuilder<Self> {
@@ -347,63 +347,235 @@ impl<P: CoreExt> SelectorBuilder<P> {
 
     /// Select the current input value.
     pub fn h(self) -> PairBuilder<P> {
-        let mut expr = P::iden();
+        let mut expr = PairBuilder::iden();
         for bit in self.selection.into_iter().rev() {
             match bit {
-                false => expr = P::take(&expr),
-                true => expr = P::drop_(&expr),
+                false => expr = expr.take(),
+                true => expr = expr.drop_(),
             }
         }
-
-        PairBuilder(expr)
+        expr
     }
 }
 
-/// Builder of expressions that contain
-/// `pair`, `take`, `drop` and `iden` only.
+/// Builder of expressions that can be composed in pairs without restriction.
 ///
-/// These expressions always type-check.
+/// ## Invariant
+///
+/// These expressions preserve the following invariant:
+/// Their source type is a (nested) product of type variables.
+/// The source type contains neither sums nor any concrete types.
 #[derive(Debug, Clone, Hash)]
 pub struct PairBuilder<P>(P);
 
 impl<P: CoreExt> PairBuilder<P> {
+    /// Create the unit expression.
+    ///
+    /// ## Invariant
+    ///
+    /// `unit` has a type variable as its source type.
+    ///
+    /// ```text
+    /// ------------
+    /// unit : A → 1
+    /// ```
+    pub fn unit() -> Self {
+        Self(P::unit())
+    }
+
+    /// Create the identity expression.
+    ///
+    /// ## Invariant
+    ///
+    /// `iden` has a type variable as its source type.
+    ///
+    /// ```text
+    /// ------------
+    /// iden : A → A
+    /// ```
+    pub fn iden() -> Self {
+        Self(P::iden())
+    }
+
+    /// Create the fail expression.
+    ///
+    /// ## Invariant
+    ///
+    /// `fail` has a type variable as its source type.
+    ///
+    /// ```text
+    /// ------------
+    /// fail : A → B
+    /// ```
+    pub fn fail(entropy: FailEntropy) -> Self {
+        Self(P::fail(entropy))
+    }
+
+    /// Left-inject the expression.
+    ///
+    /// ## Invariant
+    ///
+    /// By induction, `t` has a nested product of type variables as its source type.
+    /// `injl t` has the same source type as `t`.
+    /// Therefore, `injl t` has a nested product of type variables as its source type.
+    ///
+    /// ```text
+    /// t : A → B
+    /// ------------------
+    /// injl t : A → B + C
+    /// ```
+    pub fn injl(self) -> Self {
+        Self(P::injl(&self.0))
+    }
+
+    /// Left-inject the expression.
+    ///
+    /// ## Invariant
+    ///
+    /// By induction, `t` has a nested product of type variables as its source type.
+    /// `injr t` has the same source type as `t`.
+    /// Therefore, `injr t` has a nested product of type variables as its source type.
+    ///
+    /// ```text
+    /// t : A → C
+    /// ------------------
+    /// injr t : A → B + C
+    /// ```
+    pub fn injr(self) -> Self {
+        Self(P::injr(&self.0))
+    }
+
     /// Take the expression.
+    ///
+    /// ## Invariant
+    ///
+    /// By induction, `t` has a nested product of type variables as its source type `A`.
+    /// `take t` has the product of type `A` and of the type variable `B` as its source type.
+    /// Therefore, `take t` has a nested product of type variables as its source type.
+    ///
+    /// ```text
+    /// t : A → C
+    /// ------------------
+    /// take t : A × B → C
+    /// ```
     pub fn take(self) -> Self {
         Self(P::take(&self.0))
     }
 
     /// Drop the expression.
+    ///
+    /// ## Invariant
+    ///
+    /// By induction, `t` has a nested product of type variables as its source type `B`.
+    /// `drop t` has the product of the type variable `A` and of type `B` as its source type.
+    /// Therefore, `drop t` has a nested product of type variables as its source type.
+    ///
+    /// ```text
+    /// t : B → C
+    /// ------------------
+    /// drop t : A × B → C
+    /// ```
     pub fn drop_(self) -> Self {
         Self(P::drop_(&self.0))
     }
 
+    /// Compose two expressions.
+    ///
+    /// ## Left-associativity
+    ///
+    /// ```text
+    /// a.comp(b).comp(c) = comp (comp a b) c
+    /// a.comp(b.comp(c)) = comp a (comp b c)
+    /// ```
+    ///
+    /// ## Fallibility
+    ///
+    /// The composition will fail if the target type of the left sub-expression
+    /// cannot be unified with the source type of the right sub-expression.
+    ///
+    /// ## Invariant
+    ///
+    /// By induction, `s` has a nested product of type variables as its source type.
+    /// `comp s t` has the same source type as `s`.
+    /// Therefore, `comp s t` has a nested product of type variables as its source type.
+    ///
+    /// Note that `t` can be **any** Simplicity expression since we don't need its invariant.
+    ///
+    /// ```text
+    /// s : A → B
+    /// t : B → C
+    /// ----------------
+    /// comp s t : A → C
+    /// ```
+    pub fn comp(self, other: &P) -> Result<Self, types::Error> {
+        P::comp(&self.0, other).map(Self)
+    }
+
     /// Pair two expressions.
     ///
-    /// ## Left-associative:
+    /// ## Left-associativity
     ///
-    /// `a.pair(b).pair(c)` = `pair (pair a b) c`
+    /// ```text
+    /// a.pair(b).pair(c) = pair (pair a b) c
+    /// a.pair(b.pair(c)) = pair a (pair b c)
+    /// ```
     ///
-    /// `a.pair(b.pair(c))` = `pair a (pair b c)`
+    /// ## Infallibility
+    ///
+    /// `pair s t` unifies the source types of `s` and `t`.
+    /// Unification fails when there is a mismatch between products, sums or concrete types.
+    /// By induction, the source types of `s` and `t` are both nested products of type variables,
+    /// which contain neither sums nor concrete types.
+    /// Therefore, unification always succeeds.
+    ///
+    /// ```text
+    /// s : A → B
+    /// t : A → C
+    /// --------------------
+    /// pair s t : A → B × C
+    /// ```
+    ///
+    /// ## Invariant
+    ///
+    ///  By induction, `s` has a nested product of type variables as its source type.
+    /// `pair s t` has the same source type as `s`.
+    /// Therefore, `pair s t` has a nested product of type variables as its source type.
     pub fn pair(self, other: Self) -> Self {
-        // Expressions that consist of `take`, `drop` and `iden` have a source type
-        // that consists of nested products of type variables.
-        // Their source type does not contain any units, sums or other concrete types.
-        //
-        // s : A → B
-        // t : A → C
-        // ---------
-        // pair s t : A → B × C
-        //
-        // The pair combinator unifies the source type of both subexpressions.
-        // Two nested products of type variables can always be unified into
-        // a nested product of type variables.
-        //
-        // Unification errors occur only when products are unified with sums,
-        // which is impossible here.
-        //
-        // By induction, expressions that consist of `pair`, `take`, `drop` and `iden`
-        // have a source type that consists of nested products of type variables.
         Self(P::pair(&self.0, &other.0).unwrap())
+    }
+
+    /// Compose a unit with a constant value.
+    ///
+    /// ## Invariant
+    ///
+    /// `unit` has a type variable as its source type.
+    /// `comp unit (const v)` has the same source type as `unit`.
+    /// Therefore, `comp unit (const v)` has a nested product of type variables as its source type.
+    ///
+    /// ```text
+    /// unit    : A → 1
+    /// const v : 1 → B
+    /// ---------------------------
+    /// comp unit (const v) : A → B
+    /// ```
+    pub fn unit_const_value(value: Arc<simplicity::Value>) -> Self {
+        Self(P::unit_const_value(value))
+    }
+}
+
+impl<P: WitnessConstructible<WitnessName>> PairBuilder<P> {
+    /// Create the witness expression.
+    ///
+    /// ## Invariant
+    ///
+    /// `witness` has a type variable as its source type.
+    ///
+    /// ```text
+    /// ---------------
+    /// witness : A → B
+    /// ```
+    pub fn witness(witness: WitnessName) -> Self {
+        Self(P::witness(witness))
     }
 }
 
@@ -411,5 +583,11 @@ impl<P> PairBuilder<P> {
     /// Build the expression.
     pub fn get(self) -> P {
         self.0
+    }
+}
+
+impl<P> AsRef<P> for PairBuilder<P> {
+    fn as_ref(&self) -> &P {
+        &self.0
     }
 }

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -274,7 +274,7 @@ impl BasePattern {
     /// This means there are infinitely many translating expressions from `self` to `to`.
     /// For instance, `iden`, `iden & iden`, `(iden & iden) & iden`, and so on.
     /// We enforce a unique translation by banning ignore from the `to` pattern.
-    pub fn translate(&self, to: &Self) -> Option<ProgNode> {
+    pub fn translate(&self, to: &Self) -> Option<PairBuilder<ProgNode>> {
         #[derive(Debug, Clone)]
         enum Task<'a> {
             Translate(&'a BasePattern, &'a BasePattern),
@@ -377,7 +377,7 @@ impl BasePattern {
         }
 
         debug_assert_eq!(output.len(), 1);
-        output.pop().map(PairBuilder::get)
+        output.pop()
     }
 }
 
@@ -429,7 +429,7 @@ mod tests {
         ];
 
         for (target, expected_expr) in target_expr {
-            let expr = env.translate(&target).unwrap();
+            let expr = env.translate(&target).unwrap().get();
             assert_eq!(expected_expr, &expr.display_expr().to_string());
         }
     }

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -429,8 +429,8 @@ mod tests {
         ];
 
         for (target, expected_expr) in target_expr {
-            let expr = env.translate(&target).unwrap().get();
-            assert_eq!(expected_expr, &expr.display_expr().to_string());
+            let expr = env.translate(&target).unwrap();
+            assert_eq!(expected_expr, expr.as_ref().display_expr().to_string());
         }
     }
 }


### PR DESCRIPTION
Simfony expressions are translated into Simplicity expressions with a variable source type. This means that pairs can be constructed infallibly. Use `PairBuilder` to ensure this invariant at compile time and remove unnecessary unwraps.