### PR TITLE
analyze_named_module: make missing modules equivalent to empty ones

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1442,10 +1442,9 @@ fn analyze_named_module(
         ModuleItem::Module(module) if module.name == name => Some(module),
         _ => None,
     });
-    let witness_module = iter
-        .next()
-        .ok_or(Error::ModuleRequired(name.shallow_clone()))
-        .with_span(from)?;
+    let Some(witness_module) = iter.next() else {
+        return Ok(HashMap::new()); // "not present" is equivalent to empty
+    };
     if iter.next().is_some() {
         return Err(Error::ModuleRedefined(name)).with_span(from);
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -335,7 +335,6 @@ pub enum Error {
     WitnessTypeMismatch(WitnessName, ResolvedType, ResolvedType),
     WitnessReassigned(WitnessName),
     WitnessOutsideMain,
-    ModuleRequired(ModuleName),
     ModuleRedefined(ModuleName),
     ArgumentMissing(WitnessName),
     ArgumentTypeMismatch(WitnessName, ResolvedType, ResolvedType),
@@ -464,10 +463,6 @@ impl fmt::Display for Error {
             Error::WitnessOutsideMain => write!(
                 f,
                 "Witness expressions are not allowed outside the `main` function"
-            ),
-            Error::ModuleRequired(name) => write!(
-                f,
-                "Required module `{name}` is missing"
             ),
             Error::ModuleRedefined(name) => write!(
                 f,

--- a/src/witness.rs
+++ b/src/witness.rs
@@ -266,8 +266,11 @@ fn main() {
     #[test]
     fn missing_witness_module() {
         match WitnessValues::parse_from_str("") {
-            Ok(_) => panic!("Missing witness module was falsely accepted"),
-            Err(error) => assert!(error.to_string().contains("module `witness` is missing")),
+            Ok(v) => assert!(
+                v.iter().next().is_none(),
+                "empty witness module was parsed as nonempty"
+            ),
+            Err(error) => panic!("Missing witness module was falsely rejected: {error}"),
         }
     }
 


### PR DESCRIPTION
The web IDE expects `witness` and `params` modules, which is annoying for contracts where these modules would be empty. Allow them to be omitted, in which case they are treated as empty.

Fixes #186