### PR TITLE
Parameterize programs

### DIFF
--- a/bitcoind-tests/tests/common/daemon.rs
+++ b/bitcoind-tests/tests/common/daemon.rs
@@ -1,11 +1,11 @@
 use std::str::FromStr;
 
-use simfony::elements;
 use elements::encode::{deserialize, serialize_hex};
 use elements::hex::FromHex;
 use elementsd::bitcoincore_rpc::jsonrpc::serde_json::{json, Value};
 use elementsd::bitcoind::bitcoincore_rpc::RpcApi;
 use elementsd::ElementsD;
+use simfony::elements;
 
 // We are not using pegins right now, but it might be required in case in future
 // if we extend the tests to check pegins etc.

--- a/bitcoind-tests/tests/common/test.rs
+++ b/bitcoind-tests/tests/common/test.rs
@@ -182,7 +182,7 @@ impl<'a> TestCase<'a> {
         };
         let witness_values = (self.witness)(sighash_all.to_byte_array());
         let satisfied_program = compiled
-            .satisfy(&witness_values)
+            .satisfy(witness_values)
             .expect("program should be satisfiable");
         let (program_bytes, witness_bytes) = satisfied_program.redeem().encode_to_vec();
         psbt.inputs_mut()[0].final_script_witness = Some(vec![

--- a/bitcoind-tests/tests/common/test.rs
+++ b/bitcoind-tests/tests/common/test.rs
@@ -51,8 +51,8 @@ impl<'a> TestCase<'a> {
 
     pub fn program_path<P: AsRef<std::path::Path>>(mut self, path: P) -> Self {
         let text = std::fs::read_to_string(path).expect("path should be readable");
-        let compiled =
-            simfony::CompiledProgram::new(text.as_str()).expect("program should compile");
+        let compiled = simfony::CompiledProgram::new(text.as_str(), simfony::Arguments::default())
+            .expect("program should compile");
         self.compiled = Some(compiled);
         self
     }

--- a/bitcoind-tests/tests/spend_utxo.rs
+++ b/bitcoind-tests/tests/spend_utxo.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use elements::hashes::Hash;
 use elements::secp256k1_zkp as secp256k1;
 use secp256k1::hashes::{sha256, HashEngine};
@@ -47,77 +49,63 @@ fn spend_utxo() {
 }
 
 fn hodl_vault(sighash_all: [u8; 32]) -> simfony::WitnessValues {
-    let mut witness_values = simfony::WitnessValues::default();
+    let mut witness_values = HashMap::new();
     let oracle_height = 1000;
-    witness_values
-        .insert(
-            WitnessName::from_str_unchecked("ORACLE_HEIGHT"),
-            Value::u32(oracle_height),
-        )
-        .unwrap();
+    witness_values.insert(
+        WitnessName::from_str_unchecked("ORACLE_HEIGHT"),
+        Value::u32(oracle_height),
+    );
     let oracle_price = 100_000;
-    witness_values
-        .insert(
-            WitnessName::from_str_unchecked("ORACLE_PRICE"),
-            Value::u32(oracle_price),
-        )
-        .unwrap();
+    witness_values.insert(
+        WitnessName::from_str_unchecked("ORACLE_PRICE"),
+        Value::u32(oracle_price),
+    );
     let mut hasher = sha256::HashEngine::default();
     hasher.input(&oracle_height.to_be_bytes());
     hasher.input(&oracle_price.to_be_bytes());
     let oracle_hash = sha256::Hash::from_engine(hasher).to_byte_array();
-    witness_values
-        .insert(
-            WitnessName::from_str_unchecked("ORACLE_SIG"),
-            Value::byte_array(util::sign_schnorr(1, oracle_hash)),
-        )
-        .unwrap();
-    witness_values
-        .insert(
-            WitnessName::from_str_unchecked("OWNER_SIG"),
-            Value::byte_array(util::sign_schnorr(2, sighash_all)),
-        )
-        .unwrap();
-    witness_values
+    witness_values.insert(
+        WitnessName::from_str_unchecked("ORACLE_SIG"),
+        Value::byte_array(util::sign_schnorr(1, oracle_hash)),
+    );
+    witness_values.insert(
+        WitnessName::from_str_unchecked("OWNER_SIG"),
+        Value::byte_array(util::sign_schnorr(2, sighash_all)),
+    );
+    simfony::WitnessValues::from(witness_values)
 }
 
 fn p2pk(sighash_all: [u8; 32]) -> simfony::WitnessValues {
-    let mut witness_values = simfony::WitnessValues::default();
+    let mut witness_values = HashMap::new();
     witness_values
         .insert(
             WitnessName::from_str_unchecked("SIG"),
             Value::byte_array(util::sign_schnorr(1, sighash_all)),
         )
         .unwrap();
-    witness_values
+    simfony::WitnessValues::from(witness_values)
 }
 
 fn p2pkh(sighash_all: [u8; 32]) -> simfony::WitnessValues {
-    let mut witness_values = simfony::WitnessValues::default();
-    witness_values
-        .insert(
-            WitnessName::from_str_unchecked("PK"),
-            Value::u256(util::xonly_public_key(1)),
-        )
-        .unwrap();
-    witness_values
-        .insert(
-            WitnessName::from_str_unchecked("SIG"),
-            Value::byte_array(util::sign_schnorr(1, sighash_all)),
-        )
-        .unwrap();
-    witness_values
+    let mut witness_values = HashMap::new();
+    witness_values.insert(
+        WitnessName::from_str_unchecked("PK"),
+        Value::u256(util::xonly_public_key(1)),
+    );
+    witness_values.insert(
+        WitnessName::from_str_unchecked("SIG"),
+        Value::byte_array(util::sign_schnorr(1, sighash_all)),
+    );
+    simfony::WitnessValues::from(witness_values)
 }
 
 fn p2ms(sighash_all: [u8; 32]) -> simfony::WitnessValues {
-    let mut witness_values = simfony::WitnessValues::default();
+    let mut witness_values = HashMap::new();
     let sig1 = Value::some(Value::byte_array(util::sign_schnorr(1, sighash_all)));
     let sig2 = Value::none(ResolvedType::byte_array(64));
     let sig3 = Value::some(Value::byte_array(util::sign_schnorr(3, sighash_all)));
     let ty = sig1.ty().clone();
     let maybe_sigs = Value::array([sig1, sig2, sig3], ty);
-    witness_values
-        .insert(WitnessName::from_str_unchecked("MAYBE_SIGS"), maybe_sigs)
-        .unwrap();
-    witness_values
+    witness_values.insert(WitnessName::from_str_unchecked("MAYBE_SIGS"), maybe_sigs);
+    simfony::WitnessValues::from(witness_values)
 }

--- a/bitcoind-tests/tests/spend_utxo.rs
+++ b/bitcoind-tests/tests/spend_utxo.rs
@@ -28,7 +28,8 @@ fn spend_utxo() {
             .sequence(elements::Sequence::ENABLE_LOCKTIME_NO_RBF),
         TestCase::new(&daemon, genesis_hash)
             .name("Pay to public key")
-            .program_path("../examples/p2pk.simf")
+            .template_path("../examples/p2pk.simf")
+            .arguments(p2pk_args())
             .witness(p2pk),
         TestCase::new(&daemon, genesis_hash)
             .name("Pay to public key hash")
@@ -73,6 +74,13 @@ fn hodl_vault(sighash_all: [u8; 32]) -> simfony::WitnessValues {
         Value::byte_array(util::sign_schnorr(2, sighash_all)),
     );
     simfony::WitnessValues::from(witness_values)
+}
+
+fn p2pk_args() -> simfony::Arguments {
+    simfony::Arguments::from(HashMap::from([(
+        WitnessName::from_str_unchecked("ALICE_PUBLIC_KEY"),
+        Value::byte_array(util::xonly_public_key(0).to_byte_array()),
+    )]))
 }
 
 fn p2pk(sighash_all: [u8; 32]) -> simfony::WitnessValues {

--- a/examples/p2pk.args
+++ b/examples/p2pk.args
@@ -1,0 +1,6 @@
+{
+    "ALICE_PUBLIC_KEY": {
+        "value": "0x79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+        "type": "Pubkey"
+    }
+}

--- a/examples/p2pk.simf
+++ b/examples/p2pk.simf
@@ -6,7 +6,5 @@
  * https://docs.ivylang.org/bitcoin/language/ExampleContracts.html#lockwithpublickey
  */
 fn main() {
-    let pk: Pubkey = 0x79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798; // 1 * G
-    let msg: u256 = jet::sig_all_hash();
-    jet::bip_0340_verify((pk, msg), witness::SIG)
+    jet::bip_0340_verify((param::ALICE_PUBLIC_KEY, jet::sig_all_hash()), witness::ALICE_SIGNATURE)
 }

--- a/examples/p2pk.wit
+++ b/examples/p2pk.wit
@@ -1,5 +1,5 @@
 {
-    "SIG": {
+    "ALICE_SIGNATURE": {
         "value": "0xf74b3ca574647f8595624b129324afa2f38b598a9c1c7cfc5f08a9c036ec5acd3c0fbb9ed3dae5ca23a0a65a34b5d6cccdd6ba248985d6041f7b21262b17af6f",
         "type": "Signature"
     }

--- a/fuzz/fuzz_targets/compile_parse_tree.rs
+++ b/fuzz/fuzz_targets/compile_parse_tree.rs
@@ -1,20 +1,29 @@
 #![no_main]
 
+use arbitrary::Arbitrary;
 use libfuzzer_sys::fuzz_target;
 
 use simfony::error::WithFile;
-use simfony::{ast, named, parse};
+use simfony::{ast, named, parse, ArbitraryOfType, Arguments};
 
-fuzz_target!(|parse_program: parse::Program| {
-    match ast::Program::analyze(&parse_program) {
-        Ok(ast_program) => {
-            let simplicity_named_construct = ast_program
-                .compile()
-                .with_file("")
-                .expect("AST should always compile");
-            let _simplicity_commit = named::to_commit_node(&simplicity_named_construct)
-                .expect("Conversion to commit node should never fail");
-        }
-        Err(_) => {}
-    }
+fuzz_target!(|data: &[u8]| {
+    let mut u = arbitrary::Unstructured::new(data);
+    let parse_program = match parse::Program::arbitrary(&mut u) {
+        Ok(x) => x,
+        Err(_) => return,
+    };
+    let ast_program = match ast::Program::analyze(&parse_program) {
+        Ok(x) => x,
+        Err(_) => return,
+    };
+    let arguments = match Arguments::arbitrary_of_type(&mut u, ast_program.parameters()) {
+        Ok(arguments) => arguments,
+        Err(..) => return,
+    };
+    let simplicity_named_construct = ast_program
+        .compile(arguments)
+        .with_file("")
+        .expect("AST should compile with given arguments");
+    let _simplicity_commit = named::to_commit_node(&simplicity_named_construct)
+        .expect("Conversion to commit node should never fail");
 });

--- a/src/error.rs
+++ b/src/error.rs
@@ -331,6 +331,8 @@ pub enum Error {
     WitnessOutsideMain,
     ModuleRequired(ModuleName),
     ModuleRedefined(ModuleName),
+    ArgumentMissing(WitnessName),
+    ArgumentTypeMismatch(WitnessName, ResolvedType, ResolvedType),
 }
 
 #[rustfmt::skip]
@@ -460,6 +462,14 @@ impl fmt::Display for Error {
             Error::ModuleRedefined(name) => write!(
                 f,
                 "Module `{name}` is defined twice"
+            ),
+            Error::ArgumentMissing(name) => write!(
+                f,
+                "Parameter `{name}` is missing an argument"
+            ),
+            Error::ArgumentTypeMismatch(name, declared, assigned) => write!(
+                f,
+                "Parameter `{name}` was declared with type `{declared}` but its assigned argument is of type `{assigned}`"
             ),
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ fn run() -> Result<(), String> {
         let wit_text = std::fs::read_to_string(wit_path).map_err(|e| e.to_string())?;
         let witness = serde_json::from_str::<simfony::WitnessValues>(&wit_text).unwrap();
 
-        let satisfied = compiled.satisfy(&witness)?;
+        let satisfied = compiled.satisfy(witness)?;
         let (program_bytes, witness_bytes) = satisfied.redeem().encode_to_vec();
         println!(
             "Program:\n{}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use base64::display::Base64Display;
 use base64::engine::general_purpose::STANDARD;
 
-use simfony::CompiledProgram;
+use simfony::{Arguments, CompiledProgram};
 use std::env;
 
 // Directly returning Result<(), String> prints the error using Debug
@@ -29,7 +29,7 @@ fn run() -> Result<(), String> {
     let prog_file = &args[1];
     let prog_path = std::path::Path::new(prog_file);
     let prog_text = std::fs::read_to_string(prog_path).map_err(|e| e.to_string())?;
-    let compiled = CompiledProgram::new(&prog_text)?;
+    let compiled = CompiledProgram::new(prog_text, Arguments::default())?;
 
     if args.len() >= 3 {
         let wit_file = &args[2];
@@ -73,7 +73,7 @@ fn run() -> Result<(), String> {
     let prog_file = &args[1];
     let prog_path = std::path::Path::new(prog_file);
     let prog_text = std::fs::read_to_string(prog_path).map_err(|e| e.to_string())?;
-    let compiled = CompiledProgram::new(&prog_text)?;
+    let compiled = CompiledProgram::new(prog_text, Arguments::default())?;
 
     let program_bytes = compiled.commit().encode_to_vec();
     println!(

--- a/src/minimal.pest
+++ b/src/minimal.pest
@@ -2,7 +2,7 @@ WHITESPACE        = _{ " " | "\t" | "\n" | "\r" }
 COMMENT           = _{ ("/*" ~ (!"*/" ~ ANY)* ~ "*/") | ("//" ~ (!"\n" ~ ANY)*) }
 
 program           =  { SOI ~ item* ~ EOI }
-item              =  { type_alias | function | witness_module }
+item              =  { type_alias | function | module }
 statement         =  { assignment | expression }
 expression        =  { block_expression | single_expression }
 block_expression  =  { "{" ~ (statement ~ ";")* ~ expression? ~ "}" }
@@ -84,6 +84,7 @@ list_expr         =  { "list![" ~ (expression ~ ("," ~ expression)* ~ ","?)? ~ "
 single_expression =  { left_expr | right_expr | none_expr | some_expr | false_expr | true_expr | call_expr | match_expr | tuple_expr | array_expr | list_expr | bin_literal | hex_literal | dec_literal | witness_expr | variable_expr | "(" ~ expression ~ ")" }
 
 mod_keyword       = @{ "mod" ~ !ASCII_ALPHANUMERIC }
-witness_module    =  { mod_keyword ~ "witness" ~ "{" ~ (witness_assign ~ ";")* ~ "}" }
 const_keyword     = @{ "const" ~ !ASCII_ALPHANUMERIC }
-witness_assign    =  { const_keyword ~ witness_name ~ ":" ~ ty ~ "=" ~ expression }
+module_name       = @{ "witness" | "param" }
+module_assign     =  { const_keyword ~ witness_name ~ ":" ~ ty ~ "=" ~ expression }
+module            =  { mod_keyword ~ module_name ~ "{" ~ (module_assign ~ ";")* ~ "}" }

--- a/src/minimal.pest
+++ b/src/minimal.pest
@@ -74,6 +74,7 @@ dec_literal       = @{ (ASCII_DIGIT | "_")+ }
 bin_literal       = @{ "0b" ~ (ASCII_BIN_DIGIT | "_")+ }
 hex_literal       = @{ "0x" ~ (ASCII_HEX_DIGIT | "_")+ }
 witness_expr      = ${ "witness::" ~ witness_name }
+param_expr        = ${ "param::" ~ witness_name }
 variable_expr     =  { identifier }
 match_arm         =  { match_pattern ~ "=>" ~ (single_expression ~ "," | block_expression ~ ","?) }
 match_keyword     = @{ "match" ~ !ASCII_ALPHANUMERIC }
@@ -81,7 +82,7 @@ match_expr        =  { match_keyword ~ expression ~ "{" ~ match_arm ~ match_arm 
 tuple_expr        =  { "(" ~ ((expression ~ ",")+ ~ expression?)? ~ ")" }
 array_expr        =  { "[" ~ (expression ~ ("," ~ expression)* ~ ","?)? ~ "]" }
 list_expr         =  { "list![" ~ (expression ~ ("," ~ expression)* ~ ","?)? ~ "]" }
-single_expression =  { left_expr | right_expr | none_expr | some_expr | false_expr | true_expr | call_expr | match_expr | tuple_expr | array_expr | list_expr | bin_literal | hex_literal | dec_literal | witness_expr | variable_expr | "(" ~ expression ~ ")" }
+single_expression =  { left_expr | right_expr | none_expr | some_expr | false_expr | true_expr | call_expr | match_expr | tuple_expr | array_expr | list_expr | bin_literal | hex_literal | dec_literal | witness_expr | param_expr | variable_expr | "(" ~ expression ~ ")" }
 
 mod_keyword       = @{ "mod" ~ !ASCII_ALPHANUMERIC }
 const_keyword     = @{ "const" ~ !ASCII_ALPHANUMERIC }

--- a/src/named.rs
+++ b/src/named.rs
@@ -99,13 +99,13 @@ pub fn to_commit_node(node: &ConstructNode) -> Result<Arc<CommitNode<Elements>>,
 /// It is the responsibility of the caller to ensure that the given witness `values` match the
 /// types in the construct `node`. This can be done by calling [`WitnessValues::is_consistent`]
 /// on the original Simfony program before it is compiled to Simplicity.
-pub fn to_witness_node(node: &ConstructNode, values: &WitnessValues) -> Arc<WitnessNode<Elements>> {
-    struct Populator<'a> {
-        values: &'a WitnessValues,
+pub fn to_witness_node(node: &ConstructNode, values: WitnessValues) -> Arc<WitnessNode<Elements>> {
+    struct Populator {
+        values: WitnessValues,
         inference_context: types::Context,
     }
 
-    impl<'a, J: Jet> Converter<Construct<J>, node::Witness<J>> for Populator<'a> {
+    impl<J: Jet> Converter<Construct<J>, node::Witness<J>> for Populator {
         type Error = ();
 
         fn convert_witness(

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -779,6 +779,23 @@ trait PestParse: Sized {
     fn parse(pair: pest::iterators::Pair<Rule>) -> Result<Self, RichError>;
 }
 
+macro_rules! impl_parse_wrapped_string {
+    ($wrapper: ident, $rule: ident) => {
+        impl PestParse for $wrapper {
+            const RULE: Rule = Rule::$rule;
+
+            fn parse(pair: pest::iterators::Pair<Rule>) -> Result<Self, RichError> {
+                assert!(matches!(pair.as_rule(), Self::RULE));
+                Ok(Self::from_str_unchecked(pair.as_str()))
+            }
+        }
+    };
+}
+
+impl_parse_wrapped_string!(FunctionName, function_name);
+impl_parse_wrapped_string!(Identifier, identifier);
+impl_parse_wrapped_string!(WitnessName, witness_name);
+
 /// Copy of [`FromStr`] that internally uses the PEST parser.
 pub trait ParseFromStr: Sized {
     /// Parse a value from the string `s`.
@@ -864,15 +881,6 @@ impl PestParse for Function {
     }
 }
 
-impl PestParse for FunctionName {
-    const RULE: Rule = Rule::function_name;
-
-    fn parse(pair: pest::iterators::Pair<Rule>) -> Result<Self, RichError> {
-        assert!(matches!(pair.as_rule(), Self::RULE));
-        Ok(Self::from_str_unchecked(pair.as_str()))
-    }
-}
-
 impl PestParse for FunctionParam {
     const RULE: Rule = Rule::typed_identifier;
 
@@ -935,15 +943,6 @@ impl PestParse for Pattern {
 
         debug_assert!(output.len() == 1);
         Ok(output.pop().unwrap())
-    }
-}
-
-impl PestParse for Identifier {
-    const RULE: Rule = Rule::identifier;
-
-    fn parse(pair: pest::iterators::Pair<Rule>) -> Result<Self, RichError> {
-        assert!(matches!(pair.as_rule(), Self::RULE));
-        Ok(Self::from_str_unchecked(pair.as_str()))
     }
 }
 
@@ -1193,15 +1192,6 @@ impl PestParse for Hexadecimal {
         assert!(matches!(pair.as_rule(), Self::RULE));
         let hexadecimal = pair.as_str().strip_prefix("0x").unwrap().replace('_', "");
         Ok(Self::from_str_unchecked(hexadecimal.as_str()))
-    }
-}
-
-impl PestParse for WitnessName {
-    const RULE: Rule = Rule::witness_name;
-
-    fn parse(pair: pest::iterators::Pair<Rule>) -> Result<Self, RichError> {
-        assert!(matches!(pair.as_rule(), Self::RULE));
-        Ok(Self::from_str_unchecked(pair.as_str()))
     }
 }
 

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -7,7 +7,7 @@ use crate::parse::ParseFromStr;
 use crate::str::WitnessName;
 use crate::types::ResolvedType;
 use crate::value::Value;
-use crate::witness::WitnessValues;
+use crate::witness::{Arguments, WitnessValues};
 
 struct WitnessMapVisitor;
 
@@ -33,6 +33,17 @@ impl<'de> de::Visitor<'de> for WitnessMapVisitor {
 }
 
 impl<'de> Deserialize<'de> for WitnessValues {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer
+            .deserialize_map(WitnessMapVisitor)
+            .map(Self::from)
+    }
+}
+
+impl<'de> Deserialize<'de> for Arguments {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
@@ -155,6 +166,15 @@ impl<'a> Serialize for ValueMapSerializer<'a> {
 }
 
 impl Serialize for WitnessValues {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        WitnessMapSerializer(self.as_inner()).serialize(serializer)
+    }
+}
+
+impl Serialize for Arguments {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,

--- a/src/str.rs
+++ b/src/str.rs
@@ -23,6 +23,11 @@ macro_rules! wrapped_string {
             pub fn as_inner(&self) -> &str {
                 self.0.as_ref()
             }
+
+            /// Make a cheap copy of the name.
+            pub fn shallow_clone(&self) -> Self {
+                Self(Arc::clone(&self.0))
+            }
         }
 
         impl std::fmt::Display for $wrapper {

--- a/src/str.rs
+++ b/src/str.rs
@@ -183,6 +183,11 @@ impl ModuleName {
     pub fn witness() -> Self {
         Self(Arc::from("witness"))
     }
+
+    /// Return the name of the parameter module.
+    pub fn param() -> Self {
+        Self(Arc::from("param"))
+    }
 }
 
 wrapped_string!(ModuleName, "module name");

--- a/src/value.rs
+++ b/src/value.rs
@@ -647,7 +647,11 @@ impl Value {
             let size = data.node.n_children();
             match single.inner() {
                 S::Constant(value) => output.push(value.clone()),
-                S::Witness(..) | S::Variable(..) | S::Call(..) | S::Match(..) => return None, // not const
+                S::Witness(..)
+                | S::Parameter(..)
+                | S::Variable(..)
+                | S::Call(..)
+                | S::Match(..) => return None, // not const
                 S::Expression(..) => continue, // skip
                 S::Tuple(..) => {
                     let elements = output.split_off(output.len() - size);

--- a/src/witness.rs
+++ b/src/witness.rs
@@ -69,7 +69,7 @@ macro_rules! impl_name_value_map {
 
         impl ParseFromStr for $wrapper {
             fn parse_from_str(s: &str) -> Result<Self, RichError> {
-                parse::WitnessProgram::parse_from_str(s).and_then(|x| Self::analyze(&x))
+                parse::ModuleProgram::parse_from_str(s).and_then(|x| Self::analyze(&x))
             }
         }
 

--- a/src/witness.rs
+++ b/src/witness.rs
@@ -16,6 +16,12 @@ use crate::value::Value;
 pub struct WitnessValues(BTreeMap<WitnessName, Value>);
 
 impl WitnessValues {
+    #[cfg(feature = "serde")]
+    /// Access the inner map.
+    pub fn as_inner(&self) -> &BTreeMap<WitnessName, Value> {
+        &self.0
+    }
+
     /// Return the empty witness map.
     pub fn empty() -> Self {
         Self(BTreeMap::new())


### PR DESCRIPTION
Refactor the code that handles witness types / values / modules. Add parameterized values to Simfony which are instantiated at commitment time.

Simfony programs with parameters are templates for a family of Simfony programs. A template is instantiated by providing arguments to its parameters. Arguments can be provided via JSON or via code `mod param { ... }`.

The existing API needed to be updated to handle parameters. This turned out to be more work than expected :) While most changes are mechanical, there were some interesting engineering problems, such as handling parameters inside fuzz tests.