### PR TITLE
ci: add release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,108 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'simplicityhl-[0-9]+.[0-9]+.[0-9]+'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to build (e.g. simplicityhl-0.4.1)'
+        required: true
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            binary: simc
+            archive: simc-linux-x86_64.tar.gz
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-latest
+            binary: simc
+            archive: simc-linux-aarch64.tar.gz
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            binary: simc
+            archive: simc-macos-x86_64.tar.gz
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            binary: simc
+            archive: simc-macos-aarch64.tar.gz
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            binary: simc.exe
+            archive: simc-windows-x86_64.zip
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install cross (Linux cross-compilation)
+        if: runner.os == 'Linux'
+        run: cargo install cross --git https://github.com/cross-rs/cross
+
+      - name: Build (Linux)
+        if: runner.os == 'Linux'
+        run: cross build --release --bin simc --target ${{ matrix.target }}
+
+      - name: Build (macOS / Windows)
+        if: runner.os != 'Linux'
+        run: cargo build --release --bin simc --target ${{ matrix.target }}
+
+      - name: Package (Unix)
+        if: runner.os != 'Windows'
+        run: |
+          cp target/${{ matrix.target }}/release/${{ matrix.binary }} simc
+          tar czf ${{ matrix.archive }} simc
+          rm simc
+
+      - name: Package (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Copy-Item "target/${{ matrix.target }}/release/${{ matrix.binary }}" "simc.exe"
+          Compress-Archive -Path "simc.exe" -DestinationPath "${{ matrix.archive }}"
+          Remove-Item "simc.exe"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.archive }}
+          path: ${{ matrix.archive }}
+
+  release:
+    name: Create Release
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event.inputs.tag || github.ref_name }}
+          name: ${{ github.event.inputs.tag || github.ref_name }}
+          files: |
+            simc-linux-x86_64.tar.gz
+            simc-linux-aarch64.tar.gz
+            simc-macos-x86_64.tar.gz
+            simc-macos-aarch64.tar.gz
+            simc-windows-x86_64.zip


### PR DESCRIPTION
Adds a workflow to build binaries for simc. The main motivation is so that it can be used in versioning tools like `asdf-vm` as seen in the plugin here: https://github.com/stringhandler/asdf-simc

Currently that plugin requires the user to have a rust toolchain installed as it's built from source. Having binaries removes that requirement.
