### PR TITLE
Add CMR to compiler JSON output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -14,11 +14,14 @@ struct Output {
     witness: Option<String>,
     /// Simplicity program ABI metadata to the program which the user provides.
     abi_meta: Option<AbiMeta>,
+    /// Commitment Merkle Root (CMR) of the program, hex encoded.
+    cmr: String,
 }
 
 impl fmt::Display for Output {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "Program:\n{}", self.program)?;
+        writeln!(f, "CMR:\n{}", self.cmr)?;
         if let Some(witness) = &self.witness {
             writeln!(f, "Witness:\n{}", witness)?;
         }
@@ -156,10 +159,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         None
     };
 
+    let cmr_hex = compiled.commit().cmr().to_string();
     let output = Output {
         program: Base64Display::new(&program_bytes, &STANDARD).to_string(),
         witness: witness_bytes.map(|bytes| Base64Display::new(&bytes, &STANDARD).to_string()),
         abi_meta: abi_opt,
+        cmr: cmr_hex,
     };
 
     if output_json {


### PR DESCRIPTION
The compiler currently outputs only the program binary (base64). Callers deploying programs on-chain also need the   Commitment Merkle Root (CMR) to:                                                                                                                     
  - Derive the taproot address (P2TR scriptPubKey)                                                                   
  - Build the control block for script-path spending                                                                 
                                                                                                                       
Without CMR in the output, callers must reimplement the entire commitment hash computation externally. Since the     CMR is already computed internally during compilation, this patch exposes it by adding a cmr field (hex string) to 
  both the Output struct and the JSON output (--json flag). The human-readable display also prints it. The change is 
  non-breaking — existing callers that ignore unknown JSON fields are unaffected.