### PR TITLE
Add witness module

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,8 @@ jobs:
           - compile_text
           - display_parse_tree
           - parse_value_rtt
-          - parse_witness_rtt
+          - parse_witness_json_rtt
+          - parse_witness_module_rtt
           - reconstruct_value
     steps:
     - name: Checkout

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -43,8 +43,15 @@ doc = false
 bench = false
 
 [[bin]]
-name = "parse_witness_rtt"
-path = "fuzz_targets/parse_witness_rtt.rs"
+name = "parse_witness_json_rtt"
+path = "fuzz_targets/parse_witness_json_rtt.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "parse_witness_module_rtt"
+path = "fuzz_targets/parse_witness_module_rtt.rs"
 test = false
 doc = false
 bench = false

--- a/fuzz/fuzz_targets/parse_value_rtt.rs
+++ b/fuzz/fuzz_targets/parse_value_rtt.rs
@@ -6,8 +6,8 @@ use simfony::value::Value;
 
 fuzz_target!(|value: Value| {
     let value_string = value.to_string();
-    let parsed_value = Value::parse_from_str(&value_string, value.ty())
-        .expect("Value string should be parseable");
+    let parsed_value =
+        Value::parse_from_str(&value_string, value.ty()).expect("Value string should be parseable");
     assert_eq!(
         value, parsed_value,
         "Value string should parse to original value"

--- a/fuzz/fuzz_targets/parse_witness_json_rtt.rs
+++ b/fuzz/fuzz_targets/parse_witness_json_rtt.rs
@@ -5,8 +5,8 @@ use libfuzzer_sys::fuzz_target;
 use simfony::witness::WitnessValues;
 
 fuzz_target!(|witness_values: WitnessValues| {
-    let witness_text =
-        serde_json::to_string(&witness_values).expect("Witness map should be convertible into JSON");
+    let witness_text = serde_json::to_string(&witness_values)
+        .expect("Witness map should be convertible into JSON");
     let parsed_witness_text =
         serde_json::from_str(&witness_text).expect("Witness JSON should be parseable");
     assert_eq!(

--- a/fuzz/fuzz_targets/parse_witness_module_rtt.rs
+++ b/fuzz/fuzz_targets/parse_witness_module_rtt.rs
@@ -1,0 +1,16 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+use simfony::parse::ParseFromStr;
+use simfony::witness::WitnessValues;
+
+fuzz_target!(|witness_values: WitnessValues| {
+    let witness_text = witness_values.to_string();
+    let parsed_witness_text =
+        WitnessValues::parse_from_str(&witness_text).expect("Witness module should be parseable");
+    assert_eq!(
+        witness_values, parsed_witness_text,
+        "Witness module should parse to original witness values"
+    );
+});

--- a/fuzz/fuzz_targets/reconstruct_value.rs
+++ b/fuzz/fuzz_targets/reconstruct_value.rs
@@ -2,7 +2,7 @@
 
 use libfuzzer_sys::fuzz_target;
 
-use simfony::value::{Value, StructuralValue};
+use simfony::value::{StructuralValue, Value};
 
 fuzz_target!(|value: Value| {
     let structural_value = StructuralValue::from(&value);

--- a/justfile
+++ b/justfile
@@ -37,7 +37,8 @@ check_fuzz:
     just fuzz compile_text
     just fuzz display_parse_tree
     just fuzz parse_value_rtt
-    just fuzz parse_witness_rtt
+    just fuzz parse_witness_json_rtt
+    just fuzz parse_witness_module_rtt
     just fuzz reconstruct_value
 
 # Build fuzz tests

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,7 +6,7 @@ use simplicity::hashes::{sha256, Hash, HashEngine};
 use simplicity::{elements, Cmr};
 
 use crate::parse::{MatchPattern, Rule};
-use crate::str::{FunctionName, Identifier, JetName, WitnessName};
+use crate::str::{FunctionName, Identifier, JetName, ModuleName, WitnessName};
 use crate::types::{ResolvedType, UIntType};
 
 /// Position of an object inside a file.
@@ -329,6 +329,8 @@ pub enum Error {
     WitnessTypeMismatch(WitnessName, ResolvedType, ResolvedType),
     WitnessReassigned(WitnessName),
     WitnessOutsideMain,
+    ModuleRequired(ModuleName),
+    ModuleRedefined(ModuleName),
 }
 
 #[rustfmt::skip]
@@ -450,6 +452,14 @@ impl fmt::Display for Error {
             Error::WitnessOutsideMain => write!(
                 f,
                 "Witness expressions are not allowed outside the `main` function"
+            ),
+            Error::ModuleRequired(name) => write!(
+                f,
+                "Required module `{name}` is missing"
+            ),
+            Error::ModuleRedefined(name) => write!(
+                f,
+                "Module `{name}` is defined twice"
             ),
         }
     }

--- a/src/minimal.pest
+++ b/src/minimal.pest
@@ -2,7 +2,7 @@ WHITESPACE        = _{ " " | "\t" | "\n" | "\r" }
 COMMENT           = _{ ("/*" ~ (!"*/" ~ ANY)* ~ "*/") | ("//" ~ (!"\n" ~ ANY)*) }
 
 program           =  { SOI ~ item* ~ EOI }
-item              =  { type_alias | function }
+item              =  { type_alias | function | witness_module }
 statement         =  { assignment | expression }
 expression        =  { block_expression | single_expression }
 block_expression  =  { "{" ~ (statement ~ ";")* ~ expression? ~ "}" }
@@ -82,3 +82,8 @@ tuple_expr        =  { "(" ~ ((expression ~ ",")+ ~ expression?)? ~ ")" }
 array_expr        =  { "[" ~ (expression ~ ("," ~ expression)* ~ ","?)? ~ "]" }
 list_expr         =  { "list![" ~ (expression ~ ("," ~ expression)* ~ ","?)? ~ "]" }
 single_expression =  { left_expr | right_expr | none_expr | some_expr | false_expr | true_expr | call_expr | match_expr | tuple_expr | array_expr | list_expr | bin_literal | hex_literal | dec_literal | witness_expr | variable_expr | "(" ~ expression ~ ")" }
+
+mod_keyword       = @{ "mod" ~ !ASCII_ALPHANUMERIC }
+witness_module    =  { mod_keyword ~ "witness" ~ "{" ~ (witness_assign ~ ";")* ~ "}" }
+const_keyword     = @{ "const" ~ !ASCII_ALPHANUMERIC }
+witness_assign    =  { const_keyword ~ witness_name ~ ":" ~ ty ~ "=" ~ expression }

--- a/src/str.rs
+++ b/src/str.rs
@@ -168,3 +168,16 @@ impl<'a> arbitrary::Arbitrary<'a> for Hexadecimal {
         Ok(Self::from_str_unchecked(string.as_str()))
     }
 }
+
+/// The name of a module.
+#[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
+pub struct ModuleName(Arc<str>);
+
+impl ModuleName {
+    /// Return the name of the witness module.
+    pub fn witness() -> Self {
+        Self(Arc::from("witness"))
+    }
+}
+
+wrapped_string!(ModuleName, "module name");

--- a/src/witness.rs
+++ b/src/witness.rs
@@ -3,6 +3,7 @@ use std::collections::BTreeMap;
 
 use crate::ast::WitnessTypes;
 use crate::error::{Error, RichError, WithFile, WithSpan};
+use crate::parse;
 use crate::parse::ParseFromStr;
 use crate::str::WitnessName;
 use crate::types::{AliasedType, ResolvedType};
@@ -101,6 +102,12 @@ impl ParseFromStr for ResolvedType {
             .map_err(Error::UndefinedAlias)
             .with_span(s)
             .with_file(s)
+    }
+}
+
+impl ParseFromStr for WitnessValues {
+    fn parse_from_str(s: &str) -> Result<Self, RichError> {
+        parse::WitnessProgram::parse_from_str(s).and_then(|x| Self::analyze(&x))
     }
 }
 


### PR DESCRIPTION
Make witness JSON parsing via serde optional. Introduce witness modules as an alternative way to provide witness data. Witness modules are written directly inside the Simfony source code.

