### PR TITLE
Add TemplateProgram::witness_types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,11 @@ impl TemplateProgram {
         self.simfony.parameters()
     }
 
+    /// Access the witness types of the program.
+    pub fn witness_types(&self) -> &WitnessTypes {
+        self.simfony.witness_types()
+    }
+
     /// Instantiate the template program with the given `arguments`.
     ///
     /// ## Errors


### PR DESCRIPTION
Given nothing else but a piece of SimplicityHL source code, exposing this method allows both parameter and witness names/types to be inspected by callers of `TemplateProgram`, i.e. even before it's bound into a `CompiledProgram`.

The utility of this is further corroborated by the fact that the witness types, as defined by the user program, are already available on the private `TemplateProgram::ast` which underlies the parsing.