### PR TITLE
Add `AbiMeta` struct for `CompiledProgram` and `TemplateProgram`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,14 @@ impl TemplateProgram {
             debug_symbols: self.simfony.debug_symbols(self.file.as_ref()),
             simplicity: commit,
             witness_types: self.simfony.witness_types().shallow_clone(),
+            parameter_types: self.simfony.parameters().shallow_clone(),
+        })
+    }
+
+    pub fn generate_abi_meta(&self) -> Result<AbiMeta, String> {
+        Ok(AbiMeta {
+            witness_types: self.simfony.witness_types().shallow_clone(),
+            param_types: self.parameters().shallow_clone(),
         })
     }
 }
@@ -105,6 +113,7 @@ pub struct CompiledProgram {
     simplicity: Arc<named::CommitNode<Elements>>,
     witness_types: WitnessTypes,
     debug_symbols: DebugSymbols,
+    parameter_types: Parameters,
 }
 
 impl CompiledProgram {
@@ -168,6 +177,19 @@ impl CompiledProgram {
             debug_symbols: self.debug_symbols.clone(),
         })
     }
+
+    pub fn generate_abi_meta(&self) -> Result<AbiMeta, String> {
+        Ok(AbiMeta {
+            witness_types: self.witness_types.shallow_clone(),
+            param_types: self.parameter_types.shallow_clone(),
+        })
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AbiMeta {
+    pub witness_types: WitnessTypes,
+    pub param_types: Parameters,
 }
 
 /// A SimplicityHL program, compiled to Simplicity and satisfied with witness data.

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,13 +1,13 @@
 use std::collections::HashMap;
 use std::fmt;
 
-use serde::{de, ser::SerializeMap, Deserialize, Deserializer, Serialize, Serializer};
-
 use crate::parse::ParseFromStr;
 use crate::str::WitnessName;
 use crate::types::ResolvedType;
 use crate::value::Value;
 use crate::witness::{Arguments, WitnessValues};
+use crate::{AbiMeta, Parameters, WitnessTypes};
+use serde::{de, ser::SerializeMap, Deserialize, Deserializer, Serialize, Serializer};
 
 struct WitnessMapVisitor;
 
@@ -40,6 +40,66 @@ impl<'de> Deserialize<'de> for WitnessValues {
         deserializer
             .deserialize_map(WitnessMapVisitor)
             .map(Self::from)
+    }
+}
+
+impl Serialize for ResolvedType {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl Serialize for WitnessName {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.as_ref())
+    }
+}
+
+impl Serialize for AbiMeta {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: ::serde::Serializer,
+    {
+        use ::serde::ser::SerializeStruct;
+
+        let mut state = serializer.serialize_struct("AbiMeta", 2)?;
+        state.serialize_field("witness_types", &self.witness_types)?;
+        state.serialize_field("parameter_types", &self.param_types)?;
+        state.end()
+    }
+}
+
+impl Serialize for Parameters {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let map_ref = self.as_ref();
+        let mut map = serializer.serialize_map(Some(map_ref.len()))?;
+        for (key, value) in map_ref {
+            map.serialize_entry(key, value)?;
+        }
+        map.end()
+    }
+}
+
+impl Serialize for WitnessTypes {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let map_ref = self.as_ref();
+        let mut map = serializer.serialize_map(Some(map_ref.len()))?;
+        for (key, value) in map_ref {
+            map.serialize_entry(key, value)?;
+        }
+        map.end()
     }
 }
 

--- a/src/str.rs
+++ b/src/str.rs
@@ -125,6 +125,12 @@ pub struct WitnessName(Arc<str>);
 wrapped_string!(WitnessName, "witness name");
 impl_arbitrary_lowercase_alpha!(WitnessName);
 
+impl AsRef<str> for WitnessName {
+    fn as_ref(&self) -> &str {
+        self.0.as_ref()
+    }
+}
+
 /// The name of a jet.
 #[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub struct JetName(Arc<str>);

--- a/src/witness.rs
+++ b/src/witness.rs
@@ -94,6 +94,12 @@ pub struct WitnessTypes(Arc<HashMap<WitnessName, ResolvedType>>);
 
 impl_name_type_map!(WitnessTypes);
 
+impl AsRef<HashMap<WitnessName, ResolvedType>> for WitnessTypes {
+    fn as_ref(&self) -> &HashMap<WitnessName, ResolvedType> {
+        self.0.as_ref()
+    }
+}
+
 /// Map of witness values.
 #[derive(Clone, Debug, Eq, PartialEq, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
@@ -150,6 +156,12 @@ impl ParseFromStr for ResolvedType {
 pub struct Parameters(Arc<HashMap<WitnessName, ResolvedType>>);
 
 impl_name_type_map!(Parameters);
+
+impl AsRef<HashMap<WitnessName, ResolvedType>> for Parameters {
+    fn as_ref(&self) -> &HashMap<WitnessName, ResolvedType> {
+        self.0.as_ref()
+    }
+}
 
 /// Map of arguments.
 ///


### PR DESCRIPTION
This pr adds possibility to generate `AbiMeta` struct both for `CompiledProgram` and `TemplateProgram`.
This struct is required for generating proper macros that will simplify creation of contracts.
Since retrieving Witness arguments and Parameter types is impossible for `CompiledProgram`, I added `AbiMeta` to improve usability for both compiled and template programs.

How it can be used in macros?

From name -> type map we can automatically generate a structs for Witness and Parameters section of contract.
This pattern is consistent across all contracts we have created so far.
https://github.com/BlockstreamResearch/SimplicityHL
By now it is in development, but I don't think that such functionality would negatively impact the code. 

Related to these issues https://github.com/BlockstreamResearch/SimplicityHL/issues/196, https://github.com/BlockstreamResearch/SimplicityHL/issues/157.

PS 
FYI, it is worth noting that functionality to retrieve the AstTreePath for program witnesses could also be added here to derive the proper selection of UTXOs.
https://github.com/ikripaka/SimplicityHL/tree/feature/wallet-abi-meta
However, this PR only adds a subset of those parameters.