### PR TITLE
Fuzz fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,3 @@
-workspace = { members = ["codegen"] }
 [package]
 name = "simfony"
 version = "0.1.0"
@@ -32,3 +31,6 @@ itertools = "0.13.0"
 
 [target.wasm32-unknown-unknown.dependencies]
 getrandom = { version = "0.2", features = ["js"] }
+
+[workspace]
+members = ["codegen"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,4 +174,15 @@ fn main() {
             "Expected expression of type `bool`, found type `()`",
         );
     }
+
+    #[test]
+    fn fuzz_regression_1() {
+        compile("type f=f").unwrap_err();
+    }
+
+    #[test]
+    #[ignore]
+    fn fuzz_slow_unit_1() {
+        compile("fn fnnfn(MMet:(((sssss,((((((sssss,ssssss,ss,((((((sssss,ss,((((((sssss,ssssss,ss,((((((sssss,ssssss,((((((sssss,sssssssss,(((((((sssss,sssssssss,(((((ssss,((((((sssss,sssssssss,(((((((sssss,ssss,((((((sssss,ss,((((((sssss,ssssss,ss,((((((sssss,ssssss,((((((sssss,sssssssss,(((((((sssss,sssssssss,(((((ssss,((((((sssss,sssssssss,(((((((sssss,sssssssssssss,(((((((((((u|(").unwrap_err();
+    }
 }

--- a/src/minimal.pest
+++ b/src/minimal.pest
@@ -17,14 +17,16 @@ function_name     =  { !builtin_function ~ identifier }
 typed_identifier  =  { identifier ~ ":" ~ ty }
 function_params   =  { "(" ~ (typed_identifier ~ ("," ~ typed_identifier)*)? ~ ")" }
 function_return   =  { "->" ~ ty }
-function          =  { "fn" ~ function_name ~ function_params ~ function_return? ~ block_expression }
+fn_keyword        = @{ "fn" ~ !ASCII_ALPHANUMERIC }
+function          =  { fn_keyword ~ function_name ~ function_params ~ function_return? ~ block_expression }
 
 variable_pattern  =  { identifier }
 ignore_pattern    = @{ "_" }
 tuple_pattern     =  { "(" ~ ((pattern ~ ",")+ ~ pattern?)? ~ ")" }
 array_pattern     =  { "[" ~ (pattern ~ ("," ~ pattern)* ~ ","?)? ~ "]" }
 pattern           =  { ignore_pattern | tuple_pattern | array_pattern | variable_pattern }
-assignment        =  { "let" ~ pattern ~ ":" ~ ty ~ "=" ~ expression }
+let_keyword       = @{ "let" ~ !ASCII_ALPHANUMERIC }
+assignment        =  { let_keyword ~ pattern ~ ":" ~ ty ~ "=" ~ expression }
 
 left_pattern      =  { "Left(" ~ identifier ~ ":" ~ ty ~ ")" }
 right_pattern     =  { "Right(" ~ identifier ~ ":" ~ ty ~ ")" }
@@ -46,7 +48,8 @@ list_type         =  { "List<" ~ ty ~ "," ~ list_bound ~ ">" }
 ty                =  { alias_name | builtin_alias | sum_type | option_type | boolean_type | unsigned_type | tuple_type | array_type | list_type }
 builtin_alias     = @{ "Ctx8" | "Pubkey" | "Message64" | "Signature" | "Scalar" | "Fe" | "Gej" | "Ge" | "Point" | "Height" | "Time" | "Distance" | "Duration" | "Lock" | "Outpoint" | "Confidential1" | "ExplicitAsset" | "Asset1" | "ExplicitAmount" | "Amount1" | "ExplicitNonce" | "Nonce" | "TokenAmount1" }
 alias_name        =  { !builtin_alias ~ identifier }
-type_alias        =  { "type" ~ alias_name ~ "=" ~ ty }
+type_keyword      = @{ "type" ~ !ASCII_ALPHANUMERIC }
+type_alias        =  { type_keyword ~ alias_name ~ "=" ~ ty }
 
 left_expr         =  { "Left(" ~ expression ~ ")" }
 right_expr        =  { "Right(" ~ expression ~ ")" }
@@ -71,7 +74,8 @@ byte_string       = @{ "0x" ~ (ASCII_HEX_DIGIT | "_")+ }
 witness_expr      =  { "witness(\"" ~ witness_name ~ "\")" }
 variable_expr     =  { identifier }
 match_arm         =  { match_pattern ~ "=>" ~ (single_expression ~ "," | block_expression ~ ","?) }
-match_expr        =  { "match" ~ expression ~ "{" ~ match_arm ~ match_arm ~ "}" }
+match_keyword     = @{ "match" ~ !ASCII_ALPHANUMERIC }
+match_expr        =  { match_keyword ~ expression ~ "{" ~ match_arm ~ match_arm ~ "}" }
 tuple_expr        =  { "(" ~ ((expression ~ ",")+ ~ expression?)? ~ ")" }
 array_expr        =  { "[" ~ (expression ~ ("," ~ expression)* ~ ","?)? ~ "]" }
 list_expr         =  { "list![" ~ (expression ~ ("," ~ expression)* ~ ","?)? ~ "]" }

--- a/src/minimal.pest
+++ b/src/minimal.pest
@@ -10,7 +10,7 @@ block_expression  =  { "{" ~ (statement ~ ";")* ~ expression? ~ "}" }
 identifier        = @{ !builtin_type ~ ASCII_ALPHA ~ (ASCII_ALPHANUMERIC | "_")* }
 jet               = @{ "jet::" ~ (ASCII_ALPHANUMERIC | "_")+ }
 witness_name      = @{ (ASCII_ALPHANUMERIC | "_")+ }
-builtin_type      = @{ "Either" | "Option" | "bool" | unsigned_type | "List" }
+builtin_type      = @{ "Either" | "Option" | "bool" | "List" | unsigned_type }
 
 builtin_function  = @{ jet | "unwrap_left" | "unwrap_right" | "unwrap" | "fold" }
 function_name     =  { !builtin_function ~ identifier }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -652,6 +652,7 @@ impl PestParse for Function {
         assert!(matches!(pair.as_rule(), Self::RULE));
         let span = Span::from(&pair);
         let mut it = pair.into_inner();
+        let _fn_keyword = it.next().unwrap();
         let name = FunctionName::parse(it.next().unwrap())?;
         let params = {
             let pair = it.next().unwrap();
@@ -773,10 +774,11 @@ impl PestParse for Assignment {
     fn parse(pair: pest::iterators::Pair<Rule>) -> Result<Self, RichError> {
         assert!(matches!(pair.as_rule(), Self::RULE));
         let span = Span::from(&pair);
-        let mut inner_pair = pair.into_inner();
-        let pattern = Pattern::parse(inner_pair.next().unwrap())?;
-        let ty = AliasedType::parse(inner_pair.next().unwrap())?;
-        let expression = Expression::parse(inner_pair.next().unwrap())?;
+        let mut it = pair.into_inner();
+        let _let_keyword = it.next().unwrap();
+        let pattern = Pattern::parse(it.next().unwrap())?;
+        let ty = AliasedType::parse(it.next().unwrap())?;
+        let expression = Expression::parse(it.next().unwrap())?;
         Ok(Assignment {
             pattern,
             ty,
@@ -862,6 +864,7 @@ impl PestParse for TypeAlias {
         assert!(matches!(pair.as_rule(), Self::RULE));
         let span = Span::from(&pair);
         let mut it = pair.into_inner();
+        let _type_keyword = it.next().unwrap();
         let name = Identifier::parse(it.next().unwrap().into_inner().next().unwrap())?;
         let ty = AliasedType::parse(it.next().unwrap())?;
         Ok(Self { name, ty, span })
@@ -1075,6 +1078,7 @@ impl PestParse for Match {
         assert!(matches!(pair.as_rule(), Self::RULE));
         let span = Span::from(&pair);
         let mut it = pair.into_inner();
+        let _match_keyword = it.next().unwrap();
         let scrutinee_pair = it.next().unwrap();
         let scrutinee = Expression::parse(scrutinee_pair.clone()).map(Arc::new)?;
         let first = MatchArm::parse(it.next().unwrap())?;

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -862,7 +862,7 @@ impl PestParse for TypeAlias {
         assert!(matches!(pair.as_rule(), Self::RULE));
         let span = Span::from(&pair);
         let mut it = pair.into_inner();
-        let name = Identifier::parse(it.next().unwrap())?;
+        let name = Identifier::parse(it.next().unwrap().into_inner().next().unwrap())?;
         let ty = AliasedType::parse(it.next().unwrap())?;
         Ok(Self { name, ty, span })
     }


### PR DESCRIPTION
I set up the fuzzing infrastructure as described in #72 and looked for crashes. I fixed the bug that Andrew found in #72. There were no more crashes, but it turns out that parsing can be really show when opening `(`, `[`, `{` are spammed and not closed. This seems to be an issue with the PEST parser itself. I will look into fixing this, but for now I will just note that parsing can be slow. Unfortunately, this also means that fuzzing is slow. I found no way to skip slow units during fuzzing. I limited the input size to around 50 bytes, but even this produces slow units.