### PR TITLE
vscode: bump extension version to 0.2.0

### DIFF
--- a/vscode/package-lock.json
+++ b/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simplicityhl",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simplicityhl",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@types/vscode": "^1.66.0",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "simplicityhl",
   "displayName": "SimplicityHL Language Support",
   "description": "Syntax highlighting and autocompletion for SimplicityHL (Simfony) language",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "publisher": "Simplicity",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This updates the VSCode extension version, which I missed in #148.

