### PR TITLE
Reconstruct value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,7 +510,7 @@ dependencies = [
 [[package]]
 name = "simplicity-lang"
 version = "0.2.0"
-source = "git+https://github.com/BlockstreamResearch/rust-simplicity?rev=794918783291465a109bdaf2ef694f86467c477e#794918783291465a109bdaf2ef694f86467c477e"
+source = "git+https://github.com/BlockstreamResearch/rust-simplicity?rev=713842937ab0b5e0b1a343e19fdee6634b7a6add#713842937ab0b5e0b1a343e19fdee6634b7a6add"
 dependencies = [
  "bitcoin",
  "bitcoin_hashes",
@@ -526,7 +526,7 @@ dependencies = [
 [[package]]
 name = "simplicity-sys"
 version = "0.2.0"
-source = "git+https://github.com/BlockstreamResearch/rust-simplicity?rev=794918783291465a109bdaf2ef694f86467c477e#794918783291465a109bdaf2ef694f86467c477e"
+source = "git+https://github.com/BlockstreamResearch/rust-simplicity?rev=713842937ab0b5e0b1a343e19fdee6634b7a6add#713842937ab0b5e0b1a343e19fdee6634b7a6add"
 dependencies = [
  "bitcoin_hashes",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ pest = "2.1.3"
 pest_derive = "2.7.1"
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.105"
-simplicity-lang = { git = "https://github.com/BlockstreamResearch/rust-simplicity", rev = "794918783291465a109bdaf2ef694f86467c477e" }
+simplicity-lang = { git = "https://github.com/BlockstreamResearch/rust-simplicity", rev = "713842937ab0b5e0b1a343e19fdee6634b7a6add" }
 miniscript = "11.0.0"
 either = "1.12.0"
 itertools = "0.13.0"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -33,3 +33,10 @@ path = "fuzz_targets/display_parse_tree.rs"
 test = false
 doc = false
 bench = false
+
+[[bin]]
+name = "reconstruct_value"
+path = "fuzz_targets/reconstruct_value.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/reconstruct_value.rs
+++ b/fuzz/fuzz_targets/reconstruct_value.rs
@@ -1,0 +1,11 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+use simfony::value::{Value, StructuralValue};
+
+fuzz_target!(|value: Value| {
+    let structural_value = StructuralValue::from(&value);
+    let reconstructed_value = Value::reconstruct(&structural_value, value.ty()).unwrap();
+    assert_eq!(reconstructed_value, value);
+});

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -245,9 +245,9 @@ impl SingleExpression {
                     .map(|e| e.compile(scope))
                     .collect::<Result<Vec<PairBuilder<ProgNode>>, RichError>>()?;
                 let bound = self.ty().as_list().unwrap().1;
-                let partition = Partition::from_slice(&compiled, bound.get() / 2);
+                let partition = Partition::from_slice(&compiled, bound);
                 partition.fold(
-                    |block| {
+                    |block, _size: usize| {
                         let tree = BTreeSlice::from_slice(block);
                         match tree.fold(PairBuilder::pair) {
                             None => PairBuilder::unit(scope.ctx()).injl(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,26 @@ trait ArbitraryRec: Sized {
     fn arbitrary_rec(u: &mut arbitrary::Unstructured, budget: usize) -> arbitrary::Result<Self>;
 }
 
+/// Helper trait for implementing [`arbitrary::Arbitrary`] for typed structures.
+///
+/// [`arbitrary::Arbitrary`] is intended to produce well-formed values.
+/// Structures with an internal type should be generated in a well-typed fashion.
+///
+/// [`arbitrary::Arbitrary`] can be implemented for a typed structure as follows:
+/// 1. Generate the type via [`arbitrary::Arbitrary`].
+/// 2. Generate the structure via [`ArbitraryOfType::arbitrary_of_type`].
+#[cfg(feature = "arbitrary")]
+trait ArbitraryOfType: Sized {
+    /// Internal type of the structure.
+    type Type;
+
+    /// Generate a structure of the given type.
+    fn arbitrary_of_type(
+        u: &mut arbitrary::Unstructured,
+        ty: &Self::Type,
+    ) -> arbitrary::Result<Self>;
+}
+
 #[cfg(test)]
 mod tests {
     use base64::display::Base64Display;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 
 pub type ProgNode = Arc<named::ConstructNode>;
 
-mod array;
+pub mod array;
 pub mod ast;
 pub mod compile;
 pub mod dummy_env;

--- a/src/types.rs
+++ b/src/types.rs
@@ -989,10 +989,10 @@ impl TypeConstructible for StructuralType {
     fn list(element: Self, bound: NonZeroPow2Usize) -> Self {
         // Cheap clone because Arc<Final> consists of Arcs
         let el_vector = vec![element.0; bound.get() - 1];
-        let partition = Partition::from_slice(&el_vector, bound.get() / 2);
+        let partition = Partition::from_slice(&el_vector, bound);
         debug_assert!(partition.is_complete());
-        let process = |block: &[Arc<Final>]| -> Arc<Final> {
-            debug_assert!(!block.is_empty());
+        let process = |block: &[Arc<Final>], size: usize| -> Arc<Final> {
+            debug_assert_eq!(block.len(), size);
             let tree = BTreeSlice::from_slice(block);
             let array = tree.fold(Final::product).unwrap();
             Final::sum(Final::unit(), array)

--- a/src/value.rs
+++ b/src/value.rs
@@ -861,15 +861,17 @@ impl ValueConstructible for StructuralValue {
                 "Element {element} is not of expected type {ty}"
             );
         }
-        let partition = Partition::from_slice(&elements, bound.get() / 2);
-        let process = |block: &[Self]| -> Self {
+        let partition = Partition::from_slice(&elements, bound);
+        let process = |block: &[Self], size: usize| -> Self {
             let tree = BTreeSlice::from_slice(block);
             match tree.fold(Self::product) {
                 Some(array) => Self::some(array),
-                None => Self::none(StructuralType::array(ty.clone(), block.len())),
+                None => Self::none(StructuralType::array(ty.clone(), size)),
             }
         };
-        partition.fold(process, Self::product)
+        let ret = partition.fold(process, Self::product);
+        debug_assert!(ret.is_of_type(&StructuralType::list(ty, bound)));
+        ret
     }
 }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -591,7 +591,7 @@ impl Value {
 }
 
 impl Value {
-    /// Create a typed value from a constant expression.
+    /// Create value from a constant expression.
     ///
     /// ## Errors
     ///

--- a/src/value.rs
+++ b/src/value.rs
@@ -514,7 +514,10 @@ impl ValueConstructible for Value {
         bound: NonZeroPow2Usize,
     ) -> Self {
         let elements: Arc<[Self]> = elements.into_iter().collect();
-        assert!(elements.len() < bound.get(), "Too many elements");
+        assert!(
+            elements.len() < bound.get(),
+            "There must be fewer list elements than the bound {bound}"
+        );
         for element in elements.iter() {
             assert!(
                 element.is_of_type(&ty),
@@ -848,7 +851,10 @@ impl ValueConstructible for StructuralValue {
         bound: NonZeroPow2Usize,
     ) -> Self {
         let elements: Vec<Self> = elements.into_iter().collect();
-        assert!(bound.get() <= elements.len(), "Too many elements");
+        assert!(
+            elements.len() < bound.get(),
+            "There must be fewer list elements than the bound {bound}"
+        );
         for element in elements.iter() {
             assert!(
                 element.is_of_type(&ty),

--- a/src/witness.rs
+++ b/src/witness.rs
@@ -153,12 +153,15 @@ impl<'de> de::Visitor<'de> for ValueMapVisitor {
             Some(s) => ResolvedType::parse_from_str(s).map_err(de::Error::custom)?,
             None => return Err(de::Error::missing_field("type")),
         };
-        let expression = match value {
+        let expr = match value {
             Some(s) => parse::Expression::parse_from_str(s).map_err(de::Error::custom)?,
             None => return Err(de::Error::missing_field("value")),
         };
+        let expr = ast::Expression::analyze_const(&expr, &ty).map_err(de::Error::custom)?;
 
-        Value::from_const_expr(&expression, &ty).map_err(de::Error::custom)
+        Value::from_const_expr(&expr)
+            .ok_or(Error::ExpressionNotConstant)
+            .map_err(de::Error::custom)
     }
 }
 


### PR DESCRIPTION
Convert Simplicity values back to Simfony values via a Simfony type. We need this to display debug output from the Simplicity Bit Machine in terms of Simfony speak. Fix bugs that came up during fuzzing.