### PR TITLE
Add VSCode extension with syntax highlighter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,9 @@ target/
 
 # mdbook HTML output dir
 book/book/
+
+# Node.js modules
+node_modules/
+
+# VSCode extension package
+*.vsix

--- a/README.md
+++ b/README.md
@@ -65,3 +65,7 @@ The compiler produces a base64-encoded Simplicity program. Witness data will be 
 ```bash
 ./target/debug/simc examples/test.simf examples/test.wit
 ```
+
+### VSCode extension
+
+See the installation [instructions](./vscode/README.md).

--- a/vscode/LICENSE
+++ b/vscode/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Simfony contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE. 

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -1,0 +1,77 @@
+# Simfony extension for VSCode
+
+VSCode extension that provides syntax highlighting for the [Simfony](https://docs.simfony.dev/) programming language.
+
+## Features
+
+- Syntax highlighting for .simf files
+- Basic language configuration (brackets, comments)
+
+## Installation
+
+Install Node.js (v14 or later recommended).
+
+### Local Installation
+
+1. Clone this repository
+2. Navigate to the extension directory:
+   ```bash
+   cd vscode
+   ```
+3. Install dependencies:
+   ```bash
+   npm install
+   ```
+4. Package the extension:
+   ```bash
+   npm install -g @vscode/vsce
+   vsce package
+   ```
+   This will create a `.vsix` file in the current directory.
+
+5. Install the extension in VSCode:
+   - Launch VS Code
+   - Go to the Extensions view (Ctrl+Shift+X)
+   - Click on the "..." menu in the top-right of the Extensions view
+   - Select "Install from VSIX..."
+   - Navigate to and select the `.vsix` file you created
+
+### Alternative Installation Method
+
+You can also install the extension directly from the source code:
+
+1. Copy the `vscode` folder (rename it if necessary) to your VSCode extensions directory:
+   - Windows: `%USERPROFILE%\.vscode\extensions`
+   - macOS/Linux: `~/.vscode/extensions`
+
+2. Restart VSCode
+
+## Development
+
+1. Clone this repository and cd into `vscode` directory
+2. Run `npm install`
+3. Open the project in VS Code
+4. Press F5 to start debugging (this will launch a new VSCode window with the extension loaded)
+5. Make changes to the extension
+6. Reload the debugging window to see your changes (Ctrl+R or Cmd+R)
+
+### Reloading the Extension During Development
+
+When making changes to the extension, you can reload it without uninstalling and reinstalling:
+
+1. **Using the Command Palette**:
+   - Press `Ctrl+Shift+P` (or `Cmd+Shift+P` on macOS)
+   - Type "Developer: Reload Window" and select it
+
+2. **Using keyboard shortcut**:
+   - Press `Ctrl+R` (or `Cmd+R` on macOS)
+
+3. **For extensions installed from folder**:
+   - Make your changes to the extension files
+   - Run the "Developer: Reload Window" command as described above
+   - VSCode will reload with the updated extension
+
+4. **For more substantial changes**:
+   - If you've made significant changes to the extension's structure or manifest
+   - You may need to restart VSCode completely (close and reopen)
+   - In some cases, you might need to run the command "Developer: Restart Extension Host"

--- a/vscode/language-configuration.json
+++ b/vscode/language-configuration.json
@@ -1,0 +1,22 @@
+{
+    "comments": {
+        "lineComment": "//"
+    },
+    "brackets": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"]
+    ],
+    "autoClosingPairs": [
+        { "open": "{", "close": "}" },
+        { "open": "[", "close": "]" },
+        { "open": "(", "close": ")" },
+        { "open": "\"", "close": "\"" }
+    ],
+    "surroundingPairs": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"],
+        ["\"", "\""]
+    ]
+} 

--- a/vscode/package-lock.json
+++ b/vscode/package-lock.json
@@ -1,0 +1,16 @@
+{
+  "name": "simfony-language",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "simfony-language",
+      "version": "0.0.1",
+      "license": "MIT",
+      "engines": {
+        "vscode": "^1.85.0"
+      }
+    }
+  }
+}

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "simfony-language",
+  "displayName": "Simfony Language Support",
+  "description": "Syntax highlighting and autocompletion for Simfony language",
+  "version": "0.0.1",
+  "publisher": "blockstream",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/BlockstreamResearch/simfony"
+  },
+  "engines": {
+    "vscode": "^1.85.0"
+  },
+  "categories": [
+    "Programming Languages"
+  ],
+  "contributes": {
+    "languages": [{
+      "id": "simfony",
+      "aliases": ["Simfony", "simfony"],
+      "extensions": [".simf"],
+      "configuration": "./language-configuration.json"
+    }],
+    "grammars": [{
+      "language": "simfony",
+      "scopeName": "source.simfony",
+      "path": "./syntaxes/simfony.tmLanguage.json"
+    }]
+  },
+  "license": "MIT"
+}

--- a/vscode/syntaxes/simfony.tmLanguage.json
+++ b/vscode/syntaxes/simfony.tmLanguage.json
@@ -1,0 +1,347 @@
+{
+    "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+    "name": "Simfony",
+    "patterns": [
+        {
+            "include": "#preprocessor"
+        },
+        {
+            "include": "#comments"
+        },
+        {
+            "include": "#macros"
+        },
+        {
+            "include": "#modules"
+        },
+        {
+            "include": "#keywords"
+        },
+        {
+            "include": "#functions"
+        },
+        {
+            "include": "#types"
+        },
+        {
+            "include": "#literals"
+        },
+        {
+            "include": "#expressions"
+        }
+    ],
+    "repository": {
+        "preprocessor": {
+            "patterns": [
+                {
+                    "name": "meta.preprocessor.simfony",
+                    "match": "^\\s*#\\s*(include|define|undef|if|ifdef|ifndef|else|elif|endif|line|error|pragma)\\b",
+                    "captures": {
+                        "1": {
+                            "name": "keyword.other.preprocessor.directive.simfony"
+                        }
+                    }
+                },
+                {
+                    "name": "meta.preprocessor.include.simfony",
+                    "match": "^\\s*#\\s*include\\s+([\"<].*[\">])",
+                    "captures": {
+                        "1": {
+                            "name": "string.quoted.other.lt-gt.include.simfony"
+                        }
+                    }
+                },
+                {
+                    "name": "meta.preprocessor.define.simfony",
+                    "begin": "^\\s*#\\s*(define)\\s+([a-zA-Z_][a-zA-Z0-9_]*)",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.other.preprocessor.directive.simfony"
+                        },
+                        "2": {
+                            "name": "entity.name.function.preprocessor.simfony"
+                        }
+                    },
+                    "end": "(?=(?://|/\\*))|$",
+                    "patterns": [
+                        {
+                            "include": "#preprocessor-expression"
+                        }
+                    ]
+                },
+                {
+                    "name": "meta.preprocessor.macro.simfony",
+                    "begin": "^\\s*#\\s*(define)\\s+([a-zA-Z_][a-zA-Z0-9_]*)\\(",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.other.preprocessor.directive.simfony"
+                        },
+                        "2": {
+                            "name": "entity.name.function.preprocessor.simfony"
+                        }
+                    },
+                    "end": "\\)|(?=(?://|/\\*))|$",
+                    "patterns": [
+                        {
+                            "name": "variable.parameter.preprocessor.simfony",
+                            "match": "[a-zA-Z_][a-zA-Z0-9_]*"
+                        },
+                        {
+                            "name": "punctuation.separator.parameters.simfony",
+                            "match": ","
+                        }
+                    ]
+                },
+                {
+                    "name": "meta.preprocessor.conditional.simfony",
+                    "begin": "^\\s*#\\s*(if|ifdef|ifndef|elif)\\b",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "keyword.other.preprocessor.directive.simfony"
+                        }
+                    },
+                    "end": "(?=(?://|/\\*))|$",
+                    "patterns": [
+                        {
+                            "include": "#preprocessor-expression"
+                        }
+                    ]
+                }
+            ]
+        },
+        "preprocessor-expression": {
+            "patterns": [
+                {
+                    "name": "constant.language.preprocessor.simfony",
+                    "match": "\\b(defined)\\b"
+                },
+                {
+                    "name": "entity.name.function.preprocessor.simfony",
+                    "match": "\\b[a-zA-Z_][a-zA-Z0-9_]*\\b"
+                },
+                {
+                    "include": "#literals"
+                },
+                {
+                    "name": "keyword.operator.preprocessor.simfony",
+                    "match": "&&|\\|\\||==|!=|<=|>=|<|>|!|&&|\\|\\||\\+|\\-|\\*|\\/|%|<<|>>|&|\\||\\^|~"
+                }
+            ]
+        },
+        "comments": {
+            "patterns": [
+                {
+                    "name": "comment.line.double-slash.simfony",
+                    "match": "//.*$"
+                },
+                {
+                    "name": "comment.block.simfony",
+                    "begin": "/\\*",
+                    "end": "\\*/"
+                }
+            ]
+        },
+        "keywords": {
+            "patterns": [
+                {
+                    "name": "storage.type.function.simfony",
+                    "match": "\\bfn\\b"
+                },
+                {
+                    "name": "storage.type.simfony",
+                    "match": "\\btype\\b"
+                },
+                {
+                    "name": "keyword.other.simfony",
+                    "match": "\\b(mod|const)\\b"
+                },
+                {
+                    "name": "storage.type.simfony",
+                    "match": "\\blet\\b"
+                },
+                {
+                    "name": "keyword.control.simfony",
+                    "match": "\\b(match|if|else|while|for|return)\\b"
+                },
+                {
+                    "name": "keyword.operator.simfony",
+                    "match": "(->|=>|=|:|,|;)"
+                }
+            ]
+        },
+        "macros": {
+            "patterns": [
+                {
+                    "match": "\\b(assert|panic)(!)(\\s*\\(|\\s|$)",
+                    "captures": {
+                        "1": {
+                            "name": "keyword.other.preprocessor.directive.simfony"
+                        },
+                        "2": {
+                            "name": "keyword.other.preprocessor.directive.simfony"
+                        }
+                    }
+                },
+                {
+                    "match": "\\b([a-z][a-zA-Z0-9_]*)(!)(\\s*\\(|\\s|$)",
+                    "captures": {
+                        "1": {
+                            "name": "keyword.other.preprocessor.directive.simfony"
+                        },
+                        "2": {
+                            "name": "keyword.other.preprocessor.directive.simfony"
+                        }
+                    }
+                }
+            ]
+        },
+        "functions": {
+            "patterns": [
+                {
+                    "name": "entity.name.function.simfony",
+                    "match": "\\b(unwrap_left|unwrap_right|for_while|is_none|unwrap|into|fold|dbg)\\b"
+                },
+                {
+                    "match": "\\b(fn)\\s+([a-zA-Z][a-zA-Z0-9_]*)\\s*\\(",
+                    "captures": {
+                        "1": {
+                            "name": "storage.type.function.simfony"
+                        },
+                        "2": {
+                            "name": "entity.name.function.simfony"
+                        }
+                    }
+                },
+                {
+                    "match": "\\b([a-zA-Z][a-zA-Z0-9_]*)(?!!\\s*)\\s*\\(",
+                    "captures": {
+                        "1": {
+                            "name": "entity.name.function.call.simfony"
+                        }
+                    }
+                }
+            ]
+        },
+        "types": {
+            "patterns": [
+                {
+                    "name": "entity.name.type.simfony",
+                    "match": "\\b(Either|Option|bool|List|u128|u256|u16|u32|u64|u1|u2|u4|u8)\\b"
+                },
+                {
+                    "name": "entity.name.type.simfony",
+                    "match": "\\b(Ctx8|Pubkey|Message64|Message|Signature|Scalar|Fe|Gej|Ge|Point|Height|Time|Distance|Duration|Lock|Outpoint|Confidential1|ExplicitAsset|Asset1|ExplicitAmount|Amount1|ExplicitNonce|Nonce|TokenAmount1)\\b"
+                },
+                {
+                    "match": "\\b(type)\\s+([A-Z][a-zA-Z0-9_]*)\\s*=",
+                    "captures": {
+                        "1": {
+                            "name": "storage.type.simfony"
+                        },
+                        "2": {
+                            "name": "entity.name.type.alias.simfony"
+                        }
+                    }
+                },
+                {
+                    "match": "\\b([A-Z][a-zA-Z0-9_]*)\\b",
+                    "captures": {
+                        "1": {
+                            "name": "entity.name.type.simfony"
+                        }
+                    }
+                },
+                {
+                    "match": ":\\s*([a-zA-Z][a-zA-Z0-9_]*|Either<.*>|Option<.*>|\\(.*\\)|\\[.*\\]|List<.*>)",
+                    "captures": {
+                        "1": {
+                            "name": "entity.name.type.simfony"
+                        }
+                    }
+                }
+            ]
+        },
+        "literals": {
+            "patterns": [
+                {
+                    "name": "constant.numeric.decimal.simfony",
+                    "match": "\\b[0-9][0-9_]*\\b"
+                },
+                {
+                    "name": "constant.numeric.binary.simfony",
+                    "match": "\\b0b[01_]+\\b"
+                },
+                {
+                    "name": "constant.numeric.hex.simfony",
+                    "match": "\\b0x[0-9a-fA-F_]+\\b"
+                },
+                {
+                    "name": "constant.language.boolean.simfony",
+                    "match": "\\b(true|false)\\b"
+                },
+                {
+                    "name": "constant.language.simfony",
+                    "match": "\\b(None)\\b"
+                },
+                {
+                    "name": "string.quoted.double.simfony",
+                    "begin": "\"",
+                    "end": "\"",
+                    "patterns": [
+                        {
+                            "name": "constant.character.escape.simfony",
+                            "match": "\\\\."
+                        }
+                    ]
+                }
+            ]
+        },
+        "expressions": {
+            "patterns": [
+                {
+                    "match": "\\b(jet|witness|param)::(\\w+)",
+                    "captures": {
+                        "1": {
+                            "name": "entity.name.namespace.simfony"
+                        },
+                        "2": {
+                            "name": "entity.name.function.simfony"
+                        }
+                    }
+                },
+                {
+                    "name": "variable.other.simfony",
+                    "match": "\\b[a-z][a-zA-Z0-9_]*\\b"
+                },
+                {
+                    "match": "\\b(Left|Right|Some)\\s*\\(",
+                    "captures": {
+                        "1": {
+                            "name": "support.function.simfony"
+                        }
+                    }
+                }
+            ]
+        },
+        "modules": {
+            "patterns": [
+                {
+                    "match": "\\b(mod)\\s+(witness|param)\\b",
+                    "captures": {
+                        "1": {
+                            "name": "keyword.other.simfony"
+                        },
+                        "2": {
+                            "name": "entity.name.namespace.simfony"
+                        }
+                    }
+                },
+                {
+                    "match": "\\b(jet)\\b",
+                    "name": "entity.name.namespace.simfony"
+                }
+            ]
+        }
+    },
+    "scopeName": "source.simfony"
+} 


### PR DESCRIPTION
This PR adds a minimal extension for VSCode that highlights *.simf files and also enables basic things like auto commenting/uncommenting (when you press cmd+/).