### PR TITLE
fix: change angle bracket delimiter

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1490,7 +1490,7 @@ impl ChumskyParse for Expression {
                     Token::RBrace,
                     [
                         (Token::LParen, Token::RParen),
-                        (Token::RAngle, Token::RAngle),
+                        (Token::LAngle, Token::RAngle),
                         (Token::LBracket, Token::RBracket),
                     ],
                     |span| Expression::empty(span).inner().clone(),


### PR DESCRIPTION
Seems like a missed typo. Not sure how to reproduce this though.