### PR TITLE
misc: update codeowners and auto assign for issues

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
 # These owners will be requested for review when someone opens a pull request.
-* @imaginator
+* @apoelstra
+* @delta1

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -2,7 +2,7 @@ name: Bug Report
 description: File a bug report
 labels: ['bug']
 assignees:
-  - imaginator
+  - delta1
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -2,7 +2,7 @@ name: Feature request
 description: Suggest a new feature
 labels: ['feature']
 assignees:
-  - imaginator
+  - delta1
 body:
   - type: input
     id: project


### PR DESCRIPTION
Updates auto-assign in github for codeowner review and bug reports/feature requests. 

apoelstra please let me know if you're okay with getting review requests automatically on PRs? 

Resolves #189
