### PR TITLE
LSP: add tree-sitter as main parsing option

### DIFF
--- a/lsp/Cargo.toml
+++ b/lsp/Cargo.toml
@@ -20,10 +20,12 @@ env_logger = "0.11.8"
 thiserror = "2.0.17"
 
 ropey = "1.6.1"
-miniscript = "12"
 simplicityhl = { version = "0.3.0" }
 nom = "8.0.0"
 lazy_static = "1.5.0"
+
+tree-sitter-simplicityhl = "0.1.3"
+tree-sitter = "0.25.10"
 
 [lints.rust]
 unsafe_code = "deny"

--- a/lsp/src/completion/builtin.rs
+++ b/lsp/src/completion/builtin.rs
@@ -34,6 +34,29 @@ pub fn get_builtin_functions() -> Vec<FunctionTemplate> {
     functions.iter().filter_map(match_callname).collect()
 }
 
+pub fn string_to_callname(text: &str) -> Option<CallName> {
+    let ty = AliasedType::from(AliasName::from_str_unchecked("T"));
+    let function_name = FunctionName::from_str_unchecked("fn");
+    let some = NonZero::new(1)?;
+
+    let callname = match text {
+        "unwrap_left" => CallName::UnwrapLeft(ty),
+        "unwrap_right" => CallName::UnwrapRight(ty),
+        "unwrap" => CallName::Unwrap,
+        "is_none" => CallName::IsNone(ty),
+        "assert!" => CallName::Assert,
+        "panic!" => CallName::Panic,
+        "dbg!" => CallName::Debug,
+        "into" => CallName::TypeCast(ty),
+        "fold" => CallName::Fold(function_name, NonZeroPow2Usize::TWO),
+        "array_fold" => CallName::ArrayFold(function_name, some),
+        "for_while" => CallName::ForWhile(function_name),
+        _ => return None,
+    };
+
+    Some(callname)
+}
+
 /// Match [`simplicityhl::parse::CallName`] and return [`FunctionTemplate`]
 pub fn match_callname(call: &CallName) -> Option<FunctionTemplate> {
     let doc = builtin_documentation(call);

--- a/lsp/src/completion/mod.rs
+++ b/lsp/src/completion/mod.rs
@@ -13,6 +13,8 @@ use tower_lsp_server::lsp_types::{
 use tokens::parse;
 use tokens::CompletionType;
 
+use crate::treesitter::variable::VariableInfo;
+
 /// Build and provide [`CompletionItem`] for jets and builtin functions.
 #[derive(Debug)]
 pub struct CompletionProvider {
@@ -87,6 +89,7 @@ impl CompletionProvider {
         &self,
         prefix: &str,
         functions: &[(&Function, &str)],
+        variables: &[VariableInfo],
     ) -> Option<Vec<CompletionItem>> {
         let completion_type = parse(prefix)?;
 
@@ -125,6 +128,7 @@ impl CompletionProvider {
             _ => {
                 let mut completions = CompletionProvider::get_function_completions(functions);
 
+                completions.extend(variables.iter().map(CompletionItem::from));
                 completions.extend_from_slice(&self.builtin);
                 completions.extend_from_slice(&self.modules);
 

--- a/lsp/src/documentation/alias.rs
+++ b/lsp/src/documentation/alias.rs
@@ -1,0 +1,57 @@
+use lazy_static::lazy_static;
+use std::collections::HashMap;
+
+lazy_static! {
+    static ref TYPE_INFO: HashMap<&'static str, (&'static str, &'static str)> =
+        HashMap::from([
+            ("Ctx8",
+                ("(List<u8, 64>, (u64, u256))",
+                 "State of a SHA256 hash engine. SHA context for streams of 8-bit values.")
+            ),
+            ("Pubkey", ("u256", "X-only public key.")),
+            ("Message", ("u256", "256-bit message (signature hash).")),
+            ("Message64",
+                ("[u8; 64]",
+                 "512-bit message (CMR of program that computes signature hash + signature hash).")
+            ),
+            ("Signature", ("[u8; 64]", "Schnorr signature.")),
+
+            ("Scalar", ("u256", "Scalar of the secp256k1 elliptic curve.")),
+            ("Fe", ("u256", "Field element (coordinate) of the secp256k1 elliptic curve.")),
+            ("Ge",
+                ("(u256, u256)",
+                 "Group element of the secp256k1 elliptic curve in affine coordinates.")
+            ),
+            ("Gej",
+                ("((u256, u256), u256)",
+                 "Group element of the secp256k1 elliptic curve in projective / Jacobian coordinates.")
+            ),
+            ("Point",
+                ("(u1, u256)",
+                 "Compressed affine point (y-parity + x coordinate).")
+            ),
+
+            ("Height", ("u32", "Height of a Bitcoin block.")),
+            ("Time", ("u32", "UNIX timestamp of a Bitcoin block.")),
+            ("Distance", ("u16", "Relative distance between blocks in height.")),
+            ("Duration", ("u16", "Relative distance between blocks in UNIX time.")),
+
+            ("Lock", ("u32", "Lock time of an Elements transaction.")),
+            ("Outpoint",
+                ("(u256, u32)",
+                 "Outpoint of an Elements transaction input (transaction ID + vout).")
+            ),
+            ("Confidential1", ("(u1, u256)", "Pedersen commitment to a confidential value.")),
+            ("ExplicitAsset", ("u256", "Explicit Elements asset ID.")),
+            ("Asset1", ("Either<(u1, u256), u256>", "Elements asset (confidential or explicit).")),
+            ("ExplicitAmount", ("u64", "Explicit amount of an Elements asset.")),
+            ("Amount1", ("Either<(u1, u256), u64>", "Amount of an Elements asset (confidential or explicit).")),
+            ("ExplicitNonce", ("u256", "Explicit 256-bit nonce.")),
+            ("Nonce", ("Either<(u1, u256), u256>", "Nonce (confidential or explicit).")),
+            ("TokenAmount1", ("Either<(u1, u256), u64>", "Amount of an Elements token (confidential or explicit).")),
+        ]);
+}
+
+pub fn type_info(name: &str) -> Option<(&'static str, &'static str)> {
+    TYPE_INFO.get(name).copied()
+}

--- a/lsp/src/documentation/mod.rs
+++ b/lsp/src/documentation/mod.rs
@@ -1,0 +1,1 @@
+pub mod alias;

--- a/lsp/src/function.rs
+++ b/lsp/src/function.rs
@@ -26,16 +26,6 @@ impl Functions {
         self.map.get(name).map(|(func, doc)| (func, doc))
     }
 
-    /// Retrieves a reference to a parsed function by name.
-    pub fn get_func(&self, name: &str) -> Option<&Function> {
-        self.map.get(name).map(|(func, _)| func)
-    }
-
-    /// Returns a vector of all parsed functions.
-    pub fn functions(&self) -> Vec<&Function> {
-        self.map.values().map(|(func, _)| func).collect()
-    }
-
     /// Returns a vector of (function name, function) pairs.
     pub fn functions_and_docs(&self) -> Vec<(&Function, &str)> {
         self.map

--- a/lsp/src/main.rs
+++ b/lsp/src/main.rs
@@ -2,8 +2,10 @@
 
 mod backend;
 mod completion;
+mod documentation;
 mod error;
 mod function;
+mod treesitter;
 mod utils;
 
 use backend::Backend;

--- a/lsp/src/treesitter/mod.rs
+++ b/lsp/src/treesitter/mod.rs
@@ -1,0 +1,3 @@
+pub mod parser;
+pub mod scope;
+pub mod variable;

--- a/lsp/src/treesitter/parser.rs
+++ b/lsp/src/treesitter/parser.rs
@@ -1,0 +1,275 @@
+use tower_lsp_server::lsp_types;
+use tree_sitter::{Language, Node, Point, Query, QueryCursor, StreamingIterator, Tree};
+
+use crate::{
+    error::LspError,
+    treesitter::{scope::ScopeGraph, variable::get_range_from_node},
+};
+
+/// Represents a classified syntactic element extracted from the Tree-sitter AST.
+///
+/// Tokens produced by the tree-sitter grammar are mapped into these categories
+/// so that the LSP can distinguish between language constructs.
+#[derive(Debug)]
+pub enum Token {
+    /// A user-defined variable.
+    Identifier,
+
+    /// A built-in type alias.
+    BuiltinAlias,
+
+    /// A user-defined type alias.
+    Alias,
+
+    /// A built-in function.
+    BuiltinFunction,
+
+    /// A user-defined function.
+    Function,
+
+    /// A `jet` function.
+    Jet,
+}
+
+/// Represents a classified token together with its text value and source range.
+pub struct TokenInfo {
+    pub token: Token,
+
+    pub text: String,
+    pub range: lsp_types::Range,
+}
+
+/// Wrapper struct for working with the AST produced by Tree-sitter.
+pub struct AstContext {
+    /// Tree-sitter AST.
+    pub tree: Tree,
+    /// Scope graph which contains scopes and variables.
+    pub scopes: ScopeGraph,
+
+    /// [`tree_sitter::Language`], so we would not call
+    /// `&tree_sitter_simplicityhl::LANGUAGE.into()` every time.
+    language: Language,
+}
+
+impl AstContext {
+    pub fn new(source: &str) -> Option<Self> {
+        let mut parser = tree_sitter::Parser::new();
+        // .unwrap() fails only when Language is is cannot be loaded.
+        parser
+            .set_language(&tree_sitter_simplicityhl::LANGUAGE.into())
+            .unwrap();
+
+        let tree = parser.parse(source, None)?;
+        let scopes = ScopeGraph::new(tree.root_node(), source);
+
+        Some(Self {
+            tree,
+            scopes,
+            language: tree_sitter_simplicityhl::LANGUAGE.into(),
+        })
+    }
+
+    /// Returns the token located at the given [`lsp_types::Position`].
+    ///
+    /// Only tokens defined by [`TokenInfo`] are returned.  
+    pub fn get_token_on_position(
+        &self,
+        source: &str,
+        pos: lsp_types::Position,
+    ) -> Option<TokenInfo> {
+        let target_point = Point {
+            row: pos.line as usize,
+            column: pos.character as usize,
+        };
+        let root_node = self.tree.root_node();
+        let node_opt = root_node.named_descendant_for_point_range(target_point, target_point);
+        if let Some(node) = node_opt {
+            return match_node_kind(source, &node);
+        }
+        None
+    }
+
+    /// Returns all definitions of a type alias with the given name.
+    pub fn get_alias_definition(
+        &self,
+        source: &str,
+        alias_name: &str,
+    ) -> Result<Vec<lsp_types::Range>, LspError> {
+        let query = self.create_query(&format!(
+            r#"definition: ((alias_name) @def (#eq? @def "{alias_name}"))"#,
+        ))?;
+
+        self.collect_query_captures(&query, source)
+    }
+
+    /// Returns all definitions of a function with the given name.
+    pub fn get_function_definition(
+        &self,
+        source: &str,
+        function_name: &str,
+    ) -> Result<Vec<lsp_types::Range>, LspError> {
+        let query = self.create_query(&format!(
+            r#"definition: ((function_name) @def (#eq? @def "{function_name}"))"#,
+        ))?;
+
+        self.collect_query_captures(&query, source)
+    }
+
+    /// Returns the definition of a variable visible at the given position.
+    ///
+    /// Variable resolution is scope-dependent, so it's need to know current position.
+    pub fn get_identifier_definition(
+        &self,
+        identifier_name: &str,
+        pos: lsp_types::Position,
+    ) -> Vec<tower_lsp_server::lsp_types::Range> {
+        let visible_vars = self.scopes.get_visible_variables(pos, true);
+
+        let mut result = Vec::new();
+        if let Some(definition) = visible_vars.iter().find(|&v| v.name == identifier_name) {
+            result.push(definition.range);
+        }
+        result
+    }
+
+    /// Returns all references of a type alias, including its definition.
+    pub fn get_alias_reference(
+        &self,
+        source: &str,
+        alias_name: &str,
+    ) -> Result<Vec<lsp_types::Range>, LspError> {
+        let query = self.create_query(&format!(
+            r#"reference: ((alias_name) @call (#eq? @call "{alias_name}"))
+               definition: ((alias_name) @def (#eq? @def "{alias_name}"))"#,
+        ))?;
+
+        self.collect_query_captures(&query, source)
+    }
+
+    /// Returns all references of a function, including its definition.
+    pub fn get_function_reference(
+        &self,
+        source: &str,
+        function_name: &str,
+    ) -> Result<Vec<lsp_types::Range>, LspError> {
+        let query = self.create_query(&format!(
+            r#"reference: ((function_name) @call (#eq? @call "{function_name}"))
+               definition: ((function_name) @def (#eq? @def "{function_name}"))"#,
+        ))?;
+
+        self.collect_query_captures(&query, source)
+    }
+
+    /// Returns all references of a variable visible at the given position.
+    ///
+    /// Variable resolution is scope-dependent, so it's need to know current position.
+    pub fn get_identifier_reference(
+        &self,
+        identifier_name: &str,
+        pos: lsp_types::Position,
+    ) -> Result<Vec<lsp_types::Range>, LspError> {
+        let visible_vars = self.scopes.get_visible_variables(pos, true);
+        let mut result = vec![];
+
+        let definition = visible_vars
+            .iter()
+            .find(|&v| v.name == identifier_name)
+            .ok_or_else(|| LspError::Internal(format!("Variable {identifier_name} not found!")))?;
+
+        result.push(definition.range);
+        result.extend_from_slice(&definition.references);
+
+        Ok(result)
+    }
+
+    /// Collects all captures produced by a [`tree_sitter::Query`] and converts
+    /// them into [`lsp_types::Range`] values.
+    pub fn collect_query_captures(
+        &self,
+        query: &Query,
+        source: &str,
+    ) -> Result<Vec<lsp_types::Range>, LspError> {
+        let mut result = Vec::new();
+        let mut cursor = QueryCursor::new();
+        let mut matches = cursor.matches(query, self.tree.root_node(), source.as_bytes());
+
+        while let Some(m) = matches.next() {
+            for capture in m.captures {
+                result.push(get_range_from_node(&capture.node)?);
+            }
+        }
+
+        Ok(result)
+    }
+
+    /// Create [`tree_sitter::Query`] with query code.
+    fn create_query(&self, query: &str) -> Result<Query, LspError> {
+        Query::new(&self.language, query)
+            .map_err(|err| LspError::Internal(format!("Query creation error: {err}")))
+    }
+}
+
+/// Classifies a Tree-sitter node and returns a corresponding [`TokenInfo`].
+///
+/// Returns `None` if the node does not match any supported token category.
+pub fn match_node_kind(source: &str, node: &Node) -> Option<TokenInfo> {
+    let node_text = source[node.byte_range()].to_string();
+    let range = get_range_from_node(node).ok()?;
+    match node.kind() {
+        "identifier" => Some(TokenInfo {
+            token: Token::Identifier,
+            text: node_text,
+            range,
+        }),
+        "builtin_alias" | "bool_type" | "unsigned_type" => Some(TokenInfo {
+            token: Token::BuiltinAlias,
+            text: node_text,
+            range,
+        }),
+        "sum_type" => Some(TokenInfo {
+            token: Token::BuiltinAlias,
+            text: "Either".to_string(),
+            range,
+        }),
+        "option_type" => Some(TokenInfo {
+            token: Token::BuiltinAlias,
+            text: "Option".to_string(),
+            range,
+        }),
+        "alias_name" => Some(TokenInfo {
+            token: Token::Alias,
+            text: node_text,
+            range,
+        }),
+        "call_name" => Some(TokenInfo {
+            token: Token::BuiltinFunction,
+            text: node_text,
+            range,
+        }),
+        "unwrap_left" | "unwrap_right" | "type_cast" | "fold" | "array_fold" | "for_while" => {
+            Some(TokenInfo {
+                token: Token::BuiltinFunction,
+                text: node.kind().to_string(),
+                range: get_range_from_node(&node.child(0)?).ok()?,
+            })
+        }
+        "function_name" => {
+            if let Some(parent) = node.parent() {
+                if parent.kind() == "jet" {
+                    return match_node_kind(source, &parent);
+                }
+            }
+            Some(TokenInfo {
+                token: Token::Function,
+                text: node_text,
+                range,
+            })
+        }
+        "jet" => Some(TokenInfo {
+            token: Token::Jet,
+            text: source[node.child(2)?.byte_range()].to_string(),
+            range,
+        }),
+        _ => None,
+    }
+}

--- a/lsp/src/treesitter/scope.rs
+++ b/lsp/src/treesitter/scope.rs
@@ -1,0 +1,362 @@
+use std::collections::HashMap;
+use tower_lsp_server::lsp_types;
+use tree_sitter::Node;
+
+use crate::treesitter::variable::{self, get_range_from_node, VariableInfo};
+
+/// Scope that contains variables within it.
+#[derive(Debug, Clone)]
+pub struct Scope {
+    /// Id of this scope.
+    pub id: usize,
+
+    /// Id of parent scope.
+    pub parent_id: Option<usize>,
+
+    /// Range of this Scope.
+    pub range: lsp_types::Range,
+
+    /// All variables inside this scope.
+    ///
+    /// It's not contains variables from children scopes.
+    pub variables: Vec<VariableInfo>,
+}
+
+/// Vector that stores all scopes.
+#[derive(Debug, Clone)]
+pub struct ScopeGraph {
+    pub scopes: Vec<Scope>,
+}
+
+impl ScopeGraph {
+    pub fn new(root_node: Node, source: &str) -> Self {
+        let mut graph = ScopeGraph { scopes: Vec::new() };
+
+        let root_scope = Scope {
+            id: 0,
+            parent_id: None,
+            range: get_range_from_node(&root_node).unwrap_or_default(),
+            variables: Vec::new(),
+        };
+        graph.scopes.push(root_scope);
+
+        graph.index_node(root_node, 0, source);
+        graph.resolve_references(root_node, 0, source);
+
+        graph
+    }
+
+    /// Recursively indexes nodes to discover scopes and variables.
+    fn index_node(&mut self, node: Node, current_scope_id: usize, source: &str) {
+        let mut active_scope_id = current_scope_id;
+
+        if Self::is_scope_creator(node.kind()) && node.kind() != "program" {
+            let new_id = self.scopes.len();
+            let new_scope = Scope {
+                id: new_id,
+                parent_id: Some(current_scope_id),
+                variables: Vec::new(),
+                range: get_range_from_node(&node).unwrap_or_default(),
+            };
+            self.scopes.push(new_scope);
+            active_scope_id = new_id;
+        }
+
+        // All `typed_identifier` is defining some variable.
+        if node.kind() == "typed_identifier" {
+            if let (Some(id), Some(ty)) = (node.named_child(0), node.named_child(1)) {
+                let name = &source[id.byte_range()];
+                let ty = &source[ty.byte_range()];
+                let var_info = VariableInfo {
+                    name: name.to_string(),
+                    ty: ty.to_string(),
+                    range: get_range_from_node(&id).unwrap_or_default(),
+                    references: vec![],
+                };
+
+                if let Some(scope) = self.scopes.get_mut(active_scope_id) {
+                    scope.variables.push(var_info);
+                }
+            }
+        }
+
+        // All `assignment` also defining some variables.
+        if node.kind() == "assignment" {
+            if let Some(scope) = self.scopes.get_mut(active_scope_id) {
+                if let (Some(pat), Some(ty)) = (node.named_child(0), node.named_child(1)) {
+                    if let Some(vars) = variable::parse_assignment(source, &pat, &ty) {
+                        scope.variables.extend(vars);
+                    }
+                }
+            }
+        }
+
+        let mut cursor = node.walk();
+        for child in node.named_children(&mut cursor) {
+            self.index_node(child, active_scope_id, source);
+        }
+    }
+
+    /// Recursively collects all references to previously defined variables.
+    fn resolve_references(&mut self, node: Node, current_scope_id: usize, source: &str) {
+        let mut active_scope_id = current_scope_id;
+
+        if Self::is_scope_creator(node.kind()) && node.kind() != "program" {
+            if let Some(scope) = self
+                .scopes
+                .iter()
+                .find(|s| s.range == get_range_from_node(&node).unwrap_or_default())
+            {
+                active_scope_id = scope.id;
+            }
+        }
+
+        // All references is wrapped in `variable_expr`.
+        if node.kind() == "variable_expr" {
+            let name = &source[node.byte_range()];
+            let range = get_range_from_node(&node).unwrap_or_default();
+
+            self.add_reference(active_scope_id, name, range);
+        }
+
+        let mut cursor = node.walk();
+        for child in node.named_children(&mut cursor) {
+            self.resolve_references(child, active_scope_id, source);
+        }
+    }
+
+    /// Finds the definition of a variable and records a reference to it.
+    fn add_reference(&mut self, start_scope_id: usize, name: &str, range: lsp_types::Range) {
+        let mut current_id = Some(start_scope_id);
+
+        while let Some(scope_id) = current_id {
+            let scope = &mut self.scopes[scope_id];
+
+            if let Some(var) = scope
+                .variables
+                .iter_mut()
+                .filter(|v| (v.name == name) && (v.range.start < range.start))
+                .last()
+            {
+                var.references.push(range);
+                return;
+            }
+            current_id = scope.parent_id;
+        }
+    }
+
+    fn is_scope_creator(kind: &str) -> bool {
+        matches!(
+            kind,
+            "program" | "function" | "block_expression" | "match_arm"
+        )
+    }
+
+    /// Retrieves all visible variables at the specified [`lsp_types::Position`].
+    ///
+    /// The [`is_included`] flag determines whether the variable at the exact position
+    /// should be included. For example, completion uses `false` to avoid suggesting
+    /// the variable currently being typed.
+    pub fn get_visible_variables(
+        &self,
+        pos: lsp_types::Position,
+        is_included: bool,
+    ) -> Vec<VariableInfo> {
+        let mut visible_vars = HashMap::new();
+
+        let mut current_scope_id = self.find_deepest_scope(pos);
+
+        while let Some(scope_id) = current_scope_id {
+            let scope = &self.scopes[scope_id];
+
+            scope.variables.iter().rev().for_each(|info| {
+                if !visible_vars.contains_key(&info.name)
+                    && (if is_included {
+                        info.range.start
+                    } else {
+                        info.range.end
+                    }) <= pos
+                {
+                    visible_vars.insert(info.name.clone(), info.clone());
+                }
+            });
+
+            current_scope_id = scope.parent_id;
+        }
+
+        visible_vars.into_values().collect()
+    }
+
+    /// Finds the deepest scope that contains the given [`lsp_types::Position`].
+    fn find_deepest_scope(&self, pos: lsp_types::Position) -> Option<usize> {
+        self.scopes.iter().enumerate().rev().find_map(|(i, scope)| {
+            if scope.range.start <= pos && scope.range.end >= pos {
+                return Some(i);
+            }
+            None
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    static SOURCE_CODE: &str = "
+fn first_function(index: u32) -> u32 {
+    let pair: (Asset1, Amount1) = unwrap(jet::input_amount(index));
+    let (asset, amount): (Asset1, Amount1) = pair;
+
+    let pair: u32 = 0;
+
+    let (_, scope): (u32, u32) = {
+        let ((a1, complex_type), a2): ((u32, [u8; 2]), u64) = ((0, [1,2]), 43242);
+        (a1, a1)
+    };
+
+    let use_a1: u32 = a1;
+
+    (asset, amount)
+}
+
+fn second_function() -> u32 {
+    index
+}
+    ";
+
+    fn return_scope_graph() -> ScopeGraph {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_simplicityhl::LANGUAGE.into())
+            .unwrap();
+
+        ScopeGraph::new(
+            parser.parse(SOURCE_CODE, None).unwrap().root_node(),
+            SOURCE_CODE,
+        )
+    }
+
+    #[test]
+    fn test_number_of_scopes() {
+        let graph = return_scope_graph();
+
+        // 6 scopes:
+        // 0 - program scope
+        // 1 - first_function, 2 - first_function block, 3 - nested block
+        // 4 - second_function, 5 - second_function block
+        assert_eq!(graph.scopes.len(), 6, "Expected exactly 6 scopes");
+    }
+
+    #[test]
+    fn test_visible_variables_at_line_4_col_0() {
+        let graph = return_scope_graph();
+        let pos = lsp_types::Position::new(4, 0);
+
+        let vars = graph.get_visible_variables(pos, true);
+
+        let names: Vec<_> = vars.iter().map(|v| v.name.as_str()).collect();
+
+        assert!(
+            names.contains(&"index"),
+            "index should be visible at position 4:0"
+        );
+        assert!(
+            names.contains(&"pair"),
+            "pair should be visible at position 4:0"
+        );
+        assert!(
+            names.contains(&"asset"),
+            "asset should be visible at position 4:0"
+        );
+        assert!(
+            names.contains(&"amount"),
+            "amount should be visible at position 4:0"
+        );
+    }
+
+    #[test]
+    fn test_pair_reference_counts() {
+        let graph = return_scope_graph();
+
+        // Position 4:0
+        let pos_4_0 = lsp_types::Position::new(4, 0);
+        let vars_4_0 = graph.get_visible_variables(pos_4_0, true);
+        let pair_4_0 = vars_4_0
+            .iter()
+            .find(|v| v.name == "pair")
+            .expect("pair must be visible at 4:0");
+
+        assert_eq!(
+            pair_4_0.references.len(),
+            1,
+            "pair should have exactly 1 reference at 4:0"
+        );
+
+        // Position 6:0
+        let pos_6_0 = lsp_types::Position::new(6, 0);
+        let vars_6_0 = graph.get_visible_variables(pos_6_0, true);
+        let pair_6_0 = vars_6_0
+            .iter()
+            .find(|v| v.name == "pair")
+            .expect("pair must be visible at 6:0");
+
+        assert_eq!(
+            pair_6_0.references.len(),
+            0,
+            "pair should have 0 references at 6:0"
+        );
+    }
+
+    #[test]
+    fn test_deepest_scope_detection() {
+        let graph = return_scope_graph();
+
+        // Line inside the inner block of first_function
+        let pos_inner = lsp_types::Position::new(9, 8);
+        let scope_id = graph.find_deepest_scope(pos_inner).unwrap();
+
+        assert_eq!(scope_id, 3, "Expected block to have scope_id == 3");
+    }
+
+    #[test]
+    fn test_no_duplicate_variables() {
+        let graph = return_scope_graph();
+        let pos = lsp_types::Position::new(18, 0);
+        let vars = graph.get_visible_variables(pos, true);
+
+        assert_eq!(
+            vars.len(),
+            0,
+            "Second function shoud not contain any variables"
+        );
+    }
+
+    #[test]
+    fn test_references_are_after_definitions() {
+        let graph = return_scope_graph();
+        for scope in &graph.scopes {
+            for var in &scope.variables {
+                for r in &var.references {
+                    assert!(
+                        r.start >= var.range.start,
+                        "Reference {:?} occurs before variable definition {:?}",
+                        r.start,
+                        var.range.start
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_second_function_have_no_variables() {
+        let graph = return_scope_graph();
+        let pos = lsp_types::Position::new(4, 0);
+        let vars = graph.get_visible_variables(pos, true);
+
+        let mut set = std::collections::HashSet::new();
+        for v in vars {
+            assert!(set.insert(v.name.clone()), "Duplicate variable: {}", v.name);
+        }
+    }
+}

--- a/lsp/src/treesitter/variable.rs
+++ b/lsp/src/treesitter/variable.rs
@@ -1,0 +1,78 @@
+use tower_lsp_server::lsp_types::{self, CompletionItem, CompletionItemKind};
+use tree_sitter::Node;
+
+use crate::error::LspError;
+
+#[derive(Debug, Clone)]
+/// Info about variable.
+pub struct VariableInfo {
+    pub name: String,
+    pub ty: String,
+    pub range: lsp_types::Range,
+    pub references: Vec<lsp_types::Range>,
+}
+
+/// Parse assignment statement into [`VariableInfo`].
+///
+/// This algorithm is modified code for checking type in [`simplicityhl::pattern::Pattern::is_of_type`].
+pub fn parse_assignment(text: &str, node: &Node, ty: &Node) -> Option<Vec<VariableInfo>> {
+    let mut stack = vec![(*node, *ty)];
+    let mut output = Vec::new();
+
+    while let Some((pattern, ty)) = stack.pop() {
+        let (pattern, ty) = (pattern.child(0)?, ty.child(0)?);
+
+        match (pattern.kind(), ty.kind()) {
+            ("variable_pattern", _) => {
+                output.push(VariableInfo {
+                    name: text[pattern.byte_range()].to_string(),
+                    ty: text[ty.byte_range()].to_string(),
+                    range: get_range_from_node(&pattern).ok()?,
+                    references: vec![],
+                });
+            }
+
+            ("tuple_pattern", "tuple_type") => {
+                stack.extend(
+                    pattern
+                        .named_children(&mut pattern.walk())
+                        .zip(ty.named_children(&mut ty.walk())),
+                );
+            }
+            ("array_pattern", "array_type") => {
+                stack.extend(
+                    pattern
+                        .named_children(&mut pattern.walk())
+                        .zip(std::iter::repeat(ty.named_child(0)?)),
+                );
+            }
+            ("ignore_pattern", _) => {}
+            _ => return None,
+        }
+    }
+    Some(output)
+}
+
+pub fn get_range_from_node(node: &Node) -> Result<lsp_types::Range, LspError> {
+    Ok(lsp_types::Range {
+        start: lsp_types::Position::new(
+            node.start_position().row.try_into()?,
+            node.start_position().column.try_into()?,
+        ),
+        end: lsp_types::Position::new(
+            node.end_position().row.try_into()?,
+            node.end_position().column.try_into()?,
+        ),
+    })
+}
+
+impl From<&VariableInfo> for lsp_types::CompletionItem {
+    fn from(val: &VariableInfo) -> Self {
+        CompletionItem {
+            label: val.name.clone(),
+            kind: Some(CompletionItemKind::VARIABLE),
+            detail: Some(val.ty.clone()),
+            ..Default::default()
+        }
+    }
+}


### PR DESCRIPTION
This integrates [tree-sitter grammar](https://github.com/distributed-lab/tree-sitter-simplicityhl) parser  in order to implement more features for LSP. The following features have now been added:
- completion for variables
- hover for variables and built-in types
- references for variables and type aliases

also fixes issue with reference and hover for functions inside generics type (for_while, fold and array_fold).

Previously, navigation was based on constructs built from the original compiler parser, but it removes a lot of important information needed for this, such as the location of some tokens. 

Tree-sitter allows us to track token positions, make queries to find individual elements, perform quick searches by position, and perform incremental parsing. 

We could also use the original grammar for pest parser, using the existing grammar file inside the compiler, but that would require rewriting the parsing logic from scratch. Also, tree-sitter is more convenient to use for LSP features.
