### PR TITLE
Add imports functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Replaced the deprecated `WithFile` trait with `WithContent` and `WithSource` to cleanly separate single-file execution from multi-file environments. Additionally, replaced the `file()` method on `RichError` with `source()`. [#266](https://github.com/BlockstreamResearch/SimplicityHL/pull/266)
+
 # 0.5.0 - 2026-04-17
 
 * Migrate from the `pest` parser to a new `chumsky`-based parser, improving parser recovery and enabling multiple parse errors to be reported in one pass [#185](https://github.com/BlockstreamResearch/SimplicityHL/pull/185)

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -29,3 +29,49 @@ In SimplicityHL, the string "main" is reserved exclusively for the program's ent
 While a `TypeAlias` is technically allowed to use this name, we explicitly forbid aliasing imports
 to "main" using the `as` keyword. This avoids complicating the compiler's resolution logic and
 prevents accidental shadowing of the entry point.
+
+## Dependency Managing
+
+Currently, the module system requires explicit dependency remapping for each library context.
+In the following example, we load the `math` library using two different Dependency Root Path (DRP) names.  
+To achieve this, we must configure the remappings for the root `multiple_deps/` directory to map `base_math` and merkle to their respective paths. Additionally, for the `multiple_deps/merkle` subdirectory, we must define its own specific mapping to the `math` library.
+
+Example:
+
+``` Rust
+// multiple_deps/math/simple_op.simf
+pub fn hash(x: u32, y: u32) -> u32 {
+    jet::xor_32(x, y)
+}
+
+// multiple_deps/merkle/build_root.simf
+use math::simple_op::hash as temp_hash;
+
+pub fn get_root(tx1: u32, tx2: u32) -> u32 {
+    temp_hash(tx1, tx2)
+}
+
+pub fn hash(tx1: u32, tx2: u32) -> u32 {
+    jet::and_32(tx1, tx2)
+}
+
+// multiple_deps/main.simf
+use merkle::build_root::{get_root, hash as and_hash};
+use base_math::simple_op::hash as or_hash;
+
+pub fn get_block_value_hash(prev_hash: u32, tx1: u32, tx2: u32) -> u32 {
+    let root: u32 = get_root(tx1, tx2);
+    or_hash(prev_hash, root)
+}
+
+fn main() {
+    let block_val_hash: u32 = get_block_value_hash(5, 10, 20);
+    assert!(jet::eq_32(block_val_hash, 27));
+    
+    let first_value: u32 = 15;
+    let second_value: u32 = 22;
+    assert!(jet::eq_32(and_hash(first_value, second_value), 6));
+}
+```
+
+> NOTE: For more details, see the `multiple_deps` test inside the `src/lib.rs` file.

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -1,4 +1,7 @@
-# Architecture Note: Omitted Keywords
+# Architecture Notes
+
+## Omitted Keywords
+
 The `crate` and `super` keywords were not added to the compiler because they
 are unnecessary at this stage. Typically, they are used to resolve relative
 paths during import parsing. However, in our architecture, the prefix before
@@ -6,7 +9,7 @@ the first `::` in a `use` statement is always an dependency root path. Since all
 dependency root paths are unique and strictly bound to specific paths, the resolver
 can always unambiguously resolve the path without needing relative pointers.
 
-# Architecture Note: Namespace Separation in SimplicityHL
+## Namespace Separation in SimplicityHL
 
 SimplicityHL uses distinct namespaces for types and values. This allows the same identifier to refer to different things depending on where it appears in the code — the compiler determines the correct interpretation from syntactic context, with no risk of collision.
 
@@ -19,3 +22,10 @@ fn main() {
     assert!(foo());     // value namespace - function
 }
 ```
+
+## The "main" identifier in aliases
+
+In SimplicityHL, the string "main" is reserved exclusively for the program's entry point function.
+While a `TypeAlias` is technically allowed to use this name, we explicitly forbid aliasing imports
+to "main" using the `as` keyword. This avoids complicating the compiler's resolution logic and
+prevents accidental shadowing of the entry point.

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -1,0 +1,7 @@
+# Architecture Note: Omitted Keywords
+The `crate` and `super` keywords were not added to the compiler because they
+are unnecessary at this stage. Typically, they are used to resolve relative
+paths during import parsing. However, in our architecture, the prefix before
+the first `::` in a `use` statement is always an dependency root path. Since all
+dependency root paths are unique and strictly bound to specific paths, the resolver
+can always unambiguously resolve the path without needing relative pointers.

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -5,3 +5,17 @@ paths during import parsing. However, in our architecture, the prefix before
 the first `::` in a `use` statement is always an dependency root path. Since all
 dependency root paths are unique and strictly bound to specific paths, the resolver
 can always unambiguously resolve the path without needing relative pointers.
+
+# Architecture Note: Namespace Separation in SimplicityHL
+
+SimplicityHL uses distinct namespaces for types and values. This allows the same identifier to refer to different things depending on where it appears in the code — the compiler determines the correct interpretation from syntactic context, with no risk of collision.
+
+``` Rust
+fn foo() -> bool { false }
+type foo = bool;
+
+fn main() {
+    let x: foo = false; // type namespace  - type alias
+    assert!(foo());     // value namespace - function
+}
+```

--- a/examples/multiple_deps/main.simf
+++ b/examples/multiple_deps/main.simf
@@ -1,0 +1,16 @@
+use merkle::build_root::{get_root, hash as and_hash};
+use base_math::simple_op::hash as or_hash;
+
+pub fn get_block_value_hash(prev_hash: u32, tx1: u32, tx2: u32) -> u32 {
+    let root: u32 = get_root(tx1, tx2);
+    or_hash(prev_hash, root)
+}
+
+fn main() {
+    let block_val_hash: u32 = get_block_value_hash(5, 10, 20);
+    assert!(jet::eq_32(block_val_hash, 27));
+    
+    let first_value: u32 = 15;
+    let second_value: u32 = 22;
+    assert!(jet::eq_32(and_hash(first_value, second_value), 6));
+}

--- a/examples/multiple_deps/math/simple_op.simf
+++ b/examples/multiple_deps/math/simple_op.simf
@@ -1,0 +1,3 @@
+pub fn hash(x: u32, y: u32) -> u32 {
+    jet::xor_32(x, y)
+}

--- a/examples/multiple_deps/merkle/build_root.simf
+++ b/examples/multiple_deps/merkle/build_root.simf
@@ -1,0 +1,9 @@
+use math::simple_op::hash as temp_hash;
+
+pub fn get_root(tx1: u32, tx2: u32) -> u32 {
+    temp_hash(tx1, tx2)
+}
+
+pub fn hash(tx1: u32, tx2: u32) -> u32 {
+    jet::and_32(tx1, tx2)
+}

--- a/examples/simple_multidep/crypto/hashes.simf
+++ b/examples/simple_multidep/crypto/hashes.simf
@@ -1,0 +1,5 @@
+pub fn sha256(data: u32) -> u256 {
+    let ctx: Ctx8 = jet::sha_256_ctx_8_init();
+    let ctx: Ctx8 = jet::sha_256_ctx_8_add_4(ctx, data);
+    jet::sha_256_ctx_8_finalize(ctx)
+}

--- a/examples/simple_multidep/main.simf
+++ b/examples/simple_multidep/main.simf
@@ -1,0 +1,7 @@
+use math::arithmetic::add;
+use crypto::hashes::sha256;
+
+fn main() {
+    let sum: u32 = add(2, 3);
+    let hash: u256 = sha256(sum);
+}

--- a/examples/simple_multidep/math/arithmetic.simf
+++ b/examples/simple_multidep/math/arithmetic.simf
@@ -1,0 +1,4 @@
+pub fn add(a: u32, b: u32) -> u32 {
+    let (_, res): (bool, u32) = jet::add_32(a, b);
+    res
+}

--- a/examples/single_dep/main.simf
+++ b/examples/single_dep/main.simf
@@ -1,0 +1,11 @@
+pub use temp::constants::utils::two as smth;
+use temp::funcs::{get_five, Smth};
+
+fn seven() -> u32 {
+    7
+}
+
+fn main() {
+    let (_, temp): (bool, u32) = jet::add_32(smth(), get_five());
+    assert!(jet::eq_32(temp, seven()));
+}

--- a/examples/single_dep/temp/constants/utils.simf
+++ b/examples/single_dep/temp/constants/utils.simf
@@ -1,0 +1,5 @@
+pub use temp::funcs::Smth;
+
+pub fn two() -> Smth {
+    2
+}

--- a/examples/single_dep/temp/funcs.simf
+++ b/examples/single_dep/temp/funcs.simf
@@ -1,0 +1,5 @@
+pub type Smth = u32;
+
+pub fn get_five() -> u32 {
+    5
+}

--- a/functional-tests/error-test-cases/cyclic-dependency/lib/module_a.simf
+++ b/functional-tests/error-test-cases/cyclic-dependency/lib/module_a.simf
@@ -1,0 +1,2 @@
+pub use lib::module_b::TypeB;
+pub type TypeA = u32;

--- a/functional-tests/error-test-cases/cyclic-dependency/lib/module_b.simf
+++ b/functional-tests/error-test-cases/cyclic-dependency/lib/module_b.simf
@@ -1,0 +1,2 @@
+pub use lib::module_a::TypeA;
+pub type TypeB = u32;

--- a/functional-tests/error-test-cases/cyclic-dependency/main.simf
+++ b/functional-tests/error-test-cases/cyclic-dependency/main.simf
@@ -1,0 +1,3 @@
+use lib::module_a::TypeA; 
+
+fn main() {}

--- a/functional-tests/error-test-cases/file-not-found/main.simf
+++ b/functional-tests/error-test-cases/file-not-found/main.simf
@@ -1,0 +1,5 @@
+use lib::module::AssetId;
+
+fn main() {
+    let my_asset: AssetId = 5; 
+}

--- a/functional-tests/error-test-cases/lib-not-found/main.simf
+++ b/functional-tests/error-test-cases/lib-not-found/main.simf
@@ -1,0 +1,5 @@
+use lib::module::AssetId;
+
+fn main() {
+    let my_asset: AssetId = 5; 
+}

--- a/functional-tests/error-test-cases/name-collision/lib/groups.simf
+++ b/functional-tests/error-test-cases/name-collision/lib/groups.simf
@@ -1,0 +1,3 @@
+pub fn add(a: u32, b: u32) -> (bool, u32) {
+    jet::add_32(a, b)
+}

--- a/functional-tests/error-test-cases/name-collision/lib/math.simf
+++ b/functional-tests/error-test-cases/name-collision/lib/math.simf
@@ -1,0 +1,4 @@
+pub fn add(a: u32, b: u32) -> (bool, u32) {
+    let (_, c): (bool, u32) = jet::add_32(a, b);
+    jet::add_32(c, 1)
+}

--- a/functional-tests/error-test-cases/name-collision/main.simf
+++ b/functional-tests/error-test-cases/name-collision/main.simf
@@ -1,0 +1,9 @@
+use lib::groups::add;
+use lib::math::add;
+
+fn main() {
+    let x: u32 = 5;
+    let y: u32 = 10;
+    let (_, result): (bool, u32) = add(x, y);
+    assert!(jet::eq_32(result, 16));
+}

--- a/functional-tests/error-test-cases/private-visibility/lib/hidden.simf
+++ b/functional-tests/error-test-cases/private-visibility/lib/hidden.simf
@@ -1,0 +1,1 @@
+type SecretType = u32; pub fn ok() {}

--- a/functional-tests/error-test-cases/private-visibility/main.simf
+++ b/functional-tests/error-test-cases/private-visibility/main.simf
@@ -1,0 +1,3 @@
+use lib::hidden::SecretType;
+
+fn main() {}

--- a/functional-tests/error-test-cases/type-alias-duplication/lib/duplication.simf
+++ b/functional-tests/error-test-cases/type-alias-duplication/lib/duplication.simf
@@ -1,0 +1,2 @@
+pub type A = u32;
+pub type A = u64;

--- a/functional-tests/error-test-cases/type-alias-duplication/main.simf
+++ b/functional-tests/error-test-cases/type-alias-duplication/main.simf
@@ -1,0 +1,7 @@
+use lib::duplication::A;
+
+fn main() {
+    let smth: u64 = 55;
+    let another: A = 55;
+    assert!(jet::eq_64(smth, another));
+}

--- a/functional-tests/valid-test-cases/deep-reexport-chain/lib/level1.simf
+++ b/functional-tests/valid-test-cases/deep-reexport-chain/lib/level1.simf
@@ -1,0 +1,2 @@
+pub use lib::level2::CoreSmth;
+pub use lib::level2::core_val;

--- a/functional-tests/valid-test-cases/deep-reexport-chain/lib/level2.simf
+++ b/functional-tests/valid-test-cases/deep-reexport-chain/lib/level2.simf
@@ -1,0 +1,2 @@
+pub use lib::level3::CoreSmth;
+pub use lib::level3::core_val;

--- a/functional-tests/valid-test-cases/deep-reexport-chain/lib/level3.simf
+++ b/functional-tests/valid-test-cases/deep-reexport-chain/lib/level3.simf
@@ -1,0 +1,2 @@
+pub type CoreSmth = u32;
+pub fn core_val() -> CoreSmth { 42 }

--- a/functional-tests/valid-test-cases/deep-reexport-chain/main.simf
+++ b/functional-tests/valid-test-cases/deep-reexport-chain/main.simf
@@ -1,0 +1,7 @@
+use lib::level1::CoreSmth;
+use lib::level1::core_val;
+
+fn main() {
+    let val: CoreSmth = core_val();
+    assert!(jet::eq_32(val, 42));
+}

--- a/functional-tests/valid-test-cases/diamond-dependency-resolution/lib/base.simf
+++ b/functional-tests/valid-test-cases/diamond-dependency-resolution/lib/base.simf
@@ -1,0 +1,1 @@
+pub type BaseType = u32;

--- a/functional-tests/valid-test-cases/diamond-dependency-resolution/lib/left.simf
+++ b/functional-tests/valid-test-cases/diamond-dependency-resolution/lib/left.simf
@@ -1,0 +1,2 @@
+pub use lib::base::BaseType;
+pub fn get_left() -> BaseType { 1 }

--- a/functional-tests/valid-test-cases/diamond-dependency-resolution/lib/right.simf
+++ b/functional-tests/valid-test-cases/diamond-dependency-resolution/lib/right.simf
@@ -1,0 +1,2 @@
+pub use lib::base::BaseType;
+pub fn get_right() -> BaseType { 2 }

--- a/functional-tests/valid-test-cases/diamond-dependency-resolution/main.simf
+++ b/functional-tests/valid-test-cases/diamond-dependency-resolution/main.simf
@@ -1,0 +1,10 @@
+use lib::left::get_left;
+use lib::right::get_right;
+use lib::base::BaseType;
+
+fn main() {
+    let a: BaseType = get_left();
+    let b: BaseType = get_right();
+    let (_, c): (bool, BaseType) = jet::add_32(a, b);
+    assert!(jet::eq_32(c, 3));
+}

--- a/functional-tests/valid-test-cases/interleaved-waterfall/auth/verify.simf
+++ b/functional-tests/valid-test-cases/interleaved-waterfall/auth/verify.simf
@@ -1,0 +1,6 @@
+use types::def::UserId;
+use db::store::get_record;
+
+pub fn is_valid(id: UserId) -> UserId { 
+    get_record(id)
+}

--- a/functional-tests/valid-test-cases/interleaved-waterfall/db/store.simf
+++ b/functional-tests/valid-test-cases/interleaved-waterfall/db/store.simf
@@ -1,0 +1,2 @@
+use types::def::UserId;
+pub fn get_record(id: UserId) -> UserId { id }

--- a/functional-tests/valid-test-cases/interleaved-waterfall/main.simf
+++ b/functional-tests/valid-test-cases/interleaved-waterfall/main.simf
@@ -1,0 +1,5 @@
+use orch::handler::run_system;
+
+fn main() {
+    assert!(jet::eq_32(run_system(5), 5));
+}

--- a/functional-tests/valid-test-cases/interleaved-waterfall/orch/handler.simf
+++ b/functional-tests/valid-test-cases/interleaved-waterfall/orch/handler.simf
@@ -1,0 +1,8 @@
+use auth::verify::is_valid;
+use db::store::get_record;
+use types::def::UserId;
+
+pub fn run_system(id: UserId) -> UserId {
+    let checked: UserId = is_valid(id);
+    get_record(checked)
+}

--- a/functional-tests/valid-test-cases/interleaved-waterfall/types/def.simf
+++ b/functional-tests/valid-test-cases/interleaved-waterfall/types/def.simf
@@ -1,0 +1,1 @@
+pub type UserId = u32;

--- a/functional-tests/valid-test-cases/leaky-signature/lib/internal.simf
+++ b/functional-tests/valid-test-cases/leaky-signature/lib/internal.simf
@@ -1,0 +1,5 @@
+type SecretKey = u64;
+
+pub fn unlock(key: SecretKey) -> u64 {
+    jet::max_64(key, 0)
+}

--- a/functional-tests/valid-test-cases/leaky-signature/main.simf
+++ b/functional-tests/valid-test-cases/leaky-signature/main.simf
@@ -1,0 +1,4 @@
+use lib::internal::unlock;
+
+fn main() {
+}

--- a/functional-tests/valid-test-cases/module-simple/lib/module.simf
+++ b/functional-tests/valid-test-cases/module-simple/lib/module.simf
@@ -1,0 +1,1 @@
+pub fn add() {}

--- a/functional-tests/valid-test-cases/module-simple/main.simf
+++ b/functional-tests/valid-test-cases/module-simple/main.simf
@@ -1,0 +1,2 @@
+use lib::module::add;
+fn main() {}

--- a/functional-tests/valid-test-cases/multi-lib-facade/api/api.simf
+++ b/functional-tests/valid-test-cases/multi-lib-facade/api/api.simf
@@ -1,0 +1,3 @@
+pub use crypto::crypto::mock_hash;
+pub use math::math::MathInt;
+pub use math::math::add_two;

--- a/functional-tests/valid-test-cases/multi-lib-facade/crypto/crypto.simf
+++ b/functional-tests/valid-test-cases/multi-lib-facade/crypto/crypto.simf
@@ -1,0 +1,5 @@
+use math::math::MathInt;
+
+pub fn mock_hash(x: MathInt) -> (bool, MathInt) {
+    jet::add_32(x, 5)
+}

--- a/functional-tests/valid-test-cases/multi-lib-facade/main.simf
+++ b/functional-tests/valid-test-cases/multi-lib-facade/main.simf
@@ -1,0 +1,8 @@
+use api::api::{add_two, mock_hash, MathInt};
+
+fn main() {
+    let val: MathInt = 10;
+    let (_, step1): (bool, MathInt) = add_two(val);
+    let (_, step2): (bool, MathInt) = mock_hash(step1);
+    assert!(jet::eq_32(step2, 17));
+}

--- a/functional-tests/valid-test-cases/multi-lib-facade/math/math.simf
+++ b/functional-tests/valid-test-cases/multi-lib-facade/math/math.simf
@@ -1,0 +1,4 @@
+pub type MathInt = u32;
+pub fn add_two(x: MathInt) -> (bool, MathInt) { 
+    jet::add_32(x, 2) 
+}

--- a/functional-tests/valid-test-cases/reexport-diamond/lib/core.simf
+++ b/functional-tests/valid-test-cases/reexport-diamond/lib/core.simf
@@ -1,0 +1,2 @@
+pub type Coin = u64;
+pub fn mint(val: u64) -> Coin { val }

--- a/functional-tests/valid-test-cases/reexport-diamond/lib/route_a.simf
+++ b/functional-tests/valid-test-cases/reexport-diamond/lib/route_a.simf
@@ -1,0 +1,2 @@
+pub use lib::core::Coin;
+pub use lib::core::mint;

--- a/functional-tests/valid-test-cases/reexport-diamond/lib/route_b.simf
+++ b/functional-tests/valid-test-cases/reexport-diamond/lib/route_b.simf
@@ -1,0 +1,5 @@
+pub use lib::core::Coin;
+
+pub fn burn(c: Coin) -> (bool, Coin) {
+    jet::subtract_64(c, 1)
+}

--- a/functional-tests/valid-test-cases/reexport-diamond/main.simf
+++ b/functional-tests/valid-test-cases/reexport-diamond/main.simf
@@ -1,0 +1,9 @@
+use lib::route_a::Coin;
+use lib::route_a::mint;
+use lib::route_b::burn;
+
+fn main() {
+    let my_coin: Coin = mint(10);
+    let (_, remaining): (bool, Coin) = burn(my_coin);
+    assert!(jet::eq_64(remaining, 9));
+}

--- a/fuzz/fuzz_targets/compile_parse_tree.rs
+++ b/fuzz/fuzz_targets/compile_parse_tree.rs
@@ -3,16 +3,27 @@
 #[cfg(any(fuzzing, test))]
 fn do_test(data: &[u8]) {
     use arbitrary::Arbitrary;
+    use std::sync::Arc;
 
-    use simplicityhl::error::WithContent;
-    use simplicityhl::{ast, named, parse, ArbitraryOfType, Arguments};
+    use simplicityhl::error::{ErrorCollector, WithContent};
+    use simplicityhl::{ast, driver, named, parse, ArbitraryOfType, Arguments};
 
     let mut u = arbitrary::Unstructured::new(data);
     let parse_program = match parse::Program::arbitrary(&mut u) {
         Ok(x) => x,
         Err(_) => return,
     };
-    let ast_program = match ast::Program::analyze(&parse_program) {
+
+    let mut error_handler = ErrorCollector::new();
+    let driver_program = if let Some(program) =
+        driver::Program::from_parse(&parse_program, Arc::from(""), &mut error_handler)
+    {
+        program
+    } else {
+        return;
+    };
+
+    let ast_program = match ast::Program::analyze(&driver_program) {
         Ok(x) => x,
         Err(_) => return,
     };

--- a/fuzz/fuzz_targets/compile_parse_tree.rs
+++ b/fuzz/fuzz_targets/compile_parse_tree.rs
@@ -4,7 +4,7 @@
 fn do_test(data: &[u8]) {
     use arbitrary::Arbitrary;
 
-    use simplicityhl::error::WithFile;
+    use simplicityhl::error::WithContent;
     use simplicityhl::{ast, named, parse, ArbitraryOfType, Arguments};
 
     let mut u = arbitrary::Unstructured::new(data);
@@ -22,7 +22,7 @@ fn do_test(data: &[u8]) {
     };
     let simplicity_named_construct = ast_program
         .compile(arguments, false)
-        .with_file("")
+        .with_content("")
         .expect("AST should compile with given arguments");
     let _simplicity_commit = named::forget_names(&simplicity_named_construct);
 }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -762,6 +762,10 @@ impl AbstractSyntaxTree for Item {
             parse::Item::Function(function) => {
                 Function::analyze(function, ty, scope).map(Self::Function)
             }
+            parse::Item::Use(use_decl) => Err(RichError::new(
+                Error::CannotCompile("The `use` keyword is not supported yet.".to_string()),
+                *use_decl.span(),
+            )),
             parse::Item::Module => Ok(Self::Module),
         }
     }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -9,6 +9,7 @@ use miniscript::iter::{Tree, TreeLike};
 use simplicity::jet::Elements;
 
 use crate::debug::{CallTracker, DebugSymbols, TrackedCallName};
+use crate::driver::{FileScoped, SymbolTable, MAIN_MODULE, MAIN_STR};
 use crate::error::{Error, RichError, Span, WithSpan};
 use crate::num::{NonZeroPow2Usize, Pow2Usize};
 use crate::parse::MatchPattern;
@@ -19,7 +20,7 @@ use crate::types::{
 };
 use crate::value::{UIntValue, Value};
 use crate::witness::{Parameters, WitnessTypes, WitnessValues};
-use crate::{impl_eq_hash, parse};
+use crate::{driver, impl_eq_hash, parse};
 
 /// A program consists of the main function.
 ///
@@ -520,18 +521,52 @@ impl TreeLike for ExprTree<'_> {
 /// 2. Resolving type aliases
 /// 3. Assigning types to each witness expression
 /// 4. Resolving calls to custom functions
-#[derive(Clone, Debug, Eq, PartialEq, Default)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 struct Scope {
+    file_id: usize,
     variables: Vec<HashMap<Identifier, ResolvedType>>,
-    aliases: HashMap<AliasName, ResolvedType>,
+    aliases: HashMap<FileScoped<AliasName>, ResolvedType>,
+    aliases_table: SymbolTable<AliasName>,
     parameters: HashMap<WitnessName, ResolvedType>,
     witnesses: HashMap<WitnessName, ResolvedType>,
-    functions: HashMap<FunctionName, CustomFunction>,
+    functions: HashMap<FileScoped<FunctionName>, CustomFunction>,
+    functions_table: SymbolTable<FunctionName>,
     is_main: bool,
     call_tracker: CallTracker,
 }
 
+impl Default for Scope {
+    fn default() -> Self {
+        Self::new(
+            SymbolTable::<AliasName>::default(),
+            SymbolTable::<FunctionName>::default(),
+        )
+    }
+}
+
 impl Scope {
+    pub fn new(
+        aliases_table: SymbolTable<AliasName>,
+        functions_table: SymbolTable<FunctionName>,
+    ) -> Self {
+        Self {
+            file_id: MAIN_MODULE,
+            variables: Vec::new(),
+            aliases: HashMap::new(),
+            aliases_table,
+            parameters: HashMap::new(),
+            witnesses: HashMap::new(),
+            functions: HashMap::new(),
+            functions_table,
+            is_main: false,
+            call_tracker: CallTracker::default(),
+        }
+    }
+
+    pub fn file_id(&self) -> usize {
+        self.file_id
+    }
+
     /// Check if the current scope is topmost.
     pub fn is_topmost(&self) -> bool {
         self.variables.is_empty()
@@ -600,15 +635,59 @@ impl Scope {
             .find_map(|scope| scope.get(identifier))
     }
 
+    /// Retrieves the definition of a type alias, enforcing strict error prioritization.
+    ///
+    /// # Errors
+    /// * [`Error::UndefinedAlias`]: The alias is not found in the global registry.
+    /// * [`Error::Internal`]: The specified `file_id` does not exist in the `files`.
+    /// * [`Error::PrivateItem`]: The alias exists globally but is not exposed to the current file's scope.
+    fn get_alias(&self, name: &AliasName) -> Result<ResolvedType, Error> {
+        // 1. Get the true global ID of the alias.
+        let initial_id = (name.clone(), self.file_id);
+        let global_id = self
+            .aliases_table
+            .imports()
+            .resolved_roots()
+            .get(&initial_id)
+            .cloned()
+            .unwrap_or(initial_id);
+
+        // 2. Fetch the alias from the global pool.
+        let resolved_type = self
+            .aliases
+            .get(&global_id)
+            .ok_or_else(|| Error::UndefinedAlias(name.clone()))?;
+
+        // 3. Fetch the file scope for visibility checking.
+        let file_scope = self
+            .aliases_table
+            .local_scopes()
+            .get(self.file_id)
+            .ok_or_else(|| {
+                Error::Internal(format!(
+                    "file_id {} not found inside current Scope aliases",
+                    self.file_id
+                ))
+            })?;
+
+        // 4. Verify local scope visibility.
+        if file_scope.contains(name) {
+            // We clone here because types usually need to be owned in AST resolution
+            Ok(resolved_type.clone())
+        } else {
+            Err(Error::PrivateItem(name.as_inner().to_string()))
+        }
+    }
+
     /// Resolve a type with aliases to a type without aliases.
     ///
     /// ## Errors
     ///
-    /// There are any undefined aliases.
+    /// * [`Error::UndefinedAlias`]: The alias is not found in the global registry.
+    /// * [`Error::Internal`]: The specified `file_id` does not exist in the `files`.
+    /// * [`Error::PrivateItem`]: The alias exists globally but is not exposed to the current file's scope.
     pub fn resolve(&self, ty: &AliasedType) -> Result<ResolvedType, Error> {
-        let get_alias =
-            |name: &AliasName| -> Option<ResolvedType> { self.aliases.get(name).cloned() };
-        ty.resolve(get_alias).map_err(Error::UndefinedAlias)
+        ty.resolve(|name| self.get_alias(name))
     }
 
     /// Push a type alias into the global map.
@@ -617,11 +696,12 @@ impl Scope {
     ///
     /// There are any undefined aliases.
     pub fn insert_alias(&mut self, name: AliasName, ty: AliasedType) -> Result<(), Error> {
-        if self.aliases.contains_key(&name) {
+        let plug = (name.clone(), self.file_id);
+        if self.aliases.contains_key(&plug) {
             return Err(Error::RedefinedAlias(name));
         }
 
-        let _ = self.aliases.insert(name, self.resolve(&ty)?);
+        let _ = self.aliases.insert(plug, self.resolve(&ty)?);
         Ok(())
     }
 
@@ -684,18 +764,66 @@ impl Scope {
         name: FunctionName,
         function: CustomFunction,
     ) -> Result<(), Error> {
-        match self.functions.entry(name.clone()) {
-            Entry::Occupied(_) => Err(Error::FunctionRedefined(name)),
-            Entry::Vacant(entry) => {
-                entry.insert(function);
-                Ok(())
-            }
+        let func_name_id = (name.clone(), self.file_id);
+
+        if self.functions.contains_key(&func_name_id) {
+            return Err(Error::FunctionRedefined(name));
         }
+
+        let _ = self.functions.insert(func_name_id, function);
+        Ok(())
     }
 
-    /// Get the definition of a custom function.
-    pub fn get_function(&self, name: &FunctionName) -> Option<&CustomFunction> {
-        self.functions.get(name)
+    /// Retrieves the definition of a custom function, enforcing strict error prioritization.
+    ///
+    /// # Architecture Note
+    /// The order of operations here is intentional to prioritize specific compiler errors:
+    /// 1. Resolve the alias to find the true global coordinates.
+    /// 2. Check for global existence (`FunctionUndefined`) *before* checking local visibility.
+    /// 3. Verify if the current file's scope is actually allowed to see it (`PrivateItem`).
+    ///
+    /// # Errors
+    ///
+    /// * [`Error::FunctionUndefined`]: The function is not found in the global registry.
+    /// * [`Error::Internal`]: The specified `file_id` does not exist in the `files`.
+    /// * [`Error::PrivateItem`]: The function exists globally but is not exposed to the current file's scope.
+    pub fn get_function(&self, name: &FunctionName) -> Result<&CustomFunction, Error> {
+        // 1. Get the true global ID of the alias (or keep the current name if it is not aliased).
+        let initial_id = (name.clone(), self.file_id);
+        let global_id = self
+            .functions_table
+            .imports()
+            .resolved_roots()
+            .get(&initial_id)
+            .cloned()
+            .unwrap_or(initial_id);
+
+        // 2. Fetch the function from the global pool.
+        // We do this first so we can throw FunctionUndefined before checking local visibility.
+        let function = self
+            .functions
+            .get(&global_id)
+            .ok_or_else(|| Error::FunctionUndefined(name.clone()))?;
+
+        // TODO: Consider changing it to a better error handler with a source file.
+        let file_scope = self
+            .functions_table
+            .local_scopes()
+            .get(self.file_id)
+            .ok_or_else(|| {
+                Error::Internal(format!(
+                    "file_id {} not found inside current Scope files",
+                    self.file_id
+                ))
+            })?;
+
+        // 3. Verify local scope visibility.
+        // We successfully found the function globally, but is this file allowed to use it?
+        if file_scope.contains(name) {
+            Ok(function)
+        } else {
+            Err(Error::PrivateItem(name.as_inner().to_string()))
+        }
     }
 
     /// Track a call expression with its span.
@@ -718,9 +846,10 @@ trait AbstractSyntaxTree: Sized {
 }
 
 impl Program {
-    pub fn analyze(from: &parse::Program) -> Result<Self, RichError> {
+    pub fn analyze(from: &driver::Program) -> Result<Self, RichError> {
         let unit = ResolvedType::unit();
-        let mut scope = Scope::default();
+        let mut scope = Scope::new(from.aliases().clone(), from.functions().clone());
+
         let items = from
             .items()
             .iter()
@@ -732,6 +861,7 @@ impl Program {
             Item::Function(Function::Main(expr)) => Some(expr),
             _ => None,
         });
+
         let main = iter.next().ok_or(Error::MainRequired).with_span(from)?;
         if iter.next().is_some() {
             return Err(Error::FunctionRedefined(FunctionName::main())).with_span(from);
@@ -751,15 +881,18 @@ impl AbstractSyntaxTree for Item {
     fn analyze(from: &Self::From, ty: &ResolvedType, scope: &mut Scope) -> Result<Self, RichError> {
         assert!(ty.is_unit(), "Items cannot return anything");
         assert!(scope.is_topmost(), "Items live in the topmost scope only");
+        let previous_file_id = scope.file_id();
 
-        match from {
+        let res = match from {
             parse::Item::TypeAlias(alias) => {
+                scope.file_id = alias.file_id();
                 scope
                     .insert_alias(alias.name().clone(), alias.ty().clone())
                     .with_span(alias)?;
                 Ok(Self::TypeAlias)
             }
             parse::Item::Function(function) => {
+                scope.file_id = function.file_id();
                 Function::analyze(function, ty, scope).map(Self::Function)
             }
             parse::Item::Use(use_decl) => Err(RichError::new(
@@ -767,7 +900,10 @@ impl AbstractSyntaxTree for Item {
                 *use_decl.span(),
             )),
             parse::Item::Module => Ok(Self::Module),
-        }
+        };
+
+        scope.file_id = previous_file_id;
+        res
     }
 }
 
@@ -778,7 +914,7 @@ impl AbstractSyntaxTree for Function {
         assert!(ty.is_unit(), "Function definitions cannot return anything");
         assert!(scope.is_topmost(), "Items live in the topmost scope only");
 
-        if from.name().as_inner() != "main" {
+        if from.name().as_inner() != MAIN_STR {
             let params = from
                 .params()
                 .iter()
@@ -795,12 +931,14 @@ impl AbstractSyntaxTree for Function {
                 .map(|aliased| scope.resolve(aliased).with_span(from))
                 .transpose()?
                 .unwrap_or_else(ResolvedType::unit);
+
             scope.push_scope();
             for param in params.iter() {
                 scope.insert_variable(param.identifier().clone(), param.ty().clone());
             }
             let body = Expression::analyze(from.body(), &ret, scope).map(Arc::new)?;
             scope.pop_scope();
+
             debug_assert!(scope.is_topmost());
             let function = CustomFunction { params, body };
             scope
@@ -818,6 +956,10 @@ impl AbstractSyntaxTree for Function {
             if !resolved.is_unit() {
                 return Err(Error::MainNoOutput).with_span(from);
             }
+        }
+
+        if scope.file_id() != MAIN_MODULE {
+            return Err(Error::MainOutOfEntryFile).with_span(from);
         }
 
         scope.push_main_scope();
@@ -1325,14 +1467,9 @@ impl AbstractSyntaxTree for CallName {
                 .get_function(name)
                 .cloned()
                 .map(Self::Custom)
-                .ok_or(Error::FunctionUndefined(name.clone()))
                 .with_span(from),
             parse::CallName::ArrayFold(name, size) => {
-                let function = scope
-                    .get_function(name)
-                    .cloned()
-                    .ok_or(Error::FunctionUndefined(name.clone()))
-                    .with_span(from)?;
+                let function = scope.get_function(name).cloned().with_span(from)?;
                 // A function that is used in a array fold has the signature:
                 //   fn f(element: E, accumulator: A) -> A
                 if function.params().len() != 2 || function.params()[1].ty() != function.body().ty()
@@ -1343,11 +1480,7 @@ impl AbstractSyntaxTree for CallName {
                 }
             }
             parse::CallName::Fold(name, bound) => {
-                let function = scope
-                    .get_function(name)
-                    .cloned()
-                    .ok_or(Error::FunctionUndefined(name.clone()))
-                    .with_span(from)?;
+                let function = scope.get_function(name).cloned().with_span(from)?;
                 // A function that is used in a list fold has the signature:
                 //   fn f(element: E, accumulator: A) -> A
                 if function.params().len() != 2 || function.params()[1].ty() != function.body().ty()
@@ -1358,11 +1491,7 @@ impl AbstractSyntaxTree for CallName {
                 }
             }
             parse::CallName::ForWhile(name) => {
-                let function = scope
-                    .get_function(name)
-                    .cloned()
-                    .ok_or(Error::FunctionUndefined(name.clone()))
-                    .with_span(from)?;
+                let function = scope.get_function(name).cloned().with_span(from)?;
                 // A function that is used in a for-while loop has the signature:
                 //   fn f(accumulator: A, readonly_context: C, counter: u{N}) -> Either<B, A>
                 // where
@@ -1581,5 +1710,85 @@ impl AsRef<Span> for Module {
 impl AsRef<Span> for ModuleAssignment {
     fn as_ref(&self) -> &Span {
         &self.span
+    }
+}
+
+#[cfg(test)]
+mod alias_scope_regression_tests {
+    use super::Program;
+    use crate::driver::tests::setup_graph;
+    use crate::error::ErrorCollector;
+
+    fn analyze_multifile(files: Vec<(&str, &str)>) -> Result<(), String> {
+        let (graph, _ids, _dir) = setup_graph(files);
+
+        let mut error_handler = ErrorCollector::new();
+        let driver_program = graph
+            .linearize_and_build(&mut error_handler)
+            .unwrap()
+            .expect("driver build should succeed");
+
+        Program::analyze(&driver_program)
+            .map(|_| ())
+            .map_err(|e| e.to_string())
+    }
+
+    #[test]
+    fn private_type_alias_from_dependency_does_not_leak() {
+        let result = analyze_multifile(vec![
+            (
+                "main.simf",
+                "use lib::A::helper; fn main() { helper(); let x: Secret = 0; }",
+            ),
+            ("libs/lib/A.simf", "type Secret = u32; pub fn helper() {}"),
+        ]);
+
+        assert!(
+            result.is_err(),
+            "private alias from another file leaked into root scope: {result:?}"
+        );
+    }
+
+    #[test]
+    fn same_alias_name_in_different_modules_does_not_conflict_if_only_one_is_imported() {
+        let result = analyze_multifile(vec![
+            (
+                "main.simf",
+                "use lib::A::Word; use lib::B::id; fn main() { let x: Word = 0; assert!(jet::is_zero_32(id(x))); }",
+            ),
+            ("libs/lib/A.simf", "pub type Word = u32;"),
+            ("libs/lib/B.simf", "pub type Word = u16; pub fn id(x: u32) -> u32 { x }"),
+        ]);
+
+        assert!(
+            result.is_ok(),
+            "unimported alias from another module should not collide: {result:?}"
+        );
+    }
+
+    #[test]
+    fn dependency_main_does_not_satisfy_missing_root_main() {
+        let result = analyze_multifile(vec![
+            ("main.simf", "use lib::A::helper;"),
+            ("libs/lib/A.simf", "fn main() {} pub fn helper() {}"),
+        ]);
+
+        assert!(
+            result.is_err(),
+            "Main function must be inside an entry file: {result:?}"
+        )
+    }
+
+    #[test]
+    fn main_must_be_defined_once_per_project() {
+        let result = analyze_multifile(vec![
+            ("main.simf", "use lib::A::helper; fn main() { helper(); }"),
+            ("libs/lib/A.simf", "fn main() {} pub fn helper() {}"),
+        ]);
+
+        assert!(
+            result.is_err(),
+            "Main function must be inside an entry file: {result:?}"
+        );
     }
 }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1573,6 +1573,9 @@ fn analyze_named_module(
     from: &parse::ModuleProgram,
 ) -> Result<HashMap<WitnessName, Value>, RichError> {
     let unit = ResolvedType::unit();
+
+    // IMPORTANT! If modules allow imports, then we need to consider
+    // passing the resolution conetxt by calling `Scope::new(resolutions)`
     let mut scope = Scope::default();
     let items = from
         .items()

--- a/src/driver/linearization.rs
+++ b/src/driver/linearization.rs
@@ -14,7 +14,7 @@ use crate::driver::DependencyGraph;
 /// This is a core component of the [`DependencyGraph`].
 impl DependencyGraph {
     /// Returns the deterministic, BOTTOM-UP load order of dependencies.
-    pub(crate) fn linearize(&self) -> Result<Vec<usize>, LinearizationError> {
+    pub(super) fn linearize(&self) -> Result<Vec<usize>, LinearizationError> {
         let mut visited = HashSet::new();
         let mut visiting = Vec::new();
         let mut order = Vec::new();

--- a/src/driver/linearization.rs
+++ b/src/driver/linearization.rs
@@ -6,8 +6,6 @@
 //! Because we do not need to enforce strict local precedence, a standard post-order
 //! DFS is a better option.
 
-// TODO: Remove this once the code is actively used.
-#![allow(dead_code)]
 use std::collections::HashSet;
 use std::fmt;
 
@@ -16,7 +14,7 @@ use crate::driver::DependencyGraph;
 /// This is a core component of the [`DependencyGraph`].
 impl DependencyGraph {
     /// Returns the deterministic, BOTTOM-UP load order of dependencies.
-    pub fn linearize(&self) -> Result<Vec<usize>, LinearizationError> {
+    pub(crate) fn linearize(&self) -> Result<Vec<usize>, LinearizationError> {
         let mut visited = HashSet::new();
         let mut visiting = Vec::new();
         let mut order = Vec::new();

--- a/src/driver/linearization.rs
+++ b/src/driver/linearization.rs
@@ -1,0 +1,184 @@
+//! Computes the bottom-up load order of dependencies using a DFS.
+//!
+//! # Architectural Note: Why pure DFS instead of C3?
+//! Unlike OOP languages that require C3 Linearization to resolve complex method
+//! overriding (MRO), SimplicityHL module imports rely on namespacing and aliasing.
+//! Because we do not need to enforce strict local precedence, a standard post-order
+//! DFS is a better option.
+
+// TODO: Remove this once the code is actively used.
+#![allow(dead_code)]
+use std::collections::HashSet;
+use std::fmt;
+
+use crate::driver::DependencyGraph;
+
+/// This is a core component of the [`DependencyGraph`].
+impl DependencyGraph {
+    /// Returns the deterministic, BOTTOM-UP load order of dependencies.
+    pub fn linearize(&self) -> Result<Vec<usize>, LinearizationError> {
+        let mut visited = HashSet::new();
+        let mut visiting = Vec::new();
+        let mut order = Vec::new();
+
+        self.dfs_linearize(0, &mut visited, &mut visiting, &mut order)?;
+
+        Ok(order)
+    }
+
+    /// Core recursive Post-Order DFS for topological sorting.
+    ///
+    /// - **Visited Set (`visited`):** Prevents processing shared dependencies multiple times (solves diamonds).
+    /// - **Cycle Detection (`visiting`):** Tracks the current path stack to catch infinite loops.
+    /// - **Order List (`order`):** Accumulates the deterministic load order bottom-up.
+    fn dfs_linearize(
+        &self,
+        module: usize,
+        visited: &mut HashSet<usize>,
+        visiting: &mut Vec<usize>,
+        order: &mut Vec<usize>,
+    ) -> Result<(), LinearizationError> {
+        // If we have already fully processed this module, skip it (Diamond Deduplication)
+        if visited.contains(&module) {
+            return Ok(());
+        }
+
+        if let Some(cycle_start) = visiting.iter().position(|&m| m == module) {
+            return Err(LinearizationError::CycleDetected(
+                visiting[cycle_start..]
+                    .iter()
+                    .map(|&id| self.modules[id].source.str_name())
+                    .collect(),
+            ));
+        }
+
+        visiting.push(module);
+
+        let parents = self
+            .dependencies
+            .get(&module)
+            .map_or(&[] as &[usize], |v| v.as_slice());
+
+        for &parent in parents {
+            self.dfs_linearize(parent, visited, visiting, order)?;
+        }
+
+        visiting.pop();
+        visited.insert(module);
+        order.push(module);
+
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub enum LinearizationError {
+    /// Raised when a circular dependency (e.g., A -> B -> A) is detected.
+    CycleDetected(Vec<String>),
+}
+
+impl fmt::Display for LinearizationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            LinearizationError::CycleDetected(cycle) => {
+                write!(f, "Circular dependency detected: {:?}", cycle.join(" -> "))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::driver::tests::setup_graph;
+
+    use super::*;
+
+    #[test]
+    fn test_linearize_simple_import() {
+        let (graph, ids, _dir) = setup_graph(vec![
+            ("main.simf", "use lib::math::some_func;"),
+            ("libs/lib/math.simf", ""),
+        ]);
+
+        let order = graph.linearize().unwrap();
+
+        let root_id = ids["main"];
+        let math_id = ids["math"];
+
+        assert_eq!(order, vec![math_id, root_id]);
+    }
+
+    #[test]
+    fn test_linearize_diamond_dependency_deduplication() {
+        // Setup:
+        // root -> imports A, B
+        // A -> imports Common
+        // B -> imports Common
+        // Expected: Common loaded ONLY ONCE.
+
+        let (graph, ids, _dir) = setup_graph(vec![
+            ("main.simf", "use lib::A::foo; use lib::B::bar;"),
+            ("libs/lib/A.simf", "use lib::Common::dummy1;"),
+            ("libs/lib/B.simf", "use lib::Common::dummy2;"),
+            ("libs/lib/Common.simf", ""),
+        ]);
+
+        let order = graph.linearize().unwrap();
+
+        // Verify order using IDs from the helper map
+        let main_id = ids["main"];
+        let a_id = ids["A"];
+        let b_id = ids["B"];
+        let common_id = ids["Common"];
+
+        assert!(
+            order == vec![common_id, b_id, a_id, main_id]
+                || order == vec![common_id, a_id, b_id, main_id]
+        );
+    }
+
+    #[test]
+    fn test_linearize_detects_cycle() {
+        let (graph, _, _dir) = setup_graph(vec![
+            ("main.simf", "use lib::A::entry;"),
+            ("libs/lib/A.simf", "use lib::B::func;"),
+            ("libs/lib/B.simf", "use lib::A::func;"),
+        ]);
+
+        let order = graph.linearize();
+        assert!(matches!(
+            order,
+            Err(LinearizationError::CycleDetected { .. })
+        ));
+    }
+
+    #[test]
+    fn test_linearize_allows_conflicting_nested_import_order() {
+        // A imports X then Y, while B imports Y then X.
+        // This DAG is still valid because neither X nor Y depends on the other.
+        let (graph, ids, _dir) = setup_graph(vec![
+            ("main.simf", "use lib::A::foo; use lib::B::bar;"),
+            ("libs/lib/A.simf", "use lib::X::foo; use lib::Y::bar;"),
+            ("libs/lib/B.simf", "use lib::Y::baz; use lib::X::qux;"),
+            ("libs/lib/X.simf", ""),
+            ("libs/lib/Y.simf", ""),
+        ]);
+
+        let order = graph
+            .linearize()
+            .expect("valid dependency DAG should linearize successfully");
+
+        let main_id = ids["main"];
+        let a_id = ids["A"];
+        let b_id = ids["B"];
+        let x_id = ids["X"];
+        let y_id = ids["Y"];
+
+        assert!(
+            order == vec![x_id, y_id, a_id, b_id, main_id]
+                || order == vec![y_id, x_id, a_id, b_id, main_id]
+                || order == vec![x_id, y_id, b_id, a_id, main_id]
+                || order == vec![y_id, x_id, b_id, a_id, main_id]
+        );
+    }
+}

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -1,0 +1,598 @@
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use chumsky::container::Container;
+
+use crate::error::{Error, ErrorCollector, RichError, Span};
+use crate::parse::{self, ParseFromStrWithErrors};
+use crate::resolution::{CanonPath, DependencyMap, SourceFile};
+
+/// Caches the canonicalized path of a source file to prevent redundant,
+/// expensive, and potentially failing filesystem operations.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct CanonSourceFile {
+    /// The path of the source file (e.g., "./src/main.simf").
+    name: CanonPath,
+    /// The actual text content of the source file.
+    content: Arc<str>,
+}
+
+impl TryFrom<SourceFile> for CanonSourceFile {
+    type Error = String;
+
+    fn try_from(source: SourceFile) -> Result<Self, Self::Error> {
+        let name = if let Some(root_name) = source.name() {
+            CanonPath::canonicalize(root_name)?
+        } else {
+            return Err(
+                "Cannot canonicalize the SourceFile because it is missing a file name.".to_string(),
+            );
+        };
+
+        Ok(CanonSourceFile {
+            name,
+            content: source.content(),
+        })
+    }
+}
+
+impl CanonSourceFile {
+    pub fn new(name: CanonPath, content: Arc<str>) -> Self {
+        Self { name, content }
+    }
+
+    pub fn name(&self) -> &CanonPath {
+        &self.name
+    }
+
+    pub fn content(&self) -> Arc<str> {
+        self.content.clone()
+    }
+}
+
+/// Represents a single, isolated file in the SimplicityHL project.
+/// In this architecture, a file and a module are the exact same thing.
+#[derive(Debug, Clone)]
+struct Module {
+    source: CanonSourceFile,
+    /// The completely parsed program for this specific file.
+    /// it contains all the functions, aliases, and imports defined inside the file.
+    parsed_program: parse::Program,
+}
+
+/// An Intermediate Representation that helps transform isolated files into a global program.
+///
+/// While an AST only understands a single file, the `DependencyGraph` links multiple
+/// ASTs together into a Directed Acyclic Graph (DAG). This DAG is then used to build
+/// one convenient `Program` struct for the semantic analyzer can easily process.
+///
+/// This structure provides the global context necessary to solve high-level compiler
+/// problems, including:
+/// * **Cross-Module Resolution:** Allowing the compiler to traverse edges and verify
+///   that imported symbols, functions, and types actually exist in other files.
+/// * **Topological Sorting:** Guaranteeing that modules are analyzed and compiled in
+///   the strictly correct mathematical order (e.g., analyzing module `B` before module
+///   `A` if `A` depends on `B`).
+/// * **Cycle Detection:** Preventing infinite compiler loops by ensuring no circular
+///   imports exist before heavy semantic processing begins.
+pub struct DependencyGraph {
+    /// Implements the Arena Pattern to act as the sole, centralized owner of all parsed modules.
+    ///
+    /// In C++ or Java, a graph would typically link dependencies using direct memory
+    /// pointers (e.g., `List<Module*>`). In Rust, doing this requires either
+    /// lifetimes or performance-heavy reference counting (`Rc<RefCell<T>>`).
+    ///
+    /// Using a flat `Vec` as a memory arena is the idiomatic Rust solution.
+    modules: Vec<Module>,
+
+    /// The configuration environment.
+    /// Used to resolve external library dependencies and invoke their associated functions.
+    dependency_map: Arc<DependencyMap>,
+
+    /// Fast lookup: `CanonPath` -> Module ID.
+    /// A reverse index mapping absolute file paths to their internal IDs.
+    /// This solves the duplication problem, ensuring each file is only parsed once.
+    lookup: HashMap<CanonPath, usize>,
+
+    /// Fast lookup: Module ID -> `CanonPath`.
+    /// A direct index mapping internal IDs back to their absolute file paths.
+    /// This serves as the exact inverse of the `lookup` map.
+    paths: Vec<CanonPath>,
+
+    /// The Adjacency List: Defines the Directed acyclic Graph (DAG) of imports.
+    ///
+    /// The Key (`usize`) is the ID of a "Parent" module (the file doing the importing).
+    /// The Value (`Vec<usize>`) is a list of IDs of the "Child" modules it relies on.
+    ///
+    /// Example: If `main.simf` (ID: 0) has `use lib::math;` (ID: 1) and `use lib::io;` (ID: 2),
+    /// this map will contain: `{ 0: [1, 2] }`.
+    dependencies: HashMap<usize, Vec<usize>>,
+}
+
+impl DependencyGraph {
+    /// Initializes a new `ProjectGraph` by parsing the root program and discovering all dependencies.
+    ///
+    /// Performs a BFS to recursively parse `use` statements,
+    /// building a DAG of the project's modules.
+    ///
+    /// # Arguments
+    ///
+    /// * `root_source` - The `SourceFile` representing the entry point of the project.
+    /// * `dependency_map` - The context-aware mapping rules used to resolve external imports.
+    /// * `root_program` - A reference to the already-parsed AST of the root file.
+    /// * `handler` - The diagnostics collector used to record resolution and parsing errors.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(Some(Self))` - If the entire project graph was successfully resolved and parsed.
+    /// * `Ok(None)` - If the graph traversal completed, but one or more modules contained
+    ///   errors (which have been safely logged into the `handler`).
+    ///
+    /// # Errors
+    ///
+    /// This function will return an `Err(String)` only for critical internal compiler errors
+    /// (e.g., if a provided `SourceFile` is unexpectedly missing its underlying file path).
+    pub fn new(
+        root_source: SourceFile,
+        dependency_map: Arc<DependencyMap>,
+        root_program: &parse::Program,
+        handler: &mut ErrorCollector,
+    ) -> Result<Option<Self>, String> {
+        let root_canon_source = CanonSourceFile::try_from(root_source)?;
+
+        let mut graph = Self {
+            modules: vec![Module {
+                source: root_canon_source.clone(),
+                parsed_program: root_program.clone(),
+            }],
+            dependency_map,
+            lookup: HashMap::new(),
+            paths: vec![root_canon_source.name().clone()],
+            dependencies: HashMap::new(),
+        };
+
+        let root_id = 0;
+        graph
+            .lookup
+            .insert(root_canon_source.name().clone(), root_id);
+        graph.dependencies.insert(root_id, Vec::new());
+
+        let mut queue = VecDeque::new();
+        queue.push_back(root_id);
+
+        // Prevent errors in the checked files from being doubled in the `load_and_parse_dependencies` function.
+        let mut inalid_imports = HashSet::new();
+
+        while let Some(curr_id) = queue.pop_front() {
+            let Some(current_module) = graph.modules.get(curr_id) else {
+                return Err(format!(
+                    "Internal Driver Error: Module ID {} is in the queue but missing from the graph.modules.",
+                    curr_id
+                ));
+            };
+
+            // We need this to report errors inside THIS file.
+            let importer_source = current_module.source.clone();
+
+            // PHASE 1: Immutably read from the graph
+            let valid_imports = Self::resolve_imports(
+                &current_module.parsed_program,
+                &importer_source,
+                &graph.dependency_map,
+                handler,
+            );
+
+            // PHASE 2: Mutate the graph
+            graph.load_and_parse_dependencies(
+                curr_id,
+                valid_imports,
+                &mut inalid_imports,
+                &importer_source,
+                handler,
+                &mut queue,
+            );
+        }
+
+        // TODO: Consider getting rid of the 'String' error here and changing it to a more appropriate error
+        // (e.g. 'Result<Self, ErrorCollector>') after resolving https://github.com/BlockstreamResearch/SimplicityHL/issues/270.
+        Ok((!handler.has_errors()).then_some(graph))
+    }
+
+    /// This helper cleanly encapsulates the process of loading source text, parsing it
+    /// into an `parse::Program`, and combining them so the compiler can easily work with the file.
+    /// If the file is missing or contains syntax errors, it logs the diagnostic to the
+    /// `ErrorCollector` and safely returns `None`.
+    fn parse_and_get_program(
+        path: &CanonPath,
+        importer_source: &CanonSourceFile,
+        span: Span,
+        handler: &mut ErrorCollector,
+    ) -> Option<Module> {
+        let Ok(content) = std::fs::read_to_string(path.as_path()) else {
+            let err = RichError::new(Error::FileNotFound(PathBuf::from(path.as_path())), span)
+                .with_source(importer_source.clone());
+
+            handler.push(err);
+            return None;
+        };
+
+        let mut error_handler = ErrorCollector::new();
+        let source = CanonSourceFile::new(path.clone(), Arc::from(content));
+
+        let ast = parse::Program::parse_from_str_with_errors(source.clone(), &mut error_handler);
+
+        if error_handler.has_errors() {
+            handler.extend_with_handler(source, &error_handler);
+            None
+        } else {
+            ast.map(|parsed_program| Module {
+                source,
+                parsed_program,
+            })
+        }
+    }
+
+    /// PHASE 1 OF GRAPH CONSTRUCTION: Resolves all imports inside a single `parse::Program`.
+    /// Note: This is a specialized helper function designed exclusively for the `DependencyGraph::new()` constructor.
+    fn resolve_imports(
+        current_program: &parse::Program,
+        importer_source: &CanonSourceFile,
+        dependency_map: &DependencyMap,
+        handler: &mut ErrorCollector,
+    ) -> Vec<(CanonPath, Span)> {
+        let mut valid_imports = Vec::new();
+
+        for elem in current_program.items() {
+            let parse::Item::Use(use_decl) = elem else {
+                continue;
+            };
+
+            match dependency_map.resolve_path(importer_source.name(), use_decl) {
+                Ok(path) => valid_imports.push((path, *use_decl.span())),
+                Err(err) => handler.push(err.with_source(importer_source.clone())),
+            }
+        }
+
+        valid_imports
+    }
+
+    /// PHASE 2 OF GRAPH CONSTRUCTION: Loads, parses, and registers new dependencies.
+    /// Note: This is a specialized helper function designed exclusively for the `DependencyGraph::new()` constructor.
+    fn load_and_parse_dependencies(
+        &mut self,
+        curr_id: usize,
+        valid_imports: Vec<(CanonPath, Span)>,
+        inalid_imports: &mut HashSet<CanonPath>,
+        importer_source: &CanonSourceFile,
+        handler: &mut ErrorCollector,
+        queue: &mut VecDeque<usize>,
+    ) {
+        for (path, import_span) in valid_imports {
+            if inalid_imports.contains(&path) {
+                continue;
+            }
+
+            if let Some(&existing_id) = self.lookup.get(&path) {
+                let deps = self.dependencies.entry(curr_id).or_default();
+                if !deps.contains(&existing_id) {
+                    deps.push(existing_id);
+                }
+                continue;
+            }
+
+            let Some(module) =
+                Self::parse_and_get_program(&path, importer_source, import_span, handler)
+            else {
+                inalid_imports.push(path);
+                continue;
+            };
+
+            let last_ind = self.modules.len();
+            self.modules.push(module);
+
+            self.lookup.insert(path.clone(), last_ind);
+            self.paths.push(path.clone());
+            self.dependencies.entry(curr_id).or_default().push(last_ind);
+
+            queue.push_back(last_ind);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::resolution::tests::canon;
+    use crate::test_utils::TempWorkspace;
+
+    /// Initializes a raw graph environment for testing, explicitly allowing for and capturing failure states.
+    ///
+    /// This function handles the boilerplate of setting up a workspace, virtual files, and dependency maps.
+    /// It is primarily used to test error handling (e.g., syntax errors, unmapped imports) by returning
+    /// the raw results and the error collector without automatically panicking or exiting.
+    ///
+    /// # Arguments
+    ///
+    /// * `files` - A vector of tuples representing the file tree, formatted as `(file_path, file_content)`.
+    ///   **Note:** The list must include exactly one `"main.simf"` to act as the root entry point.
+    ///
+    /// # Returns
+    ///
+    /// A 4-element tuple containing:
+    /// 1. `Option<DependencyGraph>`: The constructed graph, or `None` if parsing/graph building failed.
+    /// 2. `HashMap<String, usize>`: A lookup mapping file stems (e.g., `"A"` from `"A.simf"`) to their `FileID`.
+    ///    This will be empty if graph creation fails.
+    /// 3. `TempWorkspace`: The temporary directory instance. This must be kept in scope by the caller so
+    ///    the OS doesn't delete the files before the test finishes.
+    /// 4. `ErrorCollector`: The handler containing any logged errors, useful fo
+    fn setup_graph_raw(
+        files: Vec<(&str, &str)>,
+    ) -> (
+        Option<DependencyGraph>,
+        HashMap<String, usize>,
+        TempWorkspace,
+        ErrorCollector,
+    ) {
+        let ws = TempWorkspace::new("graph");
+        let mut handler = ErrorCollector::new();
+
+        // Create base directories
+        let workspace_dir = canon(&ws.create_dir("workspace"));
+        let lib_dir = canon(&ws.create_dir("workspace/libs/lib"));
+
+        // Set up the dependency map for imports (e.g. `use lib::...`)
+        let mut map = DependencyMap::new();
+        map.insert(workspace_dir.clone(), "lib".to_string(), lib_dir)
+            .expect("Failed to insert dependency map");
+        let map = Arc::new(map);
+
+        let mut root_file_path = None;
+        let mut root_content = String::new();
+
+        // Create all requested files
+        for (path, content) in files {
+            let full_path = format!("workspace/{}", path);
+            let created_file = canon(&ws.create_file(&full_path, content));
+
+            if path == "main.simf" {
+                root_file_path = Some(created_file);
+                root_content = content.to_string();
+            }
+        }
+
+        let root_p = root_file_path.expect("main.simf must be defined in file list");
+        let main_canon_source = CanonSourceFile::new(root_p, Arc::from(root_content));
+        let main_source = SourceFile::from(main_canon_source);
+
+        let main_program_option =
+            parse::Program::parse_from_str_with_errors(main_source.clone(), &mut handler);
+
+        let Some(main_program) = main_program_option else {
+            return (None, HashMap::new(), ws, handler);
+        };
+
+        let graph_option =
+            DependencyGraph::new(main_source, map, &main_program, &mut handler).unwrap();
+
+        let mut file_ids = HashMap::new();
+
+        if let Some(ref graph) = graph_option {
+            for (path, id) in &graph.lookup {
+                let file_stem = path
+                    .as_path()
+                    .file_stem()
+                    .unwrap()
+                    .to_string_lossy()
+                    .to_string();
+                file_ids.insert(file_stem, *id);
+            }
+        }
+
+        (graph_option, file_ids, ws, handler)
+    }
+
+    /// Initializes a complete graph environment for testing, expecting strict success.
+    ///
+    /// This wrapper around [`setup_graph_raw`] is designed for "happy path" tests. It streamlines
+    /// testing by guaranteeing a valid graph is returned, stripping away the error handling boilerplate.
+    ///
+    /// # Arguments
+    ///
+    /// * `files` - A vector of tuples representing the file tree, formatted as `(file_path, file_content)`.
+    ///   **Note:** The list must include exactly one `"main.simf"` to act as the root entry point.
+    ///
+    /// # Returns
+    ///
+    /// A 3-element tuple containing:
+    /// 1. `DependencyGraph`: The successfully constructed dependency graph.
+    /// 2. `HashMap<String, usize>`: A lookup mapping file stems (e.g., `"A"` from `"A.simf"`) to their `FileID`.
+    /// 3. `TempWorkspace`: The temporary directory instance. This must be kept in scope by the caller so
+    ///    the OS doesn't delete the files before the test finishes.
+    ///
+    /// # Exits
+    ///
+    /// This function will immediately panic and print the collected errors
+    /// to standard error if the parser or graph builder encounters any issues.
+    fn setup_graph(
+        files: Vec<(&str, &str)>,
+    ) -> (DependencyGraph, HashMap<String, usize>, TempWorkspace) {
+        let (graph_option, file_ids, ws, handler) = setup_graph_raw(files);
+
+        let Some(graph) = graph_option else {
+            panic!(
+                "Parser or DependencyGraph Error in Test Setup:\n{}",
+                handler
+            );
+        };
+
+        (graph, file_ids, ws)
+    }
+
+    #[test]
+    fn test_simple_import() {
+        // Setup:
+        // root.simf -> "use lib::math::some_func;"
+        // libs/lib/math.simf -> ""
+
+        let (graph, ids, _ws) = setup_graph(vec![
+            ("main.simf", "use lib::math::some_func;"),
+            ("libs/lib/math.simf", ""),
+        ]);
+
+        assert_eq!(graph.modules.len(), 2, "Should have Root and Math module");
+
+        let root_id = ids["main"];
+        let math_id = ids["math"];
+
+        assert!(
+            graph
+                .dependencies
+                .get(&root_id)
+                .is_some_and(|deps| deps.contains(&math_id)),
+            "Root (main.simf) should depend on Math (math.simf)"
+        );
+    }
+
+    #[test]
+    fn test_diamond_dependency_deduplication() {
+        // Setup:
+        // root -> imports A, B
+        // A -> imports Common
+        // B -> imports Common
+        // Expected: Common loaded ONLY ONCE.
+
+        let (graph, ids, _ws) = setup_graph(vec![
+            ("main.simf", "use lib::A::foo; use lib::B::bar;"),
+            ("libs/lib/A.simf", "use lib::Common::dummy1;"),
+            ("libs/lib/B.simf", "use lib::Common::dummy2;"),
+            ("libs/lib/Common.simf", ""),
+        ]);
+
+        // Check strict deduplication (Unique modules count)
+        assert_eq!(
+            graph.modules.len(),
+            4,
+            "Should resolve exactly 4 unique modules"
+        );
+
+        // Verify Graph Topology via IDs
+        let a_id = ids["A"];
+        let b_id = ids["B"];
+        let common_id = ids["Common"];
+
+        // Check A -> Common
+        assert!(
+            graph
+                .dependencies
+                .get(&a_id)
+                .is_some_and(|deps| deps.contains(&common_id)),
+            "A should depend on Common"
+        );
+
+        // Check B -> Common (Crucial: Must be the SAME common_id)
+        assert!(
+            graph
+                .dependencies
+                .get(&b_id)
+                .is_some_and(|deps| deps.contains(&common_id)),
+            "B should depend on Common"
+        );
+    }
+
+    #[test]
+    fn test_cyclic_dependency() {
+        // Setup: A <-> B cycle
+        // main -> imports A
+        // A -> imports B
+        // B -> imports A
+
+        let (graph, ids, _ws) = setup_graph(vec![
+            ("main.simf", "use lib::A::entry;"),
+            ("libs/lib/A.simf", "use lib::B::func;"),
+            ("libs/lib/B.simf", "use lib::A::func;"),
+        ]);
+
+        let a_id = ids["A"];
+        let b_id = ids["B"];
+
+        // Check if graph correctly recorded the cycle
+        assert!(
+            graph
+                .dependencies
+                .get(&a_id)
+                .is_some_and(|deps| deps.contains(&b_id)),
+            "A should depend on B"
+        );
+        assert!(
+            graph
+                .dependencies
+                .get(&b_id)
+                .is_some_and(|deps| deps.contains(&a_id)),
+            "B should depend on A"
+        );
+    }
+
+    #[test]
+    fn test_fails_on_unmapped_imports() {
+        // Setup: root imports from "unknown", which is not in our dependency map.
+        // We use `setup_graph_raw` because we expect graph generation to fail and
+        // emit an error, rather than panicking the standard test helper.
+        let (graph_option, _ids, _ws, handler) =
+            setup_graph_raw(vec![("main.simf", "use unknown::library::item;")]);
+
+        assert!(
+            graph_option.is_none(),
+            "Graph unexpectedly succeeded despite having an unknown import!"
+        );
+
+        assert!(
+            handler.has_errors(),
+            "The ErrorCollector should have logged an error about the unmapped import"
+        );
+    }
+
+    #[test]
+    fn test_new_bfs_traversal_state() {
+        // Goal: Verify that a simple chain (main -> a -> b) correctly pushes items
+        // into the vectors and builds the adjacency list in BFS order.
+
+        let (graph, ids, _ws) = setup_graph(vec![
+            ("main.simf", "use lib::A::mock_item;"),
+            ("libs/lib/A.simf", "use lib::B::mock_item;"),
+            ("libs/lib/B.simf", ""),
+        ]);
+
+        // Assert: Size checks
+        assert_eq!(graph.modules.len(), 3);
+        assert_eq!(graph.paths.len(), 3);
+
+        // Assert: Ensure BFS assigned the IDs in the exact correct order
+        let main_id = ids["main"];
+        let a_id = ids["A"];
+        let b_id = ids["B"];
+
+        assert_eq!(main_id, 0);
+        assert_eq!(a_id, 1);
+        assert_eq!(b_id, 2);
+
+        // Assert: Ensure the Adjacency List (dependencies map) linked them correctly
+        assert_eq!(
+            *graph.dependencies.get(&main_id).unwrap(),
+            vec![a_id],
+            "Main depends on A"
+        );
+        assert_eq!(
+            *graph.dependencies.get(&a_id).unwrap(),
+            vec![b_id],
+            "A depends on B"
+        );
+
+        // Check that B has no dependencies
+        let b_has_no_deps = graph
+            .dependencies
+            .get(&b_id)
+            .map_or(true, |deps| deps.is_empty());
+        assert!(b_has_no_deps, "B depends on nothing");
+    }
+}

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -1,4 +1,34 @@
+//! The `driver` module is responsible for module resolution and dependency management.
+//!
+//! Our compiler operates in a strict pipeline: `Lexer -> Parser -> Driver -> AST`.
+//! While the Parser only understands a single file at a time, the Driver processes
+//! multiple files, resolves their dependencies, and converts them into a unified
+//! structure ready for final AST construction.
+//!
+//! # Architecture
+//!
+//! ## Dependency Graph & Linearization
+//!
+//! The driver parses the root file and recursively discovers all imported modules
+//! to build a Directed Acyclic Graph (DAG) of the project's dependencies. Because
+//! the final AST requires a flat array of items, the driver applies a deterministic
+//! linearization strategy to this DAG. This safely flattens the multi-file project
+//! into a single, logically ordered sequence, strictly enforcing visibility rules
+//! and preventing duplicate imports.
+//!
+//! ## Project Structure & Entry Point
+//!
+//! SimplicityHL does not define a "project root" directory. Instead, the compiler
+//! relies on a single entry point: the file passed as the first positional argument.
+//! This file must contain the `main` function, which serves as the program's
+//! starting point.
+//!
+//! External libraries are explicitly linked using the `--dep` flag. The driver
+//! resolves and parses these external files relative to the entry point during
+//! the dependency graph construction.
+
 mod linearization;
+mod resolve_order;
 
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::PathBuf;

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -136,6 +136,7 @@ pub struct DependencyGraph {
     /// This serves as the exact inverse of the `lookup` map.
     paths: Vec<CanonPath>,
 
+    // TODO: Consider to optimising this with `Vec` instead of `HashMap`
     /// The Adjacency List: Defines the Directed acyclic Graph (DAG) of imports.
     ///
     /// The Key (`usize`) is the ID of a "Parent" module (the file doing the importing).

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -28,7 +28,7 @@
 //! the dependency graph construction.
 
 mod linearization;
-mod resolve_order;
+pub(crate) mod resolve_order;
 
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::PathBuf;
@@ -39,6 +39,14 @@ use chumsky::container::Container;
 use crate::error::{Error, ErrorCollector, RichError, Span};
 use crate::parse::{self, ParseFromStrWithErrors};
 use crate::resolution::{CanonPath, DependencyMap, SourceFile};
+
+pub use crate::driver::resolve_order::{FileScoped, Program, SymbolTable};
+
+/// The reserved identifier for the program's entry point.
+pub const MAIN_STR: &str = "main";
+
+/// The root node index in the [`DependencyGraph`] representing the entry file.
+pub const MAIN_MODULE: usize = 0;
 
 /// Caches the canonicalized path of a source file to prevent redundant,
 /// expensive, and potentially failing filesystem operations.
@@ -189,14 +197,13 @@ impl DependencyGraph {
             dependencies: HashMap::new(),
         };
 
-        let root_id = 0;
         graph
             .lookup
-            .insert(root_canon_source.name().clone(), root_id);
-        graph.dependencies.insert(root_id, Vec::new());
+            .insert(root_canon_source.name().clone(), MAIN_MODULE);
+        graph.dependencies.insert(MAIN_MODULE, Vec::new());
 
         let mut queue = VecDeque::new();
-        queue.push_back(root_id);
+        queue.push_back(MAIN_MODULE);
 
         // Prevent errors in the checked files from being doubled in the `load_and_parse_dependencies` function.
         let mut inalid_imports = HashSet::new();
@@ -338,7 +345,7 @@ impl DependencyGraph {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
     use crate::resolution::tests::canon;
     use crate::test_utils::TempWorkspace;

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -43,10 +43,10 @@ use crate::resolution::{CanonPath, DependencyMap, SourceFile};
 pub use crate::driver::resolve_order::{FileScoped, Program, SymbolTable};
 
 /// The reserved identifier for the program's entry point.
-pub const MAIN_STR: &str = "main";
+pub(crate) const MAIN_STR: &str = "main";
 
 /// The root node index in the [`DependencyGraph`] representing the entry file.
-pub const MAIN_MODULE: usize = 0;
+pub(crate) const MAIN_MODULE: usize = 0;
 
 /// Caches the canonicalized path of a source file to prevent redundant,
 /// expensive, and potentially failing filesystem operations.
@@ -120,7 +120,7 @@ struct Module {
 ///   `A` if `A` depends on `B`).
 /// * **Cycle Detection:** Preventing infinite compiler loops by ensuring no circular
 ///   imports exist before heavy semantic processing begins.
-pub struct DependencyGraph {
+pub(crate) struct DependencyGraph {
     /// Implements the Arena Pattern to act as the sole, centralized owner of all parsed modules.
     ///
     /// In C++ or Java, a graph would typically link dependencies using direct memory

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -1,3 +1,5 @@
+mod linearization;
+
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -44,6 +46,10 @@ impl CanonSourceFile {
 
     pub fn name(&self) -> &CanonPath {
         &self.name
+    }
+
+    pub fn str_name(&self) -> String {
+        self.name.as_path().display().to_string()
     }
 
     pub fn content(&self) -> Arc<str> {
@@ -326,7 +332,7 @@ mod tests {
     /// 3. `TempWorkspace`: The temporary directory instance. This must be kept in scope by the caller so
     ///    the OS doesn't delete the files before the test finishes.
     /// 4. `ErrorCollector`: The handler containing any logged errors, useful fo
-    fn setup_graph_raw(
+    pub(crate) fn setup_graph_raw(
         files: Vec<(&str, &str)>,
     ) -> (
         Option<DependencyGraph>,
@@ -414,7 +420,7 @@ mod tests {
     ///
     /// This function will immediately panic and print the collected errors
     /// to standard error if the parser or graph builder encounters any issues.
-    fn setup_graph(
+    pub(crate) fn setup_graph(
         files: Vec<(&str, &str)>,
     ) -> (DependencyGraph, HashMap<String, usize>, TempWorkspace) {
         let (graph_option, file_ids, ws, handler) = setup_graph_raw(files);

--- a/src/driver/resolve_order.rs
+++ b/src/driver/resolve_order.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 use crate::driver::DependencyGraph;
 use crate::error::{Error, ErrorCollector, RichError, Span};
 use crate::impl_eq_hash;
-use crate::parse::{self, AliasedIdentifier, Visibility};
-use crate::resolution::CanonPath;
+use crate::parse::{self, AliasedSymbolName, Visibility};
+use crate::str::{AliasName, FunctionName, SymbolName};
 
 /// The final, flattened representation of a SimplicityHL program.
 ///
@@ -16,10 +16,11 @@ pub struct Program {
     /// The linear sequence of compiled items (`Functions`, `TypeAliases`, etc.).
     items: Arc<[parse::Item]>,
 
-    /// The files that make up this program, along with their scoping rules.
-    files: Arc<[ResolvedFile]>,
+    /// Contains all resolved aliases for the local scopes and the global import registry.
+    aliases: SymbolTable<AliasName>,
 
-    import_aliases: AliasRegistry,
+    /// Contains all resolved functions for the local scopes and the global import registry.
+    functions: SymbolTable<FunctionName>,
 
     span: Span,
 }
@@ -29,12 +30,12 @@ impl Program {
         &self.items
     }
 
-    pub fn files(&self) -> &[ResolvedFile] {
-        &self.files
+    pub fn aliases(&self) -> &SymbolTable<AliasName> {
+        &self.aliases
     }
 
-    pub fn import_aliases(&self) -> &AliasRegistry {
-        &self.import_aliases
+    pub fn functions(&self) -> &SymbolTable<FunctionName> {
+        &self.functions
     }
 
     pub fn span(&self) -> &Span {
@@ -42,60 +43,58 @@ impl Program {
     }
 }
 
-impl_eq_hash!(Program; items, files, import_aliases);
+impl_eq_hash!(Program; items, aliases, functions);
 
-/// Represents a single source file alongside its resolved scoping and visibility rules.
+/// Holds all scoping and import data for a specific namespace (e.g., Functions or Aliases).
 #[derive(Clone, Debug)]
-pub struct ResolvedFile {
-    path: CanonPath,
+pub struct SymbolTable<T> {
+    /// The items available in each file's local scope.
+    /// The index of the array corresponds to the file ID.
+    local_scopes: Arc<[BTreeSet<T>]>,
 
-    /// The set of resolved item names available within this file's scope.
-    // Use BTreeSet instead of HashMap for the impl_eq_hash! macro.
-    resolutions: BTreeSet<Arc<str>>,
+    /// The cross-file import mappings and cached roots.
+    imports: ImportRegistry<T>,
 }
 
-impl ResolvedFile {
-    pub fn path(&self) -> &CanonPath {
-        &self.path
+impl<T> SymbolTable<T> {
+    pub fn local_scopes(&self) -> &[BTreeSet<T>] {
+        &self.local_scopes
     }
 
-    pub fn resolutions(&self) -> &BTreeSet<Arc<str>> {
-        &self.resolutions
+    pub fn imports(&self) -> &ImportRegistry<T> {
+        &self.imports
     }
 }
 
-impl_eq_hash!(ResolvedFile; path, resolutions);
+impl_eq_hash!(SymbolTable<T>; local_scopes, imports);
 
-/// A registry mapping an alias [`ItemNameWithFileId`] to its target item across different files.
+/// Represents an item name alongside its originating file ID.
+pub type FileScoped<T> = (T, usize);
+
+/// A registry mapping an alias [`FileScoped<T>`] to its target item across different files.
 ///
 /// We use a type alias here to provide a convenient abstraction for the `AST::analyze`
 /// phase, making it easier to modify the underlying structure in the future if needed.
-pub type AliasMap = BTreeMap<ItemNameWithFileId, ItemNameWithFileId>;
-pub type ItemNameWithFileId = (Arc<str>, usize);
+pub type ImportMap<T> = BTreeMap<FileScoped<T>, FileScoped<T>>;
 
 /// Manages the resolution of import aliases across the entire program.
 #[derive(Clone, Debug, Default)]
-pub struct AliasRegistry {
-    /// Maps an alias to its immediate target.
-    /// (e.g., `use B as C;` stores C -> B)
-    direct_targets: AliasMap,
-
-    /// Caches the final, original definition of an alias to avoid walking the chain.
-    /// (e.g., If C -> B and B -> A, this stores C -> A)
-    resolved_roots: AliasMap,
+pub struct ImportRegistry<T> {
+    direct_targets: ImportMap<T>,
+    resolved_roots: ImportMap<T>,
 }
 
-impl AliasRegistry {
-    pub fn direct_targets(&self) -> &AliasMap {
+impl<T> ImportRegistry<T> {
+    pub fn direct_targets(&self) -> &ImportMap<T> {
         &self.direct_targets
     }
 
-    pub fn resolved_roots(&self) -> &AliasMap {
+    pub fn resolved_roots(&self) -> &ImportMap<T> {
         &self.resolved_roots
     }
 }
 
-impl_eq_hash!(AliasRegistry; direct_targets, resolved_roots);
+impl_eq_hash!(ImportRegistry<T>; direct_targets, resolved_roots);
 
 /// This is a core component of the [`DependencyGraph`].
 impl DependencyGraph {
@@ -113,10 +112,9 @@ impl DependencyGraph {
     /// Constructs the unified AST for the entire program.
     fn build_program(&self, order: &[usize], handler: &mut ErrorCollector) -> Option<Program> {
         let mut items: Vec<parse::Item> = Vec::new();
-        let mut resolutions: Vec<HashMap<Arc<str>, Visibility>> =
-            vec![HashMap::new(); self.modules.len()];
-        let mut import_aliases = AliasRegistry::default();
-        let mut items_registry = BTreeSet::<ItemNameWithFileId>::new();
+
+        let mut aliases = NamespaceTracker::<AliasName>::new(self.modules.len());
+        let mut functions = NamespaceTracker::<FunctionName>::new(self.modules.len());
 
         for &source_id in order {
             let module = &self.modules[source_id];
@@ -141,162 +139,247 @@ impl DependencyGraph {
                     };
 
                     for aliased_item in use_decl_items {
-                        if let Err(err) = Self::process_use_item(
-                            &mut items_registry,
-                            &mut import_aliases,
-                            &mut resolutions,
+                        let alias_err = Self::process_use_item(
+                            &mut aliases,
                             source_id,
                             ind,
                             aliased_item,
                             use_decl,
-                        ) {
+                        );
+
+                        let function_err = Self::process_use_item(
+                            &mut functions,
+                            source_id,
+                            ind,
+                            aliased_item,
+                            use_decl,
+                        );
+
+                        if let Err(err) =
+                            Self::resolve_processing_use_items_error(alias_err, function_err)
+                        {
                             handler.push(err.with_source(source.clone()));
                         }
                     }
                     continue;
                 }
 
-                // Handle Types & Functions
-                let (name, vis, span) = match elem {
-                    parse::Item::TypeAlias(a) => (a.name().as_inner(), a.visibility(), *a.span()),
-                    parse::Item::Function(f) => (f.name().as_inner(), f.visibility(), *f.span()),
+                items.push(elem.clone());
+
+                // Handle Types & Functions by inserting them into their STRICT namespaces
+                // Architectural Note:
+                // The code may seem duplicated. To prevent this, the best approach
+                // would be to add a `NamedItem` trait. However, doing so would require
+                // duplicating getter methods for both `Function` and `TypeAlias`.
+                // As a result, it is better to leave it as is.
+                match elem {
+                    parse::Item::TypeAlias(type_alias) => {
+                        let name = type_alias.name();
+                        let local_id = (name.clone(), source_id);
+
+                        if aliases.memo.contains(&local_id) {
+                            handler.push(
+                                RichError::new(
+                                    Error::RedefinedAlias(name.clone()),
+                                    *type_alias.span(),
+                                )
+                                .with_source(source.clone()),
+                            );
+                        }
+                        aliases.memo.insert(local_id);
+                        aliases.resolutions[source_id]
+                            .insert(name.clone(), type_alias.visibility().clone());
+                    }
+                    parse::Item::Function(function) => {
+                        let name = function.name();
+                        let local_id = (name.clone(), source_id);
+
+                        if functions.memo.contains(&local_id) {
+                            handler.push(
+                                RichError::new(
+                                    Error::FunctionRedefined(name.clone()),
+                                    *function.span(),
+                                )
+                                .with_source(source.clone()),
+                            );
+                        }
+                        functions.memo.insert(local_id);
+                        functions.resolutions[source_id]
+                            .insert(name.clone(), function.visibility().clone());
+                    }
 
                     // Safe to skip: `Use` items are handled earlier in the loop, and `Module` currently has no functionality.
                     parse::Item::Module | parse::Item::Use(_) => continue,
-                };
-
-                let item_name = (Arc::from(name), source_id);
-                if items_registry.contains(&item_name) {
-                    handler.push(
-                        RichError::new(Error::RedefinedItem(name.to_string()), span)
-                            .with_source(source.clone()),
-                    );
                 }
-                items_registry.insert(item_name);
-
-                items.push(elem.clone());
-                resolutions[source_id].insert(Arc::from(name), vis.clone());
             }
         }
 
         (!handler.has_errors()).then(|| Program {
             items: items.into(),
-            files: construct_resolved_file_array(&self.paths, &resolutions),
-            import_aliases,
+            aliases: aliases.into_symbol_table(),
+            functions: functions.into_symbol_table(),
             span: *self.modules[0].parsed_program.as_ref(),
         })
     }
 
-    /// Processes a single imported item (or alias) during the module resolution phase.
+    /// Attempts to pick the most helpful error when an import fails in both namespaces.
     ///
-    /// This function verifies that the requested item exists in the source module and
-    /// that it has the appropriate public visibility to be imported. If validation passes,
-    /// the item is registered in the importing module's resolution table and global alias registry.
+    /// Since SimplicityHL supports separated namespaces, a single `use` statement
+    /// may successfully load a `Function`, a `TypeAlias`, or both simultaneously.
+    fn resolve_processing_use_items_error(
+        alias: Result<(), RichError>,
+        function: Result<(), RichError>,
+    ) -> Result<(), RichError> {
+        match (alias, function) {
+            (Ok(()), _) | (_, Ok(())) => Ok(()),
+
+            (Err(err_alias), Err(err_func)) => {
+                let alias_is_missing = matches!(err_alias.error(), Error::UnresolvedItem(_));
+                let func_is_missing = matches!(err_func.error(), Error::UnresolvedItem(_));
+
+                if !alias_is_missing || func_is_missing {
+                    // If it's missing everywhere, OR if the function is missing
+                    // but the alias has a specific error (like PrivateItem).
+                    Err(err_alias)
+                } else {
+                    Err(err_func)
+                }
+            }
+        }
+    }
+
+    /// Processes a single imported item (or alias) and registers it within a specific namespace.
+    ///
+    /// This function verifies that the requested item exists in the source module and has the appropriate public
+    /// visibility. If validation passes and no local naming collisions are found, the item is registered
+    /// in the destination module's local scope and the global import registry.
     ///
     /// # Arguments
     ///
-    /// * `import_aliases` - The global registry tracking alias chains and their canonical roots.
-    /// * `resolutions` - The global, mutable array mapping each `file_id` to its localized `FileResolutions` table.
-    /// * `source_id` - The `usize` identifier of the destination source.
+    /// * `namespace` - The generic tracker (e.g., for Functions or Aliases) that holds
+    ///   the local file scopes, the global import registry, and the memoization set to prevent collisions.
+    /// * `source_id` - The `usize` identifier of the destination module where the item is being imported *to*.
     /// * `ind` - The unique identifier of the source module being imported *from*.
-    /// * `aliased_identifier` - The specific identifier (and potential alias) being imported from the source.
+    /// * `aliased_symbol_name` - The specific identifier (and potential alias) being imported from the source.
     /// * `use_decl` - The node of the `use` statement. This dictates the visibility of the new import
     ///   (e.g., `pub use` re-exports the item publicly).
     ///
     /// # Returns
     ///
-    /// Returns `None` on success. Returns `Some(RichError)` if:
-    /// * [`Error::UnresolvedItem`]: The target `elem` does not exist in the source module (`ind`).
-    /// * [`Error::PrivateItem`]: The target exists, but its visibility is explicitly `Private`,
-    /// * [`Error::DuplicateAlias`]: The target `alias` (or imported name) has already been used in the current module.
-    fn process_use_item(
-        items_registry: &mut BTreeSet<ItemNameWithFileId>,
-        import_aliases: &mut AliasRegistry,
-        resolutions: &mut [HashMap<Arc<str>, Visibility>],
+    /// Returns `Ok(())` on success. Returns `Err(RichError)` if:
+    /// * [`Error::UnresolvedItem`]: The target name does not exist in the source module (`ind`).
+    /// * [`Error::PrivateItem`]: The target exists, but its visibility is explicitly `Private`.
+    /// * [`Error::DuplicateAlias`]: The local name (or alias) has already been used in another import statement.
+    /// * [`Error::RedefinedItem`]: The local name conflicts with an existing item already defined in this module.
+    fn process_use_item<T>(
+        namespace: &mut NamespaceTracker<T>,
         source_id: usize,
         ind: usize,
-        (name, alias): &AliasedIdentifier,
+        (name, alias): &AliasedSymbolName,
         use_decl: &parse::UseDecl,
-    ) -> Result<(), RichError> {
+    ) -> Result<(), RichError>
+    where
+        T: From<SymbolName> + std::fmt::Display + Clone + Eq + std::hash::Hash + std::cmp::Ord,
+    {
         // NOTE: The order of errors is important!
         let span = *use_decl.span();
 
-        let name: Arc<str> = Arc::from(name.as_inner());
-        let orig_id = (name.clone(), ind);
+        // 1. Convert the unresolved SymbolName into our strict type T
+        let target_name: T = name.clone().into();
+        let orig_id = (target_name.clone(), ind);
 
-        // 1. Verify Existence: Does the item exist in the source file?
-        let visibility = resolutions[ind]
-            .get(&name)
+        // 2. Verify Existence using T
+        let visibility = namespace.resolutions[ind]
+            .get(&target_name)
             .ok_or_else(|| RichError::new(Error::UnresolvedItem(name.to_string()), span))?;
 
-        // 2. Verify Visibility: Are we allowed to see it?
+        // 3. Verify Visibility
         if matches!(visibility, parse::Visibility::Private) {
             return Err(RichError::new(Error::PrivateItem(name.to_string()), span));
         }
 
-        // 3. Determine the local name and ID up front
-        let local_name = if let Some(alias) = alias {
-            Arc::from(alias.as_inner())
-        } else {
-            name.clone()
-        };
+        // 4. Determine the local name and ID up front
+        // We figure out the raw symbol first, so we can use it for error messages
+        let local_symbol = alias.as_ref().unwrap_or(name);
+
+        // Then convert that raw symbol to T
+        let local_name: T = local_symbol.clone().into();
         let local_id = (local_name.clone(), source_id);
 
-        // 4. Check for collisions
-        if import_aliases.direct_targets.contains_key(&local_id) {
+        // 5. Check for collisions using `namespace` fields
+        if namespace.registry.direct_targets.contains_key(&local_id) {
             return Err(RichError::new(
-                Error::DuplicateAlias(local_name.to_string()),
+                Error::DuplicateAlias(local_symbol.to_string()),
                 span,
             ));
         }
 
-        if items_registry.contains(&local_id) {
+        if namespace.memo.contains(&local_id) {
             return Err(RichError::new(
-                Error::RedefinedItem(local_name.to_string()),
+                Error::RedefinedItem(local_symbol.to_string()),
                 span,
             ));
         }
-        items_registry.insert(local_id.clone());
+        namespace.memo.insert(local_id.clone());
 
-        // 5. Update the registers
-        import_aliases
+        // 6. Update the registers
+        namespace
+            .registry
             .direct_targets
             .insert(local_id.clone(), orig_id.clone());
 
-        // 6. Find the true root using a single lookup!
-        // If `orig_id` exists in resolved_roots, it means it's an alias and we get its true root.
-        // If it returns None, it means `orig_id` is the original item, so it IS the root.
-        let true_root = import_aliases
+        // 7. Find the true root
+        let true_root = namespace
+            .registry
             .resolved_roots
             .get(&orig_id)
             .cloned()
             .unwrap_or_else(|| orig_id.clone());
 
-        // Always cache the final root for instant O(1) lookups later
-        import_aliases.resolved_roots.insert(local_id, true_root);
+        namespace
+            .registry
+            .resolved_roots
+            .insert(local_id, true_root);
 
-        // 7. Register the item in the local  module's namespace
-        resolutions[source_id].insert(local_name, use_decl.visibility().clone());
+        // 8. Register the item in the local module's namespace
+        namespace.resolutions[source_id].insert(local_name, use_decl.visibility().clone());
         Ok(())
     }
 }
 
-fn construct_resolved_file_array(
-    paths: &[CanonPath],
-    resolutions: &[HashMap<Arc<str>, Visibility>],
-) -> Arc<[ResolvedFile]> {
-    let mut result = Vec::with_capacity(paths.len());
+/// Helper struct, that tracks the resolution state, imports, and memoization for a single namespace.
+#[derive(Clone, Debug)]
+struct NamespaceTracker<T> {
+    /// Local resolutions per file.
+    resolutions: Vec<HashMap<T, Visibility>>,
 
-    for i in 0..paths.len() {
-        let file_resolutions: BTreeSet<Arc<str>> = resolutions[i].keys().cloned().collect();
+    /// Global registry for `use` imports and aliasing.
+    registry: ImportRegistry<T>,
 
-        result.push(ResolvedFile {
-            path: paths[i].clone(),
-            resolutions: file_resolutions,
-        });
+    /// Tracks processed items to prevent infinite loops or redefinitions.
+    memo: BTreeSet<FileScoped<T>>,
+}
+
+impl<T: Ord + Clone + Default + std::hash::Hash> NamespaceTracker<T> {
+    pub fn new(module_count: usize) -> Self {
+        Self {
+            resolutions: vec![HashMap::new(); module_count],
+            registry: ImportRegistry::<T>::default(),
+            memo: BTreeSet::new(),
+        }
     }
 
-    result.into()
+    pub fn into_symbol_table(self) -> SymbolTable<T> {
+        SymbolTable {
+            local_scopes: self
+                .resolutions
+                .into_iter()
+                .map(|map| map.into_keys().collect::<BTreeSet<_>>())
+                .collect::<Vec<_>>()
+                .into(),
+            imports: self.registry,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -323,14 +406,14 @@ mod resolve_order_tests {
         };
 
         let root_id = ids["main"];
-        let resolutions = &program.files[root_id].resolutions;
+        let resolutions = &program.functions.local_scopes[root_id];
 
         resolutions
-            .get(&Arc::from("private_fn"))
+            .get(&FunctionName::from_str_unchecked("private_fn"))
             .expect("private_fn missing");
 
         resolutions
-            .get(&Arc::from("public_fn"))
+            .get(&FunctionName::from_str_unchecked("public_fn"))
             .expect("public_fn missing");
     }
 
@@ -359,15 +442,13 @@ mod resolve_order_tests {
         let id_root = ids["main"];
 
         // Check B's scope
-        program.files[id_b]
-            .resolutions
-            .get(&Arc::from("foo"))
+        program.functions.local_scopes[id_b]
+            .get(&FunctionName::from_str_unchecked("foo"))
             .expect("foo missing in B");
 
         // Check Root's scope
-        program.files[id_root]
-            .resolutions
-            .get(&Arc::from("foo"))
+        program.functions.local_scopes[id_root]
+            .get(&FunctionName::from_str_unchecked("foo"))
             .expect("foo missing in Root");
     }
 
@@ -392,9 +473,59 @@ mod resolve_order_tests {
             program_option.is_none(),
             "Build should fail and return None when importing a private binding"
         );
+
         assert!(error_handler
             .to_string()
             .contains(&"Item `foo` is private".to_string()));
+    }
+
+    #[test]
+    fn test_separated_type_aliases_and_functions() {
+        let (graph, ids, _dir) = setup_graph(vec![
+            ("libs/lib/A.simf", "pub type bar = u32; pub fn bar() {}"),
+            ("main.simf", "use lib::A::bar;"),
+        ]);
+
+        let mut error_handler = ErrorCollector::new();
+        let program_option = graph.linearize_and_build(&mut error_handler).unwrap();
+
+        let Some(program) = program_option else {
+            panic!("{}", error_handler);
+        };
+
+        let root_id = ids["main"];
+
+        // Check B's scope
+        program.functions.local_scopes[root_id]
+            .get(&FunctionName::from_str_unchecked("bar"))
+            .expect("Function bar missing in main");
+
+        // Check Root's scope
+        program.aliases.local_scopes[root_id]
+            .get(&AliasName::from_str_unchecked("bar"))
+            .expect("Type alias missing in main");
+    }
+
+    #[test]
+    fn test_private_alias_error_does_not_mask_duplicate_function_import() {
+        // Scenario:
+        // main.simf: load function `foo` from A.simf.
+        // Then try to load both `fn foo` and `type foo`.
+        // However, we have already loade `fn foo` and `type foo` is private, so an error occurs.
+        let (graph, _ids, _dir) = setup_graph(vec![
+            ("libs/lib/A.simf", "pub fn foo() {}"),
+            ("libs/lib/B.simf", "pub fn foo() {} type foo = u32;"),
+            ("main.simf", "use lib::A::foo; use lib::B::foo;"),
+        ]);
+
+        let mut error_handler = ErrorCollector::new();
+        let program_option = graph.linearize_and_build(&mut error_handler).unwrap();
+        let _errors = error_handler.to_string();
+
+        assert!(
+            program_option.is_none(),
+            "build should fail when a second import reuses the function name `foo`"
+        );
     }
 }
 
@@ -402,7 +533,6 @@ mod resolve_order_tests {
 mod alias_tests {
     use super::*;
     use crate::driver::tests::setup_graph;
-    use std::sync::Arc;
 
     #[test]
     fn test_renaming_with_use() {
@@ -423,14 +553,18 @@ mod alias_tests {
         };
 
         let id_root = ids["main"];
-        let scope = &program.files[id_root].resolutions;
+        let scope = &program.functions.local_scopes[id_root];
 
         assert!(
-            scope.get(&Arc::from("foo")).is_none(),
+            scope
+                .get(&FunctionName::from_str_unchecked("foo"))
+                .is_none(),
             "Original name 'foo' should not be in scope"
         );
         assert!(
-            scope.get(&Arc::from("bar")).is_some(),
+            scope
+                .get(&FunctionName::from_str_unchecked("bar"))
+                .is_some(),
             "Alias 'bar' should be in scope"
         );
     }
@@ -451,15 +585,23 @@ mod alias_tests {
         };
 
         let id_root = ids["main"];
-        let scope = &program.files[id_root].resolutions;
+        let scope = &program.functions.local_scopes[id_root];
 
         // The original names should NOT be in scope
-        assert!(scope.get(&Arc::from("foo")).is_none());
-        assert!(scope.get(&Arc::from("baz")).is_none());
+        assert!(scope
+            .get(&FunctionName::from_str_unchecked("foo"))
+            .is_none());
+        assert!(scope
+            .get(&FunctionName::from_str_unchecked("baz"))
+            .is_none());
 
         // The aliases MUST be in scope
-        assert!(scope.get(&Arc::from("bar")).is_some());
-        assert!(scope.get(&Arc::from("qux")).is_some());
+        assert!(scope
+            .get(&FunctionName::from_str_unchecked("bar"))
+            .is_some());
+        assert!(scope
+            .get(&FunctionName::from_str_unchecked("qux"))
+            .is_some());
     }
 
     #[test]
@@ -506,18 +648,26 @@ mod alias_tests {
         let id_root = ids["main"];
 
         // Assert Main Scope
-        let main_scope = &program.files[id_root].resolutions;
-        assert!(main_scope.get(&Arc::from("original")).is_none());
-        assert!(main_scope.get(&Arc::from("middle")).is_none());
+        let main_scope = &program.functions.local_scopes[id_root];
+        assert!(main_scope
+            .get(&FunctionName::from_str_unchecked("original"))
+            .is_none());
+        assert!(main_scope
+            .get(&FunctionName::from_str_unchecked("middle"))
+            .is_none());
         assert!(
-            main_scope.get(&Arc::from("final_name")).is_some(),
+            main_scope
+                .get(&FunctionName::from_str_unchecked("final_name"))
+                .is_some(),
             "Main must see the final alias"
         );
 
         // Assert B Scope (It should have the intermediate alias!)
-        let b_scope = &program.files[id_b].resolutions;
+        let b_scope = &program.functions.local_scopes[id_b];
         assert!(
-            b_scope.get(&Arc::from("middle")).is_some(),
+            b_scope
+                .get(&FunctionName::from_str_unchecked("middle"))
+                .is_some(),
             "File B must contain its own public alias"
         );
     }
@@ -658,7 +808,7 @@ mod alias_tests {
     }
 
     #[test]
-    fn test_local_definition_cannot_reuse_alias_name() {
+    fn test_local_function_cannot_reuse_alias_name() {
         let (graph, _ids, _dir) = setup_graph(vec![
             ("libs/lib/A.simf", "pub fn bar() {}"),
             ("main.simf", "use lib::A::bar as foo; pub fn foo() {}"),
@@ -671,10 +821,34 @@ mod alias_tests {
             program_option.is_none(),
             "build should fail when a local definition reuses an alias name"
         );
+
         assert!(
             error_handler
                 .to_string()
-                .contains("Item `foo` was defined multiple times"),
+                .contains("Function `foo` was defined multiple times"),
+            "expected a redefined-item diagnostic"
+        );
+    }
+
+    #[test]
+    fn test_local_type_alias_cannot_reuse_alias_name() {
+        let (graph, _ids, _dir) = setup_graph(vec![
+            ("libs/lib/A.simf", "pub type bar = u32;"),
+            ("main.simf", "use lib::A::bar as foo; type foo = u64;"),
+        ]);
+
+        let mut error_handler = ErrorCollector::new();
+        let program_option = graph.linearize_and_build(&mut error_handler).unwrap();
+
+        assert!(
+            program_option.is_none(),
+            "build should fail when a local definition reuses an alias name"
+        );
+
+        assert!(
+            error_handler
+                .to_string()
+                .contains("Type alias `foo` was defined multiple times"),
             "expected a redefined-item diagnostic"
         );
     }

--- a/src/driver/resolve_order.rs
+++ b/src/driver/resolve_order.rs
@@ -1,0 +1,291 @@
+use std::collections::{BTreeSet, HashMap};
+use std::sync::Arc;
+
+use crate::driver::DependencyGraph;
+use crate::error::{Error, ErrorCollector, RichError, Span};
+use crate::impl_eq_hash;
+use crate::parse::{self, Visibility};
+use crate::resolution::CanonPath;
+
+/// The final, flattened representation of a SimplicityHL program.
+///
+/// This struct holds the fully resolved sequence of items, paths, and scope
+/// resolutions, ready to be passed to the next stage of the compiler.
+#[derive(Clone, Debug)]
+pub struct Program {
+    /// The linear sequence of compiled items (`Functions`, `TypeAliases`, etc.).
+    items: Arc<[parse::Item]>,
+
+    /// The files that make up this program, along with their scoping rules.
+    files: Arc<[ResolvedFile]>,
+
+    span: Span,
+}
+
+impl Program {
+    pub fn items(&self) -> &[parse::Item] {
+        &self.items
+    }
+
+    pub fn files(&self) -> &[ResolvedFile] {
+        &self.files
+    }
+
+    pub fn span(&self) -> &Span {
+        &self.span
+    }
+}
+
+impl_eq_hash!(Program; items, files);
+
+/// Represents a single source file alongside its resolved scoping and visibility rules.
+#[derive(Clone, Debug)]
+pub struct ResolvedFile {
+    path: CanonPath,
+
+    /// The set of resolved item names available within this file's scope.
+    // Use BTreeSet instead of HashMap for the impl_eq_hash! macro.
+    resolutions: BTreeSet<Arc<str>>,
+}
+
+impl ResolvedFile {
+    pub fn path(&self) -> &CanonPath {
+        &self.path
+    }
+
+    pub fn resolutions(&self) -> &BTreeSet<Arc<str>> {
+        &self.resolutions
+    }
+}
+
+impl_eq_hash!(ResolvedFile; path, resolutions);
+
+/// This is a core component of the [`DependencyGraph`].
+impl DependencyGraph {
+    /// Resolves the dependency graph and constructs the final AST program.
+    pub fn linearize_and_build(
+        &self,
+        handler: &mut ErrorCollector,
+    ) -> Result<Option<Program>, String> {
+        match self.linearize() {
+            Ok(order) => Ok(self.build_program(&order, handler)),
+            Err(err) => Err(err.to_string()),
+        }
+    }
+
+    /// Constructs the unified AST for the entire program.
+    fn build_program(&self, order: &[usize], handler: &mut ErrorCollector) -> Option<Program> {
+        let mut items: Vec<parse::Item> = Vec::new();
+        let mut resolutions: Vec<HashMap<Arc<str>, Visibility>> =
+            vec![HashMap::new(); self.modules.len()];
+
+        for &source_id in order {
+            let module = &self.modules[source_id];
+            let source = &module.source;
+
+            for elem in module.parsed_program.items() {
+                // Handle Uses (Early Continue flattens the nesting)
+                if let parse::Item::Use(use_decl) = elem {
+                    let resolve_path =
+                        match self.dependency_map.resolve_path(source.name(), use_decl) {
+                            Ok(path) => path,
+                            Err(err) => {
+                                handler.push(err.with_source(source.clone()));
+                                continue;
+                            }
+                        };
+
+                    let ind = self.lookup[&resolve_path];
+                    let use_decl_items = match use_decl.items() {
+                        parse::UseItems::Single(elem) => std::slice::from_ref(elem),
+                        parse::UseItems::List(elems) => elems.as_slice(),
+                    };
+
+                    for item in use_decl_items {
+                        if let Err(err) = Self::process_use_item(
+                            &mut resolutions,
+                            source_id,
+                            ind,
+                            Arc::from(item.as_inner()),
+                            use_decl,
+                        ) {
+                            handler.push(err.with_source(source.clone()));
+                        }
+                    }
+                    continue;
+                }
+
+                // Handle Types & Functions
+                let (name, vis) = match elem {
+                    parse::Item::TypeAlias(a) => (a.name().as_inner(), a.visibility()),
+                    parse::Item::Function(f) => (f.name().as_inner(), f.visibility()),
+
+                    // Safe to skip: `Use` items are handled earlier in the loop, and `Module` currently has no functionality.
+                    parse::Item::Module | parse::Item::Use(_) => continue,
+                };
+
+                items.push(elem.clone());
+                resolutions[source_id].insert(Arc::from(name), vis.clone());
+            }
+        }
+
+        (!handler.has_errors()).then(|| Program {
+            items: items.into(),
+            files: construct_resolved_file_array(&self.paths, &resolutions),
+            span: *self.modules[0].parsed_program.as_ref(),
+        })
+    }
+
+    /// Processes a single imported item during the module resolution phase.
+    ///
+    /// # Arguments
+    ///
+    /// * `resolutions` - A mutable slice of hash maps, where each index corresponds to a module's ID and holds its resolved items and their visibilities.
+    /// * `source_id` - The `usize` identifier of the destination source.
+    /// * `ind` - The unique identifier (`usize`) of the source module being imported *from*.
+    /// * `name` - The specific item name (`Arc<str>`) being imported from the source.
+    /// * `use_decl` - The AST node of the `use` statement. This dictates the visibility of the newly imported item in the destination module.
+    ///
+    /// # Returns
+    ///
+    /// Returns `None` on success. Returns `Some(RichError)` if:
+    /// * [`Error::UnresolvedItem`]: The target `name` does not exist in the source module (`ind`).
+    /// * [`Error::PrivateItem`]: The target exists in the source module, but its visibility is expl
+    fn process_use_item(
+        resolutions: &mut [HashMap<Arc<str>, Visibility>],
+        source_id: usize,
+        ind: usize,
+        name: Arc<str>,
+        use_decl: &parse::UseDecl,
+    ) -> Result<(), RichError> {
+        let span = *use_decl.span();
+
+        let visibility = resolutions[ind]
+            .get(&name)
+            .ok_or_else(|| RichError::new(Error::UnresolvedItem(name.to_string()), span))?;
+
+        if matches!(visibility, parse::Visibility::Private) {
+            return Err(RichError::new(Error::PrivateItem(name.to_string()), span));
+        }
+
+        resolutions[source_id].insert(name, use_decl.visibility().clone());
+        Ok(())
+    }
+}
+
+fn construct_resolved_file_array(
+    paths: &[CanonPath],
+    resolutions: &[HashMap<Arc<str>, Visibility>],
+) -> Arc<[ResolvedFile]> {
+    let mut result = Vec::with_capacity(paths.len());
+
+    for i in 0..paths.len() {
+        let file_resolutions: BTreeSet<Arc<str>> = resolutions[i].keys().cloned().collect();
+
+        result.push(ResolvedFile {
+            path: paths[i].clone(),
+            resolutions: file_resolutions,
+        });
+    }
+
+    result.into()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::driver::tests::setup_graph;
+
+    use super::*;
+
+    #[test]
+    fn test_local_definitions_visibility() {
+        // main.simf defines a private function and a public function.
+        // Expected: Both should appear in the scope with correct visibility.
+
+        let (graph, ids, _dir) = setup_graph(vec![(
+            "main.simf",
+            "fn private_fn() {} pub fn public_fn() {}",
+        )]);
+
+        let mut error_handler = ErrorCollector::new();
+        let program_option = graph.linearize_and_build(&mut error_handler).unwrap();
+
+        let Some(program) = program_option else {
+            panic!("{}", error_handler);
+        };
+
+        let root_id = ids["main"];
+        let resolutions = &program.files[root_id].resolutions;
+
+        resolutions
+            .get(&Arc::from("private_fn"))
+            .expect("private_fn missing");
+
+        resolutions
+            .get(&Arc::from("public_fn"))
+            .expect("public_fn missing");
+    }
+
+    #[test]
+    fn test_pub_use_propagation() {
+        // Scenario: Re-exporting.
+        // 1. A.simf defines `pub fn foo`.
+        // 2. B.simf imports it and re-exports it via `pub use`.
+        // 3. main.simf imports it from B.
+        // Expected: B's scope must contain `foo` marked as Public.
+
+        let (graph, ids, _dir) = setup_graph(vec![
+            ("libs/lib/A.simf", "pub fn foo() {}"),
+            ("libs/lib/B.simf", "pub use lib::A::foo;"),
+            ("main.simf", "use lib::B::foo;"),
+        ]);
+
+        let mut error_handler = ErrorCollector::new();
+        let program_option = graph.linearize_and_build(&mut error_handler).unwrap();
+
+        let Some(program) = program_option else {
+            panic!("{}", error_handler);
+        };
+
+        let id_b = ids["B"];
+        let id_root = ids["main"];
+
+        // Check B's scope
+        program.files[id_b]
+            .resolutions
+            .get(&Arc::from("foo"))
+            .expect("foo missing in B");
+
+        // Check Root's scope
+        program.files[id_root]
+            .resolutions
+            .get(&Arc::from("foo"))
+            .expect("foo missing in Root");
+    }
+
+    #[test]
+    fn test_private_import_encapsulation_error() {
+        // Scenario: Access violation.
+        // 1. A.simf defines `pub fn foo`.
+        // 2. B.simf imports it via `use` (Private import).
+        // 3. main.simf tries to import `foo` from B.
+        // Expected: Error, because B did not re-export foo.
+
+        let (graph, _ids, _dir) = setup_graph(vec![
+            ("libs/lib/A.simf", "pub fn foo() {}"),
+            ("libs/lib/B.simf", "use lib::A::foo;"), // <--- Private binding!
+            ("main.simf", "use lib::B::foo;"),       // <--- Should fail
+        ]);
+
+        let mut error_handler = ErrorCollector::new();
+        let program_option = graph.linearize_and_build(&mut error_handler).unwrap();
+
+        assert!(
+            program_option.is_none(),
+            "Build should fail and return None when importing a private binding"
+        );
+        assert!(error_handler
+            .to_string()
+            .contains(&"Item `foo` is private".to_string()));
+    }
+}

--- a/src/driver/resolve_order.rs
+++ b/src/driver/resolve_order.rs
@@ -1,10 +1,10 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::sync::Arc;
 
-use crate::driver::DependencyGraph;
+use crate::driver::{DependencyGraph, MAIN_MODULE, MAIN_STR};
 use crate::error::{Error, ErrorCollector, RichError, Span};
 use crate::impl_eq_hash;
-use crate::parse::{self, AliasedSymbolName, Visibility};
+use crate::parse::{self, AliasedSymbolName, Function, TypeAlias, Visibility};
 use crate::str::{AliasName, FunctionName, SymbolName};
 
 /// The final, flattened representation of a SimplicityHL program.
@@ -26,6 +26,58 @@ pub struct Program {
 }
 
 impl Program {
+    pub fn from_parse(
+        parsed: &parse::Program,
+        content: Arc<str>,
+        handler: &mut ErrorCollector,
+    ) -> Option<Self> {
+        let module_count = 1;
+
+        let mut items: Vec<parse::Item> = Vec::new();
+
+        let mut aliases = NamespaceTracker::<AliasName>::new(module_count);
+        let mut functions = NamespaceTracker::<FunctionName>::new(module_count);
+
+        for item in parsed.items() {
+            if let parse::Item::Use(use_decl) = item {
+                handler.push(
+                    RichError::new(Error::UnknownLibrary(use_decl.str_path()), *use_decl.span())
+                        .with_content(content.clone()),
+                );
+                continue;
+            }
+
+            let mut new_elem = item.clone();
+            match &mut new_elem {
+                parse::Item::TypeAlias(type_alias) => {
+                    if let Err(err) = register_type_alias(type_alias, &mut aliases, MAIN_MODULE) {
+                        handler.push(err.with_content(content.clone()));
+                        continue;
+                    }
+                }
+                parse::Item::Function(function) => {
+                    if let Err(err) = register_function(function, &mut functions, MAIN_MODULE) {
+                        handler.push(err.with_content(content.clone()));
+                        continue;
+                    }
+                }
+
+                // Safe to skip: `Use` items are handled earlier in the loop, and `Module` currently has no functionality.
+                parse::Item::Module | parse::Item::Use(_) => continue,
+            }
+            items.push(new_elem);
+        }
+
+        // TODO: Consider getting rid of the 'String' error here and changing it to a more appropriate error
+        // (e.g. 'Result<Self, ErrorCollector>') after resolving https://github.com/BlockstreamResearch/SimplicityHL/issues/270.
+        (!handler.has_errors()).then(|| Program {
+            items: items.into(),
+            aliases: aliases.into_symbol_table(),
+            functions: functions.into_symbol_table(),
+            span: *parsed.as_ref(),
+        })
+    }
+
     pub fn items(&self) -> &[parse::Item] {
         &self.items
     }
@@ -78,7 +130,7 @@ pub type FileScoped<T> = (T, usize);
 pub type ImportMap<T> = BTreeMap<FileScoped<T>, FileScoped<T>>;
 
 /// Manages the resolution of import aliases across the entire program.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct ImportRegistry<T> {
     direct_targets: ImportMap<T>,
     resolved_roots: ImportMap<T>,
@@ -164,53 +216,26 @@ impl DependencyGraph {
                     continue;
                 }
 
-                items.push(elem.clone());
-
                 // Handle Types & Functions by inserting them into their STRICT namespaces
-                // Architectural Note:
-                // The code may seem duplicated. To prevent this, the best approach
-                // would be to add a `NamedItem` trait. However, doing so would require
-                // duplicating getter methods for both `Function` and `TypeAlias`.
-                // As a result, it is better to leave it as is.
-                match elem {
+                let mut new_elem = elem.clone();
+                match &mut new_elem {
                     parse::Item::TypeAlias(type_alias) => {
-                        let name = type_alias.name();
-                        let local_id = (name.clone(), source_id);
-
-                        if aliases.memo.contains(&local_id) {
-                            handler.push(
-                                RichError::new(
-                                    Error::RedefinedAlias(name.clone()),
-                                    *type_alias.span(),
-                                )
-                                .with_source(source.clone()),
-                            );
+                        if let Err(err) = register_type_alias(type_alias, &mut aliases, source_id) {
+                            handler.push(err.with_source(source.clone()));
+                            continue;
                         }
-                        aliases.memo.insert(local_id);
-                        aliases.resolutions[source_id]
-                            .insert(name.clone(), type_alias.visibility().clone());
                     }
                     parse::Item::Function(function) => {
-                        let name = function.name();
-                        let local_id = (name.clone(), source_id);
-
-                        if functions.memo.contains(&local_id) {
-                            handler.push(
-                                RichError::new(
-                                    Error::FunctionRedefined(name.clone()),
-                                    *function.span(),
-                                )
-                                .with_source(source.clone()),
-                            );
+                        if let Err(err) = register_function(function, &mut functions, source_id) {
+                            handler.push(err.with_source(source.clone()));
+                            continue;
                         }
-                        functions.memo.insert(local_id);
-                        functions.resolutions[source_id]
-                            .insert(name.clone(), function.visibility().clone());
                     }
 
                     // Safe to skip: `Use` items are handled earlier in the loop, and `Module` currently has no functionality.
                     parse::Item::Module | parse::Item::Use(_) => continue,
                 }
+                items.push(new_elem);
             }
         }
 
@@ -269,6 +294,7 @@ impl DependencyGraph {
     /// Returns `Ok(())` on success. Returns `Err(RichError)` if:
     /// * [`Error::UnresolvedItem`]: The target name does not exist in the source module (`ind`).
     /// * [`Error::PrivateItem`]: The target exists, but its visibility is explicitly `Private`.
+    /// * [`Error::MainCannotBeAlias`]: The `main` cannot be alias.
     /// * [`Error::DuplicateAlias`]: The local name (or alias) has already been used in another import statement.
     /// * [`Error::RedefinedItem`]: The local name conflicts with an existing item already defined in this module.
     fn process_use_item<T>(
@@ -289,7 +315,7 @@ impl DependencyGraph {
         let orig_id = (target_name.clone(), ind);
 
         // 2. Verify Existence using T
-        let visibility = namespace.resolutions[ind]
+        let visibility: &Visibility = namespace.resolutions[ind]
             .get(&target_name)
             .ok_or_else(|| RichError::new(Error::UnresolvedItem(name.to_string()), span))?;
 
@@ -303,7 +329,17 @@ impl DependencyGraph {
         let local_symbol = alias.as_ref().unwrap_or(name);
 
         // Then convert that raw symbol to T
-        let local_name: T = local_symbol.clone().into();
+        let local_name: T = if let Some(alias_sym) = alias {
+            let t_alias: T = alias_sym.clone().into();
+
+            if t_alias.to_string() == MAIN_STR {
+                return Err(RichError::new(Error::MainCannotBeAlias, span));
+            }
+            t_alias
+        } else {
+            name.clone().into()
+        };
+
         let local_id = (local_name.clone(), source_id);
 
         // 5. Check for collisions using `namespace` fields
@@ -347,6 +383,59 @@ impl DependencyGraph {
     }
 }
 
+// Architectural Note:
+// The two functions may seem duplicated. To prevent this, the best approach
+// would be to add a `NamedItem` trait. However, doing so would require
+// duplicating getter methods for both `Function` and `TypeAlias`.
+// As a result, it is better to leave it as is.
+fn register_type_alias(
+    item: &mut TypeAlias,
+    tracker: &mut NamespaceTracker<AliasName>,
+    source_id: usize,
+) -> Result<(), RichError> {
+    item.set_file_id(source_id);
+
+    let name = item.name();
+    let local_id = (name.clone(), source_id);
+
+    if tracker.memo.contains(&local_id) {
+        return Err(RichError::new(
+            Error::RedefinedAlias(name.clone()),
+            *item.span(),
+        ));
+    }
+
+    tracker.memo.insert(local_id);
+    tracker.resolutions[source_id].insert(name.clone(), item.visibility().clone());
+    Ok(())
+}
+
+fn register_function(
+    item: &mut Function,
+    tracker: &mut NamespaceTracker<FunctionName>,
+    source_id: usize,
+) -> Result<(), RichError> {
+    item.set_file_id(source_id);
+
+    let name = item.name();
+    let local_id = (name.clone(), source_id);
+
+    if name.as_inner() == MAIN_STR && matches!(item.visibility(), Visibility::Public) {
+        return Err(RichError::new(Error::MainCannotBePublic, *item.span()));
+    }
+
+    if tracker.memo.contains(&local_id) {
+        return Err(RichError::new(
+            Error::FunctionRedefined(name.clone()),
+            *item.span(),
+        ));
+    }
+
+    tracker.memo.insert(local_id);
+    tracker.resolutions[source_id].insert(name.clone(), item.visibility().clone());
+    Ok(())
+}
+
 /// Helper struct, that tracks the resolution state, imports, and memoization for a single namespace.
 #[derive(Clone, Debug)]
 struct NamespaceTracker<T> {
@@ -379,6 +468,30 @@ impl<T: Ord + Clone + Default + std::hash::Hash> NamespaceTracker<T> {
                 .into(),
             imports: self.registry,
         }
+    }
+}
+
+impl<T> Default for ImportRegistry<T> {
+    fn default() -> Self {
+        Self {
+            direct_targets: BTreeMap::new(),
+            resolved_roots: BTreeMap::new(),
+        }
+    }
+}
+
+impl<T> Default for SymbolTable<T> {
+    fn default() -> Self {
+        Self {
+            local_scopes: Arc::from([]),
+            imports: ImportRegistry::<T>::default(),
+        }
+    }
+}
+
+impl AsRef<Span> for Program {
+    fn as_ref(&self) -> &Span {
+        &self.span
     }
 }
 
@@ -525,6 +638,55 @@ mod resolve_order_tests {
         assert!(
             program_option.is_none(),
             "build should fail when a second import reuses the function name `foo`"
+        );
+    }
+
+    #[test]
+    fn test_public_main_is_forbidden() {
+        // Scenario: A user tries to declare the entry point as `pub fn main`.
+        // Expected: The compiler must reject this because `main` must be private.
+
+        let (graph, _ids, _dir) = setup_graph(vec![("main.simf", "pub fn main() {}")]);
+
+        let mut error_handler = ErrorCollector::new();
+        let program_option = graph.linearize_and_build(&mut error_handler).unwrap();
+
+        assert!(
+            program_option.is_none(),
+            "Compiler should return None when `main` is declared public"
+        );
+
+        let error_msg = error_handler.to_string();
+        assert!(
+            error_msg.contains("main") && error_msg.contains("public"),
+            "Error message should mention that `main` cannot be public. Got: {}",
+            error_msg
+        );
+    }
+
+    #[test]
+    fn test_aliasing_to_main_is_forbidden() {
+        // Scenario: A user tries to bypass entry point rules by renaming an import to `main`.
+        // Expected: The compiler must reject this because `main` is a reserved identifier.
+
+        let (graph, _ids, _dir) = setup_graph(vec![
+            ("libs/lib/A.simf", "pub type bar = u32;"),
+            ("main.simf", "use lib::A::bar as main;"),
+        ]);
+
+        let mut error_handler = ErrorCollector::new();
+        let program_option = graph.linearize_and_build(&mut error_handler).unwrap();
+
+        assert!(
+            program_option.is_none(),
+            "Compiler should return None when a user tries to alias an import to `main`"
+        );
+
+        let error_msg = error_handler.to_string();
+        assert!(
+            error_msg.contains("main") && error_msg.contains("alias"),
+            "Error message should clearly state that `main` cannot be used as an alias. Got: {}",
+            error_msg
         );
     }
 }

--- a/src/driver/resolve_order.rs
+++ b/src/driver/resolve_order.rs
@@ -1,10 +1,10 @@
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::sync::Arc;
 
 use crate::driver::DependencyGraph;
 use crate::error::{Error, ErrorCollector, RichError, Span};
 use crate::impl_eq_hash;
-use crate::parse::{self, Visibility};
+use crate::parse::{self, AliasedIdentifier, Visibility};
 use crate::resolution::CanonPath;
 
 /// The final, flattened representation of a SimplicityHL program.
@@ -19,6 +19,8 @@ pub struct Program {
     /// The files that make up this program, along with their scoping rules.
     files: Arc<[ResolvedFile]>,
 
+    import_aliases: AliasRegistry,
+
     span: Span,
 }
 
@@ -31,12 +33,16 @@ impl Program {
         &self.files
     }
 
+    pub fn import_aliases(&self) -> &AliasRegistry {
+        &self.import_aliases
+    }
+
     pub fn span(&self) -> &Span {
         &self.span
     }
 }
 
-impl_eq_hash!(Program; items, files);
+impl_eq_hash!(Program; items, files, import_aliases);
 
 /// Represents a single source file alongside its resolved scoping and visibility rules.
 #[derive(Clone, Debug)]
@@ -60,6 +66,37 @@ impl ResolvedFile {
 
 impl_eq_hash!(ResolvedFile; path, resolutions);
 
+/// A registry mapping an alias [`ItemNameWithFileId`] to its target item across different files.
+///
+/// We use a type alias here to provide a convenient abstraction for the `AST::analyze`
+/// phase, making it easier to modify the underlying structure in the future if needed.
+pub type AliasMap = BTreeMap<ItemNameWithFileId, ItemNameWithFileId>;
+pub type ItemNameWithFileId = (Arc<str>, usize);
+
+/// Manages the resolution of import aliases across the entire program.
+#[derive(Clone, Debug, Default)]
+pub struct AliasRegistry {
+    /// Maps an alias to its immediate target.
+    /// (e.g., `use B as C;` stores C -> B)
+    direct_targets: AliasMap,
+
+    /// Caches the final, original definition of an alias to avoid walking the chain.
+    /// (e.g., If C -> B and B -> A, this stores C -> A)
+    resolved_roots: AliasMap,
+}
+
+impl AliasRegistry {
+    pub fn direct_targets(&self) -> &AliasMap {
+        &self.direct_targets
+    }
+
+    pub fn resolved_roots(&self) -> &AliasMap {
+        &self.resolved_roots
+    }
+}
+
+impl_eq_hash!(AliasRegistry; direct_targets, resolved_roots);
+
 /// This is a core component of the [`DependencyGraph`].
 impl DependencyGraph {
     /// Resolves the dependency graph and constructs the final AST program.
@@ -78,6 +115,8 @@ impl DependencyGraph {
         let mut items: Vec<parse::Item> = Vec::new();
         let mut resolutions: Vec<HashMap<Arc<str>, Visibility>> =
             vec![HashMap::new(); self.modules.len()];
+        let mut import_aliases = AliasRegistry::default();
+        let mut items_registry = BTreeSet::<ItemNameWithFileId>::new();
 
         for &source_id in order {
             let module = &self.modules[source_id];
@@ -101,12 +140,14 @@ impl DependencyGraph {
                         parse::UseItems::List(elems) => elems.as_slice(),
                     };
 
-                    for item in use_decl_items {
+                    for aliased_item in use_decl_items {
                         if let Err(err) = Self::process_use_item(
+                            &mut items_registry,
+                            &mut import_aliases,
                             &mut resolutions,
                             source_id,
                             ind,
-                            Arc::from(item.as_inner()),
+                            aliased_item,
                             use_decl,
                         ) {
                             handler.push(err.with_source(source.clone()));
@@ -116,13 +157,22 @@ impl DependencyGraph {
                 }
 
                 // Handle Types & Functions
-                let (name, vis) = match elem {
-                    parse::Item::TypeAlias(a) => (a.name().as_inner(), a.visibility()),
-                    parse::Item::Function(f) => (f.name().as_inner(), f.visibility()),
+                let (name, vis, span) = match elem {
+                    parse::Item::TypeAlias(a) => (a.name().as_inner(), a.visibility(), *a.span()),
+                    parse::Item::Function(f) => (f.name().as_inner(), f.visibility(), *f.span()),
 
                     // Safe to skip: `Use` items are handled earlier in the loop, and `Module` currently has no functionality.
                     parse::Item::Module | parse::Item::Use(_) => continue,
                 };
+
+                let item_name = (Arc::from(name), source_id);
+                if items_registry.contains(&item_name) {
+                    handler.push(
+                        RichError::new(Error::RedefinedItem(name.to_string()), span)
+                            .with_source(source.clone()),
+                    );
+                }
+                items_registry.insert(item_name);
 
                 items.push(elem.clone());
                 resolutions[source_id].insert(Arc::from(name), vis.clone());
@@ -132,43 +182,101 @@ impl DependencyGraph {
         (!handler.has_errors()).then(|| Program {
             items: items.into(),
             files: construct_resolved_file_array(&self.paths, &resolutions),
+            import_aliases,
             span: *self.modules[0].parsed_program.as_ref(),
         })
     }
 
-    /// Processes a single imported item during the module resolution phase.
+    /// Processes a single imported item (or alias) during the module resolution phase.
+    ///
+    /// This function verifies that the requested item exists in the source module and
+    /// that it has the appropriate public visibility to be imported. If validation passes,
+    /// the item is registered in the importing module's resolution table and global alias registry.
     ///
     /// # Arguments
     ///
-    /// * `resolutions` - A mutable slice of hash maps, where each index corresponds to a module's ID and holds its resolved items and their visibilities.
+    /// * `import_aliases` - The global registry tracking alias chains and their canonical roots.
+    /// * `resolutions` - The global, mutable array mapping each `file_id` to its localized `FileResolutions` table.
     /// * `source_id` - The `usize` identifier of the destination source.
-    /// * `ind` - The unique identifier (`usize`) of the source module being imported *from*.
-    /// * `name` - The specific item name (`Arc<str>`) being imported from the source.
-    /// * `use_decl` - The AST node of the `use` statement. This dictates the visibility of the newly imported item in the destination module.
+    /// * `ind` - The unique identifier of the source module being imported *from*.
+    /// * `aliased_identifier` - The specific identifier (and potential alias) being imported from the source.
+    /// * `use_decl` - The node of the `use` statement. This dictates the visibility of the new import
+    ///   (e.g., `pub use` re-exports the item publicly).
     ///
     /// # Returns
     ///
     /// Returns `None` on success. Returns `Some(RichError)` if:
-    /// * [`Error::UnresolvedItem`]: The target `name` does not exist in the source module (`ind`).
-    /// * [`Error::PrivateItem`]: The target exists in the source module, but its visibility is expl
+    /// * [`Error::UnresolvedItem`]: The target `elem` does not exist in the source module (`ind`).
+    /// * [`Error::PrivateItem`]: The target exists, but its visibility is explicitly `Private`,
+    /// * [`Error::DuplicateAlias`]: The target `alias` (or imported name) has already been used in the current module.
     fn process_use_item(
+        items_registry: &mut BTreeSet<ItemNameWithFileId>,
+        import_aliases: &mut AliasRegistry,
         resolutions: &mut [HashMap<Arc<str>, Visibility>],
         source_id: usize,
         ind: usize,
-        name: Arc<str>,
+        (name, alias): &AliasedIdentifier,
         use_decl: &parse::UseDecl,
     ) -> Result<(), RichError> {
+        // NOTE: The order of errors is important!
         let span = *use_decl.span();
 
+        let name: Arc<str> = Arc::from(name.as_inner());
+        let orig_id = (name.clone(), ind);
+
+        // 1. Verify Existence: Does the item exist in the source file?
         let visibility = resolutions[ind]
             .get(&name)
             .ok_or_else(|| RichError::new(Error::UnresolvedItem(name.to_string()), span))?;
 
+        // 2. Verify Visibility: Are we allowed to see it?
         if matches!(visibility, parse::Visibility::Private) {
             return Err(RichError::new(Error::PrivateItem(name.to_string()), span));
         }
 
-        resolutions[source_id].insert(name, use_decl.visibility().clone());
+        // 3. Determine the local name and ID up front
+        let local_name = if let Some(alias) = alias {
+            Arc::from(alias.as_inner())
+        } else {
+            name.clone()
+        };
+        let local_id = (local_name.clone(), source_id);
+
+        // 4. Check for collisions
+        if import_aliases.direct_targets.contains_key(&local_id) {
+            return Err(RichError::new(
+                Error::DuplicateAlias(local_name.to_string()),
+                span,
+            ));
+        }
+
+        if items_registry.contains(&local_id) {
+            return Err(RichError::new(
+                Error::RedefinedItem(local_name.to_string()),
+                span,
+            ));
+        }
+        items_registry.insert(local_id.clone());
+
+        // 5. Update the registers
+        import_aliases
+            .direct_targets
+            .insert(local_id.clone(), orig_id.clone());
+
+        // 6. Find the true root using a single lookup!
+        // If `orig_id` exists in resolved_roots, it means it's an alias and we get its true root.
+        // If it returns None, it means `orig_id` is the original item, so it IS the root.
+        let true_root = import_aliases
+            .resolved_roots
+            .get(&orig_id)
+            .cloned()
+            .unwrap_or_else(|| orig_id.clone());
+
+        // Always cache the final root for instant O(1) lookups later
+        import_aliases.resolved_roots.insert(local_id, true_root);
+
+        // 7. Register the item in the local  module's namespace
+        resolutions[source_id].insert(local_name, use_decl.visibility().clone());
         Ok(())
     }
 }
@@ -192,7 +300,7 @@ fn construct_resolved_file_array(
 }
 
 #[cfg(test)]
-mod tests {
+mod resolve_order_tests {
     use crate::driver::tests::setup_graph;
 
     use super::*;
@@ -287,5 +395,287 @@ mod tests {
         assert!(error_handler
             .to_string()
             .contains(&"Item `foo` is private".to_string()));
+    }
+}
+
+#[cfg(test)]
+mod alias_tests {
+    use super::*;
+    use crate::driver::tests::setup_graph;
+    use std::sync::Arc;
+
+    #[test]
+    fn test_renaming_with_use() {
+        // Scenario: Renaming imports.
+        // main.simf: use lib::A::foo as bar;
+        // Expected: Scope should contain "bar", but not "foo".
+
+        let (graph, ids, _dir) = setup_graph(vec![
+            ("libs/lib/A.simf", "pub fn foo() {}"),
+            ("main.simf", "use lib::A::foo as bar;"),
+        ]);
+
+        let mut error_handler = ErrorCollector::new();
+        let program_option = graph.linearize_and_build(&mut error_handler).unwrap();
+
+        let Some(program) = program_option else {
+            panic!("{}", error_handler);
+        };
+
+        let id_root = ids["main"];
+        let scope = &program.files[id_root].resolutions;
+
+        assert!(
+            scope.get(&Arc::from("foo")).is_none(),
+            "Original name 'foo' should not be in scope"
+        );
+        assert!(
+            scope.get(&Arc::from("bar")).is_some(),
+            "Alias 'bar' should be in scope"
+        );
+    }
+
+    #[test]
+    fn test_multiple_aliases_in_list() {
+        // Scenario: Renaming multiple imports inside brackets.
+        let (graph, ids, _dir) = setup_graph(vec![
+            ("libs/lib/A.simf", "pub fn foo() {} pub fn baz() {}"),
+            ("main.simf", "use lib::A::{foo as bar, baz as qux};"),
+        ]);
+
+        let mut error_handler = ErrorCollector::new();
+        let program_option = graph.linearize_and_build(&mut error_handler).unwrap();
+
+        let Some(program) = program_option else {
+            panic!("{}", error_handler);
+        };
+
+        let id_root = ids["main"];
+        let scope = &program.files[id_root].resolutions;
+
+        // The original names should NOT be in scope
+        assert!(scope.get(&Arc::from("foo")).is_none());
+        assert!(scope.get(&Arc::from("baz")).is_none());
+
+        // The aliases MUST be in scope
+        assert!(scope.get(&Arc::from("bar")).is_some());
+        assert!(scope.get(&Arc::from("qux")).is_some());
+    }
+
+    #[test]
+    fn test_alias_private_item_fails() {
+        // Scenario: Attempting to alias a private item should fail.
+        let (graph, _ids, _dir) = setup_graph(vec![
+            ("libs/lib/A.simf", "fn secret() {}"), // Note: Missing `pub`
+            ("main.simf", "use lib::A::secret as my_secret;"),
+        ]);
+
+        let mut error_handler = ErrorCollector::new();
+        let program_option = graph.linearize_and_build(&mut error_handler).unwrap();
+
+        assert!(
+            program_option.is_none(),
+            "Compiler should emit an error and return None when aliasing a private item"
+        );
+
+        assert!(
+            error_handler
+                .to_string()
+                .contains("Item `secret` is private"),
+            "Error should mention the private item restriction"
+        );
+    }
+
+    #[test]
+    fn test_deep_reexport_with_aliases() {
+        // Scenario: Chaining aliases across multiple files.
+        let (graph, ids, _dir) = setup_graph(vec![
+            ("libs/lib/A.simf", "pub fn original() {}"),
+            ("libs/lib/B.simf", "pub use lib::A::original as middle;"),
+            ("main.simf", "use lib::B::middle as final_name;"),
+        ]);
+
+        let mut error_handler = ErrorCollector::new();
+        let program_option = graph.linearize_and_build(&mut error_handler).unwrap();
+
+        let Some(program) = program_option else {
+            panic!("{}", error_handler);
+        };
+
+        let id_b = ids["B"];
+        let id_root = ids["main"];
+
+        // Assert Main Scope
+        let main_scope = &program.files[id_root].resolutions;
+        assert!(main_scope.get(&Arc::from("original")).is_none());
+        assert!(main_scope.get(&Arc::from("middle")).is_none());
+        assert!(
+            main_scope.get(&Arc::from("final_name")).is_some(),
+            "Main must see the final alias"
+        );
+
+        // Assert B Scope (It should have the intermediate alias!)
+        let b_scope = &program.files[id_b].resolutions;
+        assert!(
+            b_scope.get(&Arc::from("middle")).is_some(),
+            "File B must contain its own public alias"
+        );
+    }
+
+    #[test]
+    fn test_deep_reexport_private_link_fails() {
+        // Scenario: Main tries to import an alias from B, but B's alias is private!
+        let (graph, _ids, _dir) = setup_graph(vec![
+            ("libs/lib/A.simf", "pub fn target() {}"),
+            // Note: Missing `pub` keyword here! This makes `hidden_alias` private to B.
+            ("libs/lib/B.simf", "use lib::A::target as hidden_alias;"),
+            ("main.simf", "use lib::B::hidden_alias;"),
+        ]);
+
+        let mut error_handler = ErrorCollector::new();
+        let program_option = graph.linearize_and_build(&mut error_handler).unwrap();
+
+        assert!(
+            program_option.is_none(),
+            "Compiler must return None when trying to import a private alias from an intermediate module"
+        );
+
+        assert!(
+            error_handler
+                .to_string()
+                .contains("Item `hidden_alias` is private"),
+            "Error should correctly identify the private intermediate alias"
+        );
+    }
+
+    #[test]
+    fn test_alias_cycle_detection() {
+        // Scenario: A malicious or confused user creates an infinite alias/import loop.
+        let (graph, _ids, _dir) = setup_graph(vec![
+            // A imports from B, B imports from A. This creates a file-level cycle!
+            ("libs/lib/A.simf", "pub use lib::B::pong as ping;"),
+            ("libs/lib/B.simf", "pub use lib::A::ping as pong;"),
+            ("main.simf", "use lib::A::ping;"),
+        ]);
+
+        let mut error_handler = ErrorCollector::new();
+
+        // Because A and B depend on each other, `linearize()` should catch the cycle
+        // and return an Err(...) directly, rather than causing a Stack Overflow.
+        let result = graph.linearize_and_build(&mut error_handler);
+
+        match result {
+            Err(e) => {
+                println!("{e}");
+                assert!(
+                    e.contains("Cycle") || e.contains("Circular"),
+                    "DFS Linearizer must catch infinite alias cycles"
+                );
+            }
+            Ok(None) => {
+                assert!(
+                    error_handler.has_errors(),
+                    "If linearization passes, the builder must catch the cycle"
+                );
+            }
+            Ok(Some(_)) => {
+                panic!("Expected compilation to fail due to a dependency cycle, but it succeeded!")
+            }
+        }
+    }
+
+    #[test]
+    fn test_plain_import_and_alias_to_same_name_is_rejected() {
+        let (graph, _ids, _dir) = setup_graph(vec![
+            ("libs/lib/A.simf", "pub fn foo() {}"),
+            ("libs/lib/B.simf", "pub fn foo() {}"),
+            ("main.simf", "use lib::A::foo; use lib::B::foo as foo;"),
+        ]);
+
+        let mut error_handler = ErrorCollector::new();
+        let program_option = graph.linearize_and_build(&mut error_handler).unwrap();
+
+        assert!(
+            program_option.is_none(),
+            "build should fail when two imports bind the same local name"
+        );
+        assert!(
+            error_handler
+                .to_string()
+                .contains("The alias `foo` was defined multiple times"),
+            "expected a duplicate-alias diagnostic"
+        );
+    }
+
+    #[test]
+    fn test_failed_alias_import_does_not_poison_following_imports() {
+        let (graph, _ids, _dir) = setup_graph(vec![
+            ("libs/lib/A.simf", "pub fn nope() {}"),
+            ("libs/lib/B.simf", "pub fn bar() {}"),
+            (
+                "main.simf",
+                "use lib::A::missing as foo; use lib::B::bar as foo;",
+            ),
+        ]);
+
+        let mut error_handler = ErrorCollector::new();
+        let program_option = graph.linearize_and_build(&mut error_handler).unwrap();
+        let errors = error_handler.to_string();
+
+        assert!(
+            program_option.is_none(),
+            "build should fail on the unresolved import"
+        );
+        assert!(errors.contains("Item `missing` could not be found"));
+        assert!(
+            !errors.contains("The alias `foo` was defined multiple times"),
+            "a failed import must not reserve the alias name"
+        );
+    }
+
+    #[test]
+    fn test_alias_cannot_reuse_local_definition_name() {
+        let (graph, _ids, _dir) = setup_graph(vec![
+            ("libs/lib/A.simf", "pub fn bar() {}"),
+            ("main.simf", "pub fn foo() {} use lib::A::bar as foo;"),
+        ]);
+
+        let mut error_handler = ErrorCollector::new();
+        let program_option = graph.linearize_and_build(&mut error_handler).unwrap();
+
+        dbg!(&error_handler.to_string());
+
+        assert!(
+            program_option.is_none(),
+            "build should fail when an alias reuses a local definition name"
+        );
+        assert!(
+            error_handler
+                .to_string()
+                .contains("Item `foo` was defined multiple times"),
+            "expected a redefined-item diagnostic"
+        );
+    }
+
+    #[test]
+    fn test_local_definition_cannot_reuse_alias_name() {
+        let (graph, _ids, _dir) = setup_graph(vec![
+            ("libs/lib/A.simf", "pub fn bar() {}"),
+            ("main.simf", "use lib::A::bar as foo; pub fn foo() {}"),
+        ]);
+
+        let mut error_handler = ErrorCollector::new();
+        let program_option = graph.linearize_and_build(&mut error_handler).unwrap();
+
+        assert!(
+            program_option.is_none(),
+            "build should fail when a local definition reuses an alias name"
+        );
+        assert!(
+            error_handler
+                .to_string()
+                .contains("Item `foo` was defined multiple times"),
+            "expected a redefined-item diagnostic"
+        );
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -494,6 +494,7 @@ pub enum Error {
     JetDoesNotExist(JetName),
     InvalidCast(ResolvedType, ResolvedType),
     FileNotFound(PathBuf),
+    RedefinedItem(String),
     UnresolvedItem(String),
     PrivateItem(String),
     MainNoInputs,
@@ -610,15 +611,17 @@ impl fmt::Display for Error {
                 f,
                 "Function `{name}` was called but not defined"
             ),
+            Error::RedefinedItem(name) => write!(
+                f,
+                "Item `{name}` was defined multiple times"
+            ),
             Error::UnresolvedItem(name) => write!(
                 f,
-                "Item `{}` could not be found",
-                name
+                "Item `{name}` could not be found"
             ),
             Error::PrivateItem(name) => write!(
                 f,
-                "Item `{}` is private",
-                name
+                "Item `{name}` is private"
             ),
             Error::InvalidNumberOfArguments(expected, found) => write!(
                 f,
@@ -666,8 +669,7 @@ impl fmt::Display for Error {
             ),
             Error::DuplicateAlias(name) => write!(
                 f,
-                "The alias `{}` was defined multiple times",
-                name,
+                "The alias `{name}` was defined multiple times"
             ),
             Error::VariableReuseInPattern(identifier) => write!(
                 f,

--- a/src/error.rs
+++ b/src/error.rs
@@ -468,6 +468,7 @@ impl fmt::Display for ErrorCollector {
     }
 }
 
+// TODO: Add file context to `UnresolvedItem`, `PrivateItem`, and `DuplicateItem` errors.
 /// An individual error.
 ///
 /// Records _what_ happened but not where.
@@ -493,14 +494,8 @@ pub enum Error {
     JetDoesNotExist(JetName),
     InvalidCast(ResolvedType, ResolvedType),
     FileNotFound(PathBuf),
-    UnresolvedItem {
-        name: String,
-        target_file: PathBuf,
-    },
-    PrivateItem {
-        name: String,
-        target_file: PathBuf,
-    },
+    UnresolvedItem(String),
+    PrivateItem(String),
     MainNoInputs,
     MainNoOutput,
     MainRequired,
@@ -517,10 +512,7 @@ pub enum Error {
     RedefinedAlias(AliasName),
     RedefinedAliasAsBuiltin(AliasName),
     UndefinedAlias(AliasName),
-    DuplicateAlias {
-        name: String,
-        target_file: PathBuf,
-    },
+    DuplicateAlias(String),
     VariableReuseInPattern(Identifier),
     WitnessReused(WitnessName),
     WitnessTypeMismatch(WitnessName, ResolvedType, ResolvedType),
@@ -618,15 +610,15 @@ impl fmt::Display for Error {
                 f,
                 "Function `{name}` was called but not defined"
             ),
-            Error::UnresolvedItem { name, target_file } => write!(
+            Error::UnresolvedItem(name) => write!(
                 f,
-                "Item `{}` could not be fouhnd in the file `{}`",
-                name, target_file.to_string_lossy()
+                "Item `{}` could not be found",
+                name
             ),
-            Error::PrivateItem { name, target_file } => write!(
+            Error::PrivateItem(name) => write!(
                 f,
-                "Item `{}` is private in module `{}`",
-                name, target_file.to_string_lossy()
+                "Item `{}` is private",
+                name
             ),
             Error::InvalidNumberOfArguments(expected, found) => write!(
                 f,
@@ -672,10 +664,10 @@ impl fmt::Display for Error {
                 f,
                 "Type alias `{identifier}` is not defined"
             ),
-            Error::DuplicateAlias { name, target_file } => write!(
+            Error::DuplicateAlias(name) => write!(
                 f,
-                "The alias `{}` was defined multiple times for `{}`",
-                name, target_file.to_string_lossy()
+                "The alias `{}` was defined multiple times",
+                name,
             ),
             Error::VariableReuseInPattern(identifier) => write!(
                 f,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 use std::ops::Range;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use chumsky::error::Error as ChumskyError;
@@ -137,9 +138,14 @@ impl<T> WithFile<T> for Result<T, RichError> {
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct RichError {
     /// The error that occurred.
-    error: Error,
+    ///
+    /// Wrapped in a `Box` to keep the `RichError` struct small on the stack,
+    /// ensuring cheap moves when returning errors inside a `Result`.
+    error: Box<Error>,
+
     /// Area that the error spans inside the file.
     span: Span,
+
     /// File in which the error occurred.
     ///
     /// Required to print pretty errors.
@@ -150,7 +156,7 @@ impl RichError {
     /// Create a new error with context.
     pub fn new(error: Error, span: Span) -> RichError {
         RichError {
-            error,
+            error: Box::new(error),
             span,
             file: None,
         }
@@ -171,7 +177,7 @@ impl RichError {
     /// a problem on the parsing side.
     pub fn parsing_error(reason: &str) -> Self {
         Self {
-            error: Error::CannotParse(reason.to_string()),
+            error: Box::new(Error::CannotParse(reason.to_string())),
             span: Span::new(0, 0),
             file: None,
         }
@@ -258,7 +264,7 @@ impl std::error::Error for RichError {}
 
 impl From<RichError> for Error {
     fn from(error: RichError) -> Self {
-        error.error
+        *error.error
     }
 }
 
@@ -274,7 +280,7 @@ where
     I: ValueInput<'tokens, Token = Token<'src>, Span = Span>,
 {
     fn merge(self, other: Self) -> Self {
-        match (&self.error, &other.error) {
+        match (self.error.as_ref(), other.error.as_ref()) {
             (Error::Grammar(_), Error::Grammar(_)) => other,
             (Error::Grammar(_), _) => other,
             (_, Error::Grammar(_)) => self,
@@ -310,11 +316,11 @@ where
         let found_string = found.map(|t| t.to_string());
 
         Self {
-            error: Error::Syntax {
+            error: Box::new(Error::Syntax {
                 expected: expected_tokens,
                 label: None,
                 found: found_string,
-            },
+            }),
             span,
             file: None,
         }
@@ -337,11 +343,11 @@ where
         let found_string = found.map(|t| t.to_string());
 
         Self {
-            error: Error::Syntax {
+            error: Box::new(Error::Syntax {
                 expected: expected_strings,
                 label: None,
                 found: found_string,
-            },
+            }),
             span,
             file: None,
         }
@@ -350,7 +356,7 @@ where
     fn label_with(&mut self, label: &'tokens str) {
         if let Error::Syntax {
             label: ref mut l, ..
-        } = &mut self.error
+        } = self.error.as_mut()
         {
             *l = Some(label.to_string());
         }
@@ -406,6 +412,8 @@ impl fmt::Display for ErrorCollector {
 /// Records _what_ happened but not where.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub enum Error {
+    Internal(String),
+    UnknownLibrary(String),
     ArraySizeNonZero(usize),
     ListBoundPow2(usize),
     BitStringPow2(usize),
@@ -423,6 +431,15 @@ pub enum Error {
     CannotCompile(String),
     JetDoesNotExist(JetName),
     InvalidCast(ResolvedType, ResolvedType),
+    FileNotFound(PathBuf),
+    UnresolvedItem {
+        name: String,
+        target_file: PathBuf,
+    },
+    PrivateItem {
+        name: String,
+        target_file: PathBuf,
+    },
     MainNoInputs,
     MainNoOutput,
     MainRequired,
@@ -439,6 +456,10 @@ pub enum Error {
     RedefinedAlias(AliasName),
     RedefinedAliasAsBuiltin(AliasName),
     UndefinedAlias(AliasName),
+    DuplicateAlias {
+        name: String,
+        target_file: PathBuf,
+    },
     VariableReuseInPattern(Identifier),
     WitnessReused(WitnessName),
     WitnessTypeMismatch(WitnessName, ResolvedType, ResolvedType),
@@ -453,6 +474,14 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Error::Internal(err) => write!(
+                f,
+                "INTERNAL ERROR: {err}"
+            ),
+            Error::UnknownLibrary(name) => write!(
+                f,
+                "Unknown module or library '{name}'"
+            ),
             Error::ArraySizeNonZero(size) => write!(
                 f,
                 "Expected a non-negative integer as array size, found {size}"
@@ -472,6 +501,10 @@ impl fmt::Display for Error {
             Error::Grammar(description) => write!(
                 f,
                 "Grammar error: {description}"
+            ),
+            Error::FileNotFound(path) => write!(
+                f,
+                "File `{}` not found", path.to_string_lossy()
             ),
             Error::Syntax { expected, label, found } => {
                 let found_text = found.clone().unwrap_or("end of input".to_string());
@@ -524,6 +557,16 @@ impl fmt::Display for Error {
                 f,
                 "Function `{name}` was called but not defined"
             ),
+            Error::UnresolvedItem { name, target_file } => write!(
+                f,
+                "Item `{}` could not be fouhnd in the file `{}`",
+                name, target_file.to_string_lossy()
+            ),
+            Error::PrivateItem { name, target_file } => write!(
+                f,
+                "Item `{}` is private in module `{}`",
+                name, target_file.to_string_lossy()
+            ),
             Error::InvalidNumberOfArguments(expected, found) => write!(
                 f,
                 "Expected {expected} arguments, found {found} arguments"
@@ -567,6 +610,11 @@ impl fmt::Display for Error {
             Error::UndefinedAlias(identifier) => write!(
                 f,
                 "Type alias `{identifier}` is not defined"
+            ),
+            Error::DuplicateAlias { name, target_file } => write!(
+                f,
+                "The alias `{}` was defined multiple times for `{}`",
+                name, target_file.to_string_lossy()
             ),
             Error::VariableReuseInPattern(identifier) => write!(
                 f,

--- a/src/error.rs
+++ b/src/error.rs
@@ -500,6 +500,9 @@ pub enum Error {
     MainNoInputs,
     MainNoOutput,
     MainRequired,
+    MainOutOfEntryFile,
+    MainCannotBePublic,
+    MainCannotBeAlias,
     FunctionRedefined(FunctionName),
     FunctionUndefined(FunctionName),
     InvalidNumberOfArguments(usize, usize),
@@ -602,6 +605,18 @@ impl fmt::Display for Error {
             Error::MainRequired => write!(
                 f,
                 "Main function is required"
+            ),
+            Error::MainOutOfEntryFile => write!(
+                f,
+                "The 'main' function must be defined in the entry point file"
+            ),
+            Error::MainCannotBePublic => write!(
+                f,
+                "Main function cannot be public"
+            ),
+            Error::MainCannotBeAlias => write!(
+                f,
+                "Main function cannot be alias",
             ),
             Error::FunctionRedefined(name) => write!(
                 f,

--- a/src/error.rs
+++ b/src/error.rs
@@ -192,11 +192,11 @@ impl RichError {
     /// Add the source file where the error occurred.
     ///
     /// Enable pretty errors.
-    pub fn with_source(self, source: SourceFile) -> Self {
+    pub fn with_source(self, source: impl Into<SourceFile>) -> Self {
         Self {
             error: self.error,
             span: self.span,
-            source: Some(source),
+            source: Some(source.into()),
         }
     }
 
@@ -421,7 +421,7 @@ impl ErrorCollector {
         Self { errors: Vec::new() }
     }
 
-    /// Exten existing errors with specific `RichError`.
+    /// Extend existing errors with specific `RichError`.
     /// We assume that `RichError` contains `SourceFile`.
     pub fn push(&mut self, error: RichError) {
         self.errors.push(error);
@@ -429,12 +429,25 @@ impl ErrorCollector {
 
     /// Appends new errors, tagging them with the provided source context.
     /// Automatically handles both single-file and multi-file environments.
-    pub fn extend(&mut self, source: SourceFile, errors: impl IntoIterator<Item = RichError>) {
+    pub fn extend(
+        &mut self,
+        source: impl Into<SourceFile> + Clone,
+        errors: impl IntoIterator<Item = RichError>,
+    ) {
         let new_errors = errors
             .into_iter()
             .map(|err| err.with_source(source.clone()));
 
         self.errors.extend(new_errors);
+    }
+
+    /// The same idea applies to the `extend()` function.
+    pub fn extend_with_handler(
+        &mut self,
+        source: impl Into<SourceFile> + Clone,
+        handler: &ErrorCollector,
+    ) {
+        self.extend(source, handler.errors.iter().cloned());
     }
 
     pub fn get(&self) -> &[RichError] {

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,6 +15,7 @@ use simplicity::elements;
 
 use crate::lexer::Token;
 use crate::parse::MatchPattern;
+use crate::resolution::SourceFile;
 use crate::str::{AliasName, FunctionName, Identifier, JetName, ModuleName, WitnessName};
 use crate::types::{ResolvedType, UIntType};
 
@@ -119,16 +120,30 @@ impl<T, E: Into<Error>> WithSpan<T> for Result<T, E> {
 }
 
 /// Helper trait to update `Result<A, RichError>` with the affected source file.
-pub trait WithFile<T> {
+pub trait WithContent<T> {
     /// Update the result with the affected source file.
     ///
     /// Enable pretty errors.
-    fn with_file<F: Into<Arc<str>>>(self, file: F) -> Result<T, RichError>;
+    fn with_content<C: Into<Arc<str>>>(self, content: C) -> Result<T, RichError>;
 }
 
-impl<T> WithFile<T> for Result<T, RichError> {
-    fn with_file<F: Into<Arc<str>>>(self, file: F) -> Result<T, RichError> {
-        self.map_err(|e| e.with_file(file.into()))
+impl<T> WithContent<T> for Result<T, RichError> {
+    fn with_content<C: Into<Arc<str>>>(self, content: C) -> Result<T, RichError> {
+        self.map_err(|e| e.with_content(content.into()))
+    }
+}
+
+/// Helper trait to update `Result<A, RichError>` with the affected source file.
+pub trait WithSource<T> {
+    /// Update the result with the affected source file.
+    ///
+    /// Enable pretty errors.
+    fn with_source<S: Into<SourceFile>>(self, source: S) -> Result<T, RichError>;
+}
+
+impl<T> WithSource<T> for Result<T, RichError> {
+    fn with_source<S: Into<SourceFile>>(self, source: S) -> Result<T, RichError> {
+        self.map_err(|e| e.with_source(source.into()))
     }
 }
 
@@ -146,10 +161,10 @@ pub struct RichError {
     /// Area that the error spans inside the file.
     span: Span,
 
-    /// File in which the error occurred.
+    /// File context in which the error occurred.
     ///
     /// Required to print pretty errors.
-    file: Option<Arc<str>>,
+    source: Option<SourceFile>,
 }
 
 impl RichError {
@@ -158,18 +173,30 @@ impl RichError {
         RichError {
             error: Box::new(error),
             span,
-            file: None,
+            source: None,
+        }
+    }
+
+    /// Adds raw source code content to the error context.
+    ///
+    /// Use this when the error occurs in an environment without a backing physical file
+    /// (e.g., raw string input for single-file program) to enable basic error formatting.
+    pub fn with_content(self, program_content: Arc<str>) -> Self {
+        Self {
+            error: self.error,
+            span: self.span,
+            source: Some(SourceFile::anonymous(program_content)),
         }
     }
 
     /// Add the source file where the error occurred.
     ///
     /// Enable pretty errors.
-    pub fn with_file(self, file: Arc<str>) -> Self {
+    pub fn with_source(self, source: SourceFile) -> Self {
         Self {
             error: self.error,
             span: self.span,
-            file: Some(file),
+            source: Some(source),
         }
     }
 
@@ -179,12 +206,12 @@ impl RichError {
         Self {
             error: Box::new(Error::CannotParse(reason.to_string())),
             span: Span::new(0, 0),
-            file: None,
+            source: None,
         }
     }
 
-    pub fn file(&self) -> &Option<Arc<str>> {
-        &self.file
+    pub fn source(&self) -> &Option<SourceFile> {
+        &self.source
     }
 
     pub fn error(&self) -> &Error {
@@ -216,47 +243,61 @@ impl fmt::Display for RichError {
             (line, col + 1)
         }
 
-        match self.file {
-            Some(ref file) if !file.is_empty() => {
-                let (start_line, start_col) = get_line_col(file, self.span.start);
-                let (end_line, end_col) = get_line_col(file, self.span.end);
+        let Some(source) = &self.source else {
+            return write!(f, "{}", self.error);
+        };
 
-                let start_line_index = start_line - 1;
+        let content = source.content();
 
-                let n_spanned_lines = end_line - start_line_index;
-                let line_num_width = end_line.to_string().len();
-
-                writeln!(f, "{:width$} |", " ", width = line_num_width)?;
-
-                let mut lines = file
-                    .split(|c: char| c.is_newline())
-                    .skip(start_line_index)
-                    .peekable();
-
-                let start_line_len = lines
-                    .peek()
-                    .map_or(0, |l| l.chars().map(char::len_utf16).sum());
-
-                for (relative_line_index, line_str) in lines.take(n_spanned_lines).enumerate() {
-                    let line_num = start_line_index + relative_line_index + 1;
-                    writeln!(f, "{line_num:line_num_width$} | {line_str}")?;
-                }
-
-                let is_multiline = end_line > start_line;
-
-                let (underline_start, underline_length) = match is_multiline {
-                    true => (0, start_line_len),
-                    false => (start_col, (end_col - start_col).max(1)),
-                };
-                write!(f, "{:width$} |", " ", width = line_num_width)?;
-                write!(f, "{:width$}", " ", width = underline_start)?;
-                write!(f, "{:^<width$} ", "", width = underline_length)?;
-                write!(f, "{}", self.error)
-            }
-            _ => {
-                write!(f, "{}", self.error)
-            }
+        if content.is_empty() {
+            return write!(f, "{}", self.error);
         }
+
+        let (start_line, start_col) = get_line_col(&content, self.span.start);
+        let (end_line, end_col) = get_line_col(&content, self.span.end);
+
+        let start_line_index = start_line - 1;
+
+        let n_spanned_lines = end_line - start_line_index;
+        let line_num_width = end_line.to_string().len();
+
+        if let Some(name) = source.name() {
+            writeln!(
+                f,
+                "{:>width$}--> {}:{}:{}",
+                "",
+                name.display(),
+                start_line,
+                start_col,
+                width = line_num_width
+            )?;
+        }
+
+        writeln!(f, "{:width$} |", " ", width = line_num_width)?;
+
+        let mut lines = content
+            .split(|c: char| c.is_newline())
+            .skip(start_line_index)
+            .peekable();
+        let start_line_len = lines
+            .peek()
+            .map_or(0, |l| l.chars().map(char::len_utf16).sum());
+
+        for (relative_line_index, line_str) in lines.take(n_spanned_lines).enumerate() {
+            let line_num = start_line_index + relative_line_index + 1;
+            writeln!(f, "{line_num:line_num_width$} | {line_str}")?;
+        }
+
+        let is_multiline = end_line > start_line;
+
+        let (underline_start, underline_length) = match is_multiline {
+            true => (0, start_line_len),
+            false => (start_col, (end_col - start_col).max(1)),
+        };
+        write!(f, "{:width$} |", " ", width = line_num_width)?;
+        write!(f, "{:width$}", " ", width = underline_start)?;
+        write!(f, "{:^<width$} ", "", width = underline_length)?;
+        write!(f, "{}", self.error)
     }
 }
 
@@ -322,7 +363,7 @@ where
                 found: found_string,
             }),
             span,
-            file: None,
+            source: None,
         }
     }
 }
@@ -349,7 +390,7 @@ where
                 found: found_string,
             }),
             span,
-            file: None,
+            source: None,
         }
     }
 
@@ -365,26 +406,33 @@ where
 
 #[derive(Debug, Clone, Hash)]
 pub struct ErrorCollector {
-    /// File in which the error occurred.
-    file: Arc<str>,
-
     /// Collected errors.
     errors: Vec<RichError>,
 }
 
+impl Default for ErrorCollector {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ErrorCollector {
-    pub fn new(file: Arc<str>) -> Self {
-        Self {
-            file,
-            errors: Vec::new(),
-        }
+    pub fn new() -> Self {
+        Self { errors: Vec::new() }
     }
 
-    /// Extend existing errors with slice of new errors.
-    pub fn update(&mut self, errors: impl IntoIterator<Item = RichError>) {
+    /// Exten existing errors with specific `RichError`.
+    /// We assume that `RichError` contains `SourceFile`.
+    pub fn push(&mut self, error: RichError) {
+        self.errors.push(error);
+    }
+
+    /// Appends new errors, tagging them with the provided source context.
+    /// Automatically handles both single-file and multi-file environments.
+    pub fn extend(&mut self, source: SourceFile, errors: impl IntoIterator<Item = RichError>) {
         let new_errors = errors
             .into_iter()
-            .map(|err| err.with_file(Arc::clone(&self.file)));
+            .map(|err| err.with_source(source.clone()));
 
         self.errors.extend(new_errors);
     }
@@ -393,8 +441,8 @@ impl ErrorCollector {
         &self.errors
     }
 
-    pub fn is_empty(&self) -> bool {
-        self.get().is_empty()
+    pub fn has_errors(&self) -> bool {
+        !self.errors.is_empty()
     }
 }
 
@@ -689,7 +737,7 @@ impl From<simplicity::types::Error> for Error {
 mod tests {
     use super::*;
 
-    const FILE: &str = r#"let a1: List<u32, 5> = None;
+    const CONTENT: &str = r#"let a1: List<u32, 5> = None;
 let x: u32 = Left(
     Right(0)
 );"#;
@@ -699,7 +747,7 @@ let x: u32 = Left(
     fn display_single_line() {
         let error = Error::ListBoundPow2(5)
             .with_span(Span::new(13, 19))
-            .with_file(Arc::from(FILE));
+            .with_content(Arc::from(CONTENT));
         let expected = r#"
   |
 1 | let a1: List<u32, 5> = None;
@@ -712,8 +760,8 @@ let x: u32 = Left(
         let error = Error::CannotParse(
             "Expected value of type `u32`, got `Either<Either<_, u32>, _>`".to_string(),
         )
-        .with_span(Span::new(41, FILE.len()))
-        .with_file(Arc::from(FILE));
+        .with_span(Span::new(41, CONTENT.len()))
+        .with_content(Arc::from(CONTENT));
         let expected = r#"
   |
 2 | let x: u32 = Left(
@@ -726,8 +774,8 @@ let x: u32 = Left(
     #[test]
     fn display_entire_file() {
         let error = Error::CannotParse("This span covers the entire file".to_string())
-            .with_span(Span::from(FILE))
-            .with_file(Arc::from(FILE));
+            .with_span(Span::from(CONTENT))
+            .with_content(Arc::from(CONTENT));
         let expected = r#"
   |
 1 | let a1: List<u32, 5> = None;
@@ -754,7 +802,7 @@ let x: u32 = Left(
     fn display_empty_file() {
         let error = Error::CannotParse("This error has an empty file".to_string())
             .with_span(Span::from(EMPTY_FILE))
-            .with_file(Arc::from(EMPTY_FILE));
+            .with_content(Arc::from(EMPTY_FILE));
         let expected = "Cannot parse: This error has an empty file";
         assert_eq!(&expected, &error.to_string());
     }
@@ -764,7 +812,7 @@ let x: u32 = Left(
         let file = "/*😀*/ let a: u8 = 65536;";
         let error = Error::CannotParse("number too large to fit in target type".to_string())
             .with_span(Span::new(21, 26))
-            .with_file(Arc::from(file));
+            .with_content(Arc::from(file));
 
         let expected = r#"
   |
@@ -783,7 +831,7 @@ let x: u32 = Left(
 );"#;
         let error = Error::CannotParse("This span covers the entire file".to_string())
             .with_span(Span::from(file))
-            .with_file(Arc::from(file));
+            .with_content(Arc::from(file));
 
         let expected = r#"
   |
@@ -802,7 +850,7 @@ let x: u32 = Left(
         let file = "let a: u8 = 65536;\u{2028}let b: u8 = 0;";
         let error = Error::CannotParse("number too large to fit in target type".to_string())
             .with_span(Span::new(12, 17))
-            .with_file(Arc::from(file));
+            .with_content(Arc::from(file));
 
         let expected = r#"
   |
@@ -817,7 +865,7 @@ let x: u32 = Left(
         let file = "fn main()";
         let error = Error::Grammar("Error span at (0,0)".to_string())
             .with_span(Span::new(0, 0))
-            .with_file(Arc::from(file));
+            .with_content(Arc::from(file));
 
         let expected = r#"
   |
@@ -831,13 +879,69 @@ let x: u32 = Left(
         let file = "fn main(){\n    let a:\n";
         let error = Error::CannotParse("eof".to_string())
             .with_span(Span::new(file.len(), file.len()))
-            .with_file(Arc::from(file));
+            .with_content(Arc::from(file));
 
         let expected = r#"
   |
 3 | 
   | ^ Cannot parse: eof"#;
 
+        assert_eq!(&expected[1..], &error.to_string());
+    }
+
+    // --- Tests with filename ---
+    #[test]
+    fn display_single_line_with_file() {
+        let source = SourceFile::new(std::path::Path::new("src/main.simf"), Arc::from(CONTENT));
+        let error = Error::ListBoundPow2(5)
+            .with_span(Span::new(13, 19))
+            .with_source(source);
+
+        let expected = r#"
+ --> src/main.simf:1:14
+  |
+1 | let a1: List<u32, 5> = None;
+  |              ^^^^^^ Expected a power of two greater than one (2, 4, 8, 16, 32, ...) as list bound, found 5"#;
+        assert_eq!(&expected[1..], &error.to_string());
+    }
+
+    #[test]
+    fn display_multi_line_with_file() {
+        let source = SourceFile::new(std::path::Path::new("lib/parser.simf"), Arc::from(CONTENT));
+        let error = Error::CannotParse(
+            "Expected value of type `u32`, got `Either<Either<_, u32>, _>`".to_string(),
+        )
+        .with_span(Span::new(41, CONTENT.len()))
+        .with_source(source);
+
+        let expected = r#"
+ --> lib/parser.simf:2:13
+  |
+2 | let x: u32 = Left(
+3 |     Right(0)
+4 | );
+  | ^^^^^^^^^^^^^^^^^^ Cannot parse: Expected value of type `u32`, got `Either<Either<_, u32>, _>`"#;
+        assert_eq!(&expected[1..], &error.to_string());
+    }
+
+    #[test]
+    fn display_entire_file_with_file() {
+        let source = SourceFile::new(
+            std::path::Path::new("tests/integration.simf"),
+            Arc::from(CONTENT),
+        );
+        let error = Error::CannotParse("This span covers the entire file".to_string())
+            .with_span(Span::from(CONTENT))
+            .with_source(source);
+
+        let expected = r#"
+ --> tests/integration.simf:1:1
+  |
+1 | let a1: List<u32, 5> = None;
+2 | let x: u32 = Left(
+3 |     Right(0)
+4 | );
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Cannot parse: This span covers the entire file"#;
         assert_eq!(&expected[1..], &error.to_string());
     }
 }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -11,6 +11,8 @@ pub type Tokens<'src> = Vec<(Token<'src>, crate::error::Span)>;
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Token<'src> {
     // Keywords
+    Pub,
+    Use,
     Fn,
     Let,
     Type,
@@ -66,6 +68,8 @@ pub enum Token<'src> {
 impl<'src> fmt::Display for Token<'src> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Token::Pub => write!(f, "pub"),
+            Token::Use => write!(f, "use"),
             Token::Fn => write!(f, "fn"),
             Token::Let => write!(f, "let"),
             Token::Type => write!(f, "type"),
@@ -138,6 +142,8 @@ pub fn lexer<'src>(
         choice((just("assert!"), just("panic!"), just("dbg!"), just("list!"))).map(Token::Macro);
 
     let keyword = text::ident().map(|s| match s {
+        "pub" => Token::Pub,
+        "use" => Token::Use,
         "fn" => Token::Fn,
         "let" => Token::Let,
         "type" => Token::Type,
@@ -247,7 +253,7 @@ pub fn lex<'src>(input: &'src str) -> (Option<Tokens<'src>>, Vec<crate::error::R
 pub fn is_keyword(s: &str) -> bool {
     matches!(
         s,
-        "fn" | "let" | "type" | "mod" | "const" | "match" | "true" | "false"
+        "pub" | "use" | "fn" | "let" | "type" | "mod" | "const" | "match" | "true" | "false"
     )
 }
 

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -13,6 +13,7 @@ pub enum Token<'src> {
     // Keywords
     Pub,
     Use,
+    As,
     Fn,
     Let,
     Type,
@@ -70,6 +71,7 @@ impl<'src> fmt::Display for Token<'src> {
         match self {
             Token::Pub => write!(f, "pub"),
             Token::Use => write!(f, "use"),
+            Token::As => write!(f, "as"),
             Token::Fn => write!(f, "fn"),
             Token::Let => write!(f, "let"),
             Token::Type => write!(f, "type"),
@@ -144,6 +146,7 @@ pub fn lexer<'src>(
     let keyword = text::ident().map(|s| match s {
         "pub" => Token::Pub,
         "use" => Token::Use,
+        "as" => Token::As,
         "fn" => Token::Fn,
         "let" => Token::Let,
         "type" => Token::Type,
@@ -253,7 +256,7 @@ pub fn lex<'src>(input: &'src str) -> (Option<Tokens<'src>>, Vec<crate::error::R
 pub fn is_keyword(s: &str) -> bool {
     matches!(
         s,
-        "pub" | "use" | "fn" | "let" | "type" | "mod" | "const" | "match" | "true" | "false"
+        "pub" | "use" | "as" | "fn" | "let" | "type" | "mod" | "const" | "match" | "true" | "false"
     )
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,9 +36,10 @@ pub extern crate simplicity;
 pub use simplicity::elements;
 
 use crate::debug::DebugSymbols;
-use crate::error::{ErrorCollector, WithContent};
+use crate::driver::DependencyGraph;
+use crate::error::{ErrorCollector, WithContent, WithSource as _};
 use crate::parse::ParseFromStrWithErrors;
-use crate::resolution::SourceFile;
+use crate::resolution::{DependencyMap, SourceFile};
 pub use crate::types::ResolvedType;
 pub use crate::value::Value;
 pub use crate::witness::{Arguments, Parameters, WitnessTypes, WitnessValues};
@@ -53,6 +54,49 @@ pub struct TemplateProgram {
 }
 
 impl TemplateProgram {
+    // TODO: Consider passing `CanonSourceFile`` deeper into the driver to avoid paying the path canonicalization cost multiple times.
+    /// Parse the template of a SimplicityHL program.
+    ///
+    /// ## Errors
+    ///
+    /// The string is not a valid SimplicityHL program.
+    pub fn new_with_dep(
+        source: SourceFile,
+        dependency_map: &DependencyMap,
+    ) -> Result<Self, String> {
+        let mut error_handler = ErrorCollector::new();
+
+        // 1. Parse root file
+        let parsed_program =
+            parse::Program::parse_from_str_with_errors(source.clone(), &mut error_handler)
+                .ok_or_else(|| error_handler.to_string())?;
+
+        // 2. Create the driver program
+        let driver_program: driver::Program = if dependency_map.is_empty() {
+            driver::Program::from_parse(&parsed_program, source.content(), &mut error_handler)
+                .ok_or_else(|| error_handler.to_string())?
+        } else {
+            let graph = DependencyGraph::new(
+                source.clone(),
+                Arc::from(dependency_map.clone()),
+                &parsed_program,
+                &mut error_handler,
+            )?
+            .ok_or_else(|| error_handler.to_string())?;
+
+            graph
+                .linearize_and_build(&mut error_handler)?
+                .ok_or_else(|| error_handler.to_string())?
+        };
+
+        // 3. AST Analysis
+        let ast_program = ast::Program::analyze(&driver_program).with_source(source.clone())?;
+        Ok(Self {
+            simfony: ast_program,
+            file: source.content(),
+        })
+    }
+
     /// Parse the template of a SimplicityHL program.
     ///
     /// ## Errors
@@ -137,6 +181,22 @@ pub struct CompiledProgram {
 }
 
 impl CompiledProgram {
+    /// Parse and compile a SimplicityHL program from the given
+    ///
+    /// ## See
+    ///
+    /// - [`TemplateProgram::new_with_dep`]
+    /// - [`TemplateProgram::instantiate`]
+    pub fn new_with_dep(
+        source: SourceFile,
+        dependency_map: &DependencyMap,
+        arguments: Arguments,
+        include_debug_symbols: bool,
+    ) -> Result<Self, String> {
+        TemplateProgram::new_with_dep(source, dependency_map)
+            .and_then(|template| template.instantiate(arguments, include_debug_symbols))
+    }
+
     /// Parse and compile a SimplicityHL program from the given string.
     ///
     /// ## See
@@ -339,11 +399,12 @@ pub trait ArbitraryOfType: Sized {
 #[cfg(test)]
 pub(crate) mod tests {
     use crate::parse::ParseFromStr;
+    use crate::resolution::CanonPath;
     use base64::display::Base64Display;
     use base64::engine::general_purpose::STANDARD;
     use simplicity::BitMachine;
     use std::borrow::Cow;
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
 
     use crate::*;
 
@@ -358,6 +419,23 @@ pub(crate) mod tests {
         pub fn template_file<P: AsRef<Path>>(program_file_path: P) -> Self {
             let program_text = std::fs::read_to_string(program_file_path).unwrap();
             Self::template_text(Cow::Owned(program_text))
+        }
+
+        pub fn template_deps(prog_path: &Path, dependency_map: &DependencyMap) -> Self {
+            let program_text = std::fs::read_to_string(prog_path).unwrap();
+            let source = SourceFile::new(prog_path, Arc::from(program_text));
+
+            let program = match TemplateProgram::new_with_dep(source, dependency_map) {
+                Ok(x) => x,
+                Err(error) => panic!("{error}"),
+            };
+
+            Self {
+                program,
+                lock_time: elements::LockTime::ZERO,
+                sequence: elements::Sequence::MAX,
+                include_fee_output: false,
+            }
         }
 
         pub fn template_text(program_text: Cow<str>) -> Self {
@@ -408,6 +486,26 @@ pub(crate) mod tests {
 
         pub fn program_text(program_text: Cow<str>) -> Self {
             TestCase::<TemplateProgram>::template_text(program_text)
+                .with_arguments(Arguments::default())
+        }
+
+        pub fn program_file_with_deps<P, I, K>(prog_path: P, dependencies: I) -> Self
+        where
+            P: AsRef<Path>,
+            I: IntoIterator<Item = (P, K, P)>,
+            K: Into<String>,
+        {
+            let mut dependency_map = DependencyMap::new();
+            for (context, alias, target) in dependencies {
+                let context = CanonPath::canonicalize(context.as_ref()).unwrap();
+                let target = CanonPath::canonicalize(target.as_ref()).unwrap();
+
+                dependency_map
+                    .insert(context, alias.into(), target)
+                    .unwrap();
+            }
+
+            TestCase::<TemplateProgram>::template_deps(prog_path.as_ref(), &dependency_map)
                 .with_arguments(Arguments::default())
         }
 
@@ -508,6 +606,101 @@ pub(crate) mod tests {
                 Base64Display::new(&witness_bytes, &STANDARD).to_string(),
             )
         }
+    }
+
+    /// THE DEFAULT HELPER
+    /// Automatically sets up the standard `lib` self-referencing dependency.
+    fn run_dependency_test(root_path: &str, lib_alias: &str) {
+        let root_path = PathBuf::from(root_path);
+        let lib_path = root_path.join(lib_alias);
+        let main_path = root_path.join("main.simf");
+
+        TestCase::program_file_with_deps(
+            &main_path,
+            [
+                (&root_path, lib_alias, &lib_path),
+                (&lib_path, lib_alias, &lib_path),
+            ],
+        )
+        .with_witness_values(WitnessValues::default())
+        .assert_run_success();
+    }
+
+    /// THE ADVANCED HELPER
+    /// A helper function to run standard library dependency tests.
+    /// `deps` expects an array of tuples: `(context_folder, alias, target_folder)`.
+    /// Use `"."` for the `context_folder` if the context is the root test directory.
+    fn run_multidep_test(root_path: &str, deps: &[(&str, &str, &str)]) {
+        let root_path = PathBuf::from(root_path);
+        let main_path = root_path.join("main.simf");
+
+        // Convert the string slices into proper PathBufs dynamically
+        let mapped_deps: Vec<(PathBuf, &str, PathBuf)> = deps
+            .iter()
+            .map(|(ctx, alias, target)| {
+                let ctx_path = if *ctx == "." {
+                    root_path.clone()
+                } else {
+                    root_path.join(ctx)
+                };
+
+                let target_path = root_path.join(target);
+
+                (ctx_path, *alias, target_path)
+            })
+            .collect();
+
+        let ref_deps = mapped_deps.iter().map(|(c, a, t)| (c, *a, t));
+
+        TestCase::program_file_with_deps(&main_path, ref_deps)
+            .with_witness_values(WitnessValues::default())
+            .assert_run_success();
+    }
+
+    /// Run with `simc` command:
+    ///
+    /// ```
+    /// simc examples/single_dep/main.simf \
+    ///   --dep examples/single_dep/:temp=examples/single_dep/temp/
+    /// ```
+    #[test]
+    fn single_dep() {
+        run_dependency_test("./examples/single_dep", "temp");
+    }
+
+    /// Run with `simc` command:
+    ///
+    /// ```
+    /// simc examples/simple_multidep/main.simf \
+    ///   --dep examples/simple_multidep/:math=examples/simple_multidep/math/ \
+    ///   --dep examples/simple_multidep/:crypto=examples/simple_multidep/crypto/
+    /// ```
+    #[test]
+    fn simple_multidep() {
+        run_multidep_test(
+            "./examples/simple_multidep",
+            &[(".", "math", "math"), (".", "crypto", "crypto")],
+        );
+    }
+
+    /// Run with `simc` command:
+    ///
+    /// ```
+    /// simc examples/multiple_deps/main.simf \
+    ///   --dep examples/multiple_deps/:merkle=examples/multiple_deps/merkle/ \
+    ///   --dep examples/multiple_deps/:base_math=examples/multiple_deps/math/ \
+    ///   --dep examples/multiple_deps/merkle/:math=examples/multiple_deps/math/
+    /// ```
+    #[test]
+    fn multiple_deps() {
+        run_multidep_test(
+            "./examples/multiple_deps",
+            &[
+                (".", "merkle", "merkle"),
+                (".", "base_math", "math"),
+                ("merkle", "math", "math"),
+            ],
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod compile;
 pub mod debug;
 #[cfg(feature = "docs")]
 pub mod docs;
+pub mod driver;
 pub mod dummy_env;
 pub mod error;
 pub mod jet;
@@ -37,6 +38,7 @@ pub use simplicity::elements;
 use crate::debug::DebugSymbols;
 use crate::error::{ErrorCollector, WithContent};
 use crate::parse::ParseFromStrWithErrors;
+use crate::resolution::SourceFile;
 pub use crate::types::ResolvedType;
 pub use crate::value::Value;
 pub use crate::witness::{Arguments, Parameters, WitnessTypes, WitnessValues};
@@ -58,8 +60,10 @@ impl TemplateProgram {
     /// The string is not a valid SimplicityHL program.
     pub fn new<Str: Into<Arc<str>>>(s: Str) -> Result<Self, String> {
         let file = s.into();
+        let source = SourceFile::anonymous(file.clone());
         let mut error_handler = ErrorCollector::new();
-        let parse_program = parse::Program::parse_from_str_with_errors(&file, &mut error_handler);
+        let parse_program = parse::Program::parse_from_str_with_errors(source, &mut error_handler);
+
         if let Some(program) = parse_program {
             let ast_program = ast::Program::analyze(&program).with_content(Arc::clone(&file))?;
             Ok(Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,13 @@ impl TemplateProgram {
         let mut error_handler = ErrorCollector::new();
         let parse_program = parse::Program::parse_from_str_with_errors(source, &mut error_handler);
 
-        if let Some(program) = parse_program {
+        let driver_program = if let Some(parse_program) = parse_program {
+            driver::Program::from_parse(&parse_program, file.clone(), &mut error_handler)
+        } else {
+            None
+        };
+
+        if let Some(program) = driver_program {
             let ast_program = ast::Program::analyze(&program).with_content(Arc::clone(&file))?;
             Ok(Self {
                 simfony: ast_program,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ pub extern crate simplicity;
 pub use simplicity::elements;
 
 use crate::debug::DebugSymbols;
-use crate::error::{ErrorCollector, WithFile};
+use crate::error::{ErrorCollector, WithContent};
 use crate::parse::ParseFromStrWithErrors;
 pub use crate::types::ResolvedType;
 pub use crate::value::Value;
@@ -56,10 +56,10 @@ impl TemplateProgram {
     /// The string is not a valid SimplicityHL program.
     pub fn new<Str: Into<Arc<str>>>(s: Str) -> Result<Self, String> {
         let file = s.into();
-        let mut error_handler = ErrorCollector::new(Arc::clone(&file));
+        let mut error_handler = ErrorCollector::new();
         let parse_program = parse::Program::parse_from_str_with_errors(&file, &mut error_handler);
         if let Some(program) = parse_program {
-            let ast_program = ast::Program::analyze(&program).with_file(Arc::clone(&file))?;
+            let ast_program = ast::Program::analyze(&program).with_content(Arc::clone(&file))?;
             Ok(Self {
                 simfony: ast_program,
                 file,
@@ -97,7 +97,7 @@ impl TemplateProgram {
         let commit = self
             .simfony
             .compile(arguments, include_debug_symbols)
-            .with_file(Arc::clone(&self.file))?;
+            .with_content(Arc::clone(&self.file))?;
 
         Ok(CompiledProgram {
             debug_symbols: self.simfony.debug_symbols(self.file.as_ref()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1103,6 +1103,99 @@ fn main() {
 }
 
 #[cfg(test)]
+mod error_tests {
+    use std::path::Path;
+
+    use super::*;
+
+    use crate::resolution::tests::canon;
+    use crate::resolution::CanonPath;
+    use crate::test_utils::TempWorkspace;
+
+    fn dependency_map(root_dir: &Path, drp: &str, lib_dir: &Path) -> DependencyMap {
+        let mut dependency_map = DependencyMap::new();
+
+        let context = CanonPath::canonicalize(root_dir).unwrap();
+        let target = CanonPath::canonicalize(lib_dir).unwrap();
+
+        dependency_map.insert(context, drp.into(), target).unwrap();
+
+        dependency_map
+    }
+
+    fn source_file(path: &Path) -> SourceFile {
+        let content = std::fs::read_to_string(path).expect("Failed to read test file");
+        SourceFile::new(path, Arc::from(content))
+    }
+
+    #[test]
+    #[ignore = "TODO: Bug in Error Handler. Expected to be fixed in a future update to correctly point to dependency source files."]
+    fn dependency_ast_errors_use_dependency_source_file() {
+        let ws = TempWorkspace::new("dependency_ast_error_source");
+        let root_dir = ws.create_dir("workspace");
+        let lib_dir = ws.create_dir("workspace/lib");
+        let main_path = ws.create_file(
+            "workspace/main.simf",
+            "use lib::bad::f;\nfn main() { f(); }\n",
+        );
+        let bad_path = ws.create_file(
+            "workspace/lib/bad.simf",
+            "pub fn f() { let x: u32 = true; }\n",
+        );
+
+        let dependencies = dependency_map(&root_dir, "lib", &lib_dir);
+
+        let err = TemplateProgram::new_with_dep(source_file(&main_path), &dependencies)
+            .expect_err("dependency body has a type error");
+        let dependency_source = canon(&bad_path).as_path().display().to_string();
+
+        assert!(
+            err.contains(&dependency_source),
+            "expected diagnostic to point at dependency source {dependency_source}, got:\n{err}"
+        );
+    }
+
+    #[test]
+    fn omitted_context_dependency_applies_inside_dependency_files() {
+        let ws = TempWorkspace::new("omitted_context_dependency");
+        let lib_dir = ws.create_dir("workspace/lib");
+        let main_path = ws.create_file(
+            "workspace/main.simf",
+            "use lib::nested::two;\nfn main() { assert!(jet::eq_32(two(), 2)); }\n",
+        );
+        ws.create_file(
+            "workspace/lib/nested.simf",
+            "use lib::base::one;\npub fn two() -> u32 {\n    let (_, out): (bool, u32) = jet::add_32(one(), 1);\n    out\n}\n",
+        );
+        ws.create_file("workspace/lib/base.simf", "pub fn one() -> u32 { 1 }\n");
+
+        let dependencies = dependency_map(&main_path, "lib", &lib_dir);
+        let _err = TemplateProgram::new_with_dep(source_file(&main_path), &dependencies)
+            .expect_err("omitted-context dependencies");
+    }
+
+    #[test]
+    fn missing_mapped_module_is_reported_as_file_not_found() {
+        let ws = TempWorkspace::new("missing_mapped_module");
+        let root_dir = ws.create_dir("workspace");
+        let lib_dir = ws.create_dir("workspace/lib");
+        let main_path = ws.create_file(
+            "workspace/main.simf",
+            "use lib::missing::Thing;\nfn main() {}\n",
+        );
+        let dependencies = dependency_map(&root_dir, "lib", &lib_dir);
+
+        let err = TemplateProgram::new_with_dep(source_file(&main_path), &dependencies)
+            .expect_err("missing imported module should fail");
+
+        assert!(
+            err.contains("missing.simf"),
+            "diagnostic should mention the missing module path, got:\n{err}"
+        );
+    }
+}
+
+#[cfg(test)]
 mod functional_tests {
     use crate::tests::{run_dependency_test, run_multidep_test};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,8 @@ pub mod resolution;
 #[cfg(feature = "serde")]
 mod serde;
 pub mod str;
+#[cfg(test)]
+pub mod test_utils;
 pub mod tracker;
 pub mod types;
 pub mod value;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -610,7 +610,7 @@ pub(crate) mod tests {
 
     /// THE DEFAULT HELPER
     /// Automatically sets up the standard `lib` self-referencing dependency.
-    fn run_dependency_test(root_path: &str, lib_alias: &str) {
+    pub(crate) fn run_dependency_test(root_path: &str, lib_alias: &str) {
         let root_path = PathBuf::from(root_path);
         let lib_path = root_path.join(lib_alias);
         let main_path = root_path.join("main.simf");
@@ -630,7 +630,7 @@ pub(crate) mod tests {
     /// A helper function to run standard library dependency tests.
     /// `deps` expects an array of tuples: `(context_folder, alias, target_folder)`.
     /// Use `"."` for the `context_folder` if the context is the root test directory.
-    fn run_multidep_test(root_path: &str, deps: &[(&str, &str, &str)]) {
+    pub(crate) fn run_multidep_test(root_path: &str, deps: &[(&str, &str, &str)]) {
         let root_path = PathBuf::from(root_path);
         let main_path = root_path.join("main.simf");
 
@@ -1099,5 +1099,133 @@ fn main() {
         fn transfer_with_timeout_regression() {
             regression_test("transfer_with_timeout");
         }
+    }
+}
+
+#[cfg(test)]
+mod functional_tests {
+    use crate::tests::{run_dependency_test, run_multidep_test};
+
+    const VALID_TESTS_DIR: &str = "./functional-tests/valid-test-cases";
+    const ERROR_TESTS_DIR: &str = "./functional-tests/error-test-cases";
+
+    // Real test cases
+    #[test]
+    fn module_simple() {
+        run_dependency_test(format!("{}/module-simple", VALID_TESTS_DIR).as_str(), "lib");
+    }
+
+    #[test]
+    fn diamond_dependency_resolution() {
+        run_dependency_test(
+            format!("{}/diamond-dependency-resolution", VALID_TESTS_DIR).as_str(),
+            "lib",
+        );
+    }
+
+    #[test]
+    fn deep_reexport_chain() {
+        run_dependency_test(
+            format!("{}/deep-reexport-chain", VALID_TESTS_DIR).as_str(),
+            "lib",
+        );
+    }
+
+    #[test]
+    fn leaky_signature() {
+        run_dependency_test(
+            format!("{}/leaky-signature", VALID_TESTS_DIR).as_str(),
+            "lib",
+        );
+    }
+
+    #[test]
+    fn reexport_diamond() {
+        run_dependency_test(
+            format!("{}/reexport-diamond", VALID_TESTS_DIR).as_str(),
+            "lib",
+        );
+    }
+
+    #[test]
+    fn multi_lib_facade_resolution() {
+        run_multidep_test(
+            format!("{}/multi-lib-facade", VALID_TESTS_DIR).as_str(),
+            &[
+                (".", "api", "api"),
+                ("crypto", "math", "math"),
+                ("api", "crypto", "crypto"),
+                ("api", "math", "math"),
+            ],
+        );
+    }
+
+    #[test]
+    fn interleaved_waterfall() {
+        run_multidep_test(
+            format!("{}/interleaved-waterfall", VALID_TESTS_DIR).as_str(),
+            &[
+                (".", "orch", "orch"),
+                ("orch", "db", "db"),
+                ("orch", "auth", "auth"),
+                ("orch", "types", "types"),
+                ("db", "types", "types"),
+                ("auth", "types", "types"),
+                ("auth", "db", "db"),
+            ],
+        );
+    }
+
+    // Error tests
+    #[test]
+    #[should_panic(expected = "Circular dependency detected:")]
+    fn cyclic_dependency_error() {
+        run_dependency_test(
+            format!("{}/cyclic-dependency", ERROR_TESTS_DIR).as_str(),
+            "lib",
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "No such file or directory")]
+    fn file_not_found_error() {
+        run_dependency_test(
+            format!("{}/file-not-found", ERROR_TESTS_DIR).as_str(),
+            "lib",
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "No such file or directory")]
+    fn lib_not_found_error() {
+        run_dependency_test(format!("{}/lib-not-found", ERROR_TESTS_DIR).as_str(), "lib");
+    }
+
+    #[test]
+    #[should_panic(expected = "Item `SecretType` is private")]
+    fn private_type_visibility_error() {
+        run_dependency_test(
+            format!("{}/private-visibility", ERROR_TESTS_DIR).as_str(),
+            "lib",
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "The alias `add` was defined multiple times")]
+    fn name_collision_error() {
+        run_dependency_test(
+            format!("{}/name-collision", ERROR_TESTS_DIR).as_str(),
+            "lib",
+        );
+    }
+
+    // Reference to the following bug: https://github.com/BlockstreamResearch/SimplicityHL/issues/220
+    #[test]
+    #[should_panic(expected = "Type alias `A` was defined multiple times")]
+    fn type_alias_duplication_error() {
+        run_dependency_test(
+            format!("{}/type-alias-duplication", ERROR_TESTS_DIR).as_str(),
+            "lib",
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -262,6 +262,31 @@ macro_rules! impl_eq_hash {
             }
         }
     };
+
+    ($ty:ident < $($gen:ident),+ > ; $($member:ident),*) => {
+        impl<$($gen),+> PartialEq for $ty<$($gen),+>
+        where
+            $($gen: PartialEq,)+
+        {
+            fn eq(&self, other: &Self) -> bool {
+                true $(&& self.$member() == other.$member())*
+            }
+        }
+
+        impl<$($gen),+> Eq for $ty<$($gen),+>
+        where
+            $($gen: Eq,)+
+        {}
+
+        impl<$($gen),+> std::hash::Hash for $ty<$($gen),+>
+        where
+            $($gen: std::hash::Hash,)+
+        {
+            fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+                $(self.$member().hash(state);)*
+            }
+        }
+    };
 }
 
 /// Helper trait for implementing [`arbitrary::Arbitrary`] for recursive structures.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod named;
 pub mod num;
 pub mod parse;
 pub mod pattern;
+pub mod resolution;
 #[cfg(feature = "serde")]
 mod serde;
 pub mod str;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,11 @@ use base64::display::Base64Display;
 use base64::engine::general_purpose::STANDARD;
 use clap::{Arg, ArgAction, Command};
 
-use simplicityhl::{AbiMeta, CompiledProgram};
+use simplicityhl::{
+    resolution::{CanonPath, DependencyMap, SourceFile},
+    AbiMeta, CompiledProgram,
+};
+use std::path::Path;
 use std::{env, fmt};
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
@@ -50,6 +54,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     .help("SimplicityHL program file to build"),
             )
             .arg(
+                Arg::new("dependencies")
+                    .long("dep")
+                    .value_name("[CONTEXT:]ALIAS=PATH")
+                    .action(ArgAction::Append)
+                    .help("Link a dependency, optionally scoped to a specific module (e.g., --dep ./libs/merkle:math=./libs/math)"),
+            )
+            .arg(
                 Arg::new("wit_file")
                     .long("wit")
                     .short('w')
@@ -88,8 +99,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let matches = command.get_matches();
 
     let prog_file = matches.get_one::<String>("prog_file").unwrap();
-    let prog_path = std::path::Path::new(prog_file);
-    let prog_text = std::fs::read_to_string(prog_path).map_err(|e| e.to_string())?;
+    let main_path = CanonPath::canonicalize(Path::new(prog_file))?;
+    let main_text = std::fs::read_to_string(main_path.as_path()).map_err(|e| e.to_string())?;
     let include_debug_symbols = matches.get_flag("debug");
     let output_json = matches.get_flag("json");
     let abi_param = matches.get_flag("abi");
@@ -98,7 +109,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args_opt: simplicityhl::Arguments = match matches.get_one::<String>("args_file") {
         None => simplicityhl::Arguments::default(),
         Some(args_file) => {
-            let args_path = std::path::Path::new(&args_file);
+            let args_path = Path::new(&args_file);
             let args_text = std::fs::read_to_string(args_path).map_err(|e| e.to_string())?;
             serde_json::from_str::<simplicityhl::Arguments>(&args_text)?
         }
@@ -113,19 +124,56 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         simplicityhl::Arguments::default()
     };
 
-    let compiled = match CompiledProgram::new(prog_text, args_opt, include_debug_symbols) {
-        Ok(program) => program,
-        Err(e) => {
-            eprintln!("{}", e);
+    let dep_args = matches
+        .get_many::<String>("dependencies")
+        .unwrap_or_default();
+
+    let mut dependencies = DependencyMap::new();
+
+    for arg in dep_args {
+        let (left_side, path_str) = arg.split_once('=').unwrap_or_else(|| {
+            eprintln!(
+                "Error: Library argument must be in format [CONTEXT:]ALIAS=PATH, got '{arg}'"
+            );
+            std::process::exit(1);
+        });
+
+        let (context_path, alias) = if let Some((ctx_str, alias_str)) = left_side.split_once(':') {
+            // Specific context provided (e.g., merkle:base_math=...)
+            // We convert it to PathBuf so it shares the same type as main_path
+            let canon_path = CanonPath::canonicalize(Path::new(ctx_str))?;
+            (canon_path, alias_str)
+        } else {
+            // No context provided (e.g., math=...). Bind it to the main file!
+            (main_path.clone(), left_side)
+        };
+
+        let target_path = CanonPath::canonicalize(Path::new(path_str))?;
+
+        // Insert and handle the potential io::Error!
+        // We convert path_str to PathBuf so it maches the tyep of context_path
+        if let Err(e) = dependencies.insert(context_path, alias.to_string(), target_path) {
+            eprintln!("Error: {e}");
             std::process::exit(1);
         }
-    };
+    }
+
+    let source = SourceFile::new(main_path.as_path(), std::sync::Arc::from(main_text));
+    let compiled =
+        match CompiledProgram::new_with_dep(source, &dependencies, args_opt, include_debug_symbols)
+        {
+            Ok(program) => program,
+            Err(e) => {
+                eprintln!("{}", e);
+                std::process::exit(1);
+            }
+        };
 
     #[cfg(feature = "serde")]
     let witness_opt = matches
         .get_one::<String>("wit_file")
         .map(|wit_file| -> Result<simplicityhl::WitnessValues, String> {
-            let wit_path = std::path::Path::new(wit_file);
+            let wit_path = Path::new(wit_file);
             let wit_text = std::fs::read_to_string(wit_path).map_err(|e| e.to_string())?;
             let witness = serde_json::from_str::<simplicityhl::WitnessValues>(&wit_text).unwrap();
             Ok(witness)

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -52,13 +52,92 @@ pub enum Item {
     TypeAlias(TypeAlias),
     /// A function.
     Function(Function),
+    /// An import declaration (e.g., `use math::add`) that brings another
+    /// [`Item`] into the current scope.
+    Use(UseDecl),
     /// A module, which is ignored.
     Module,
 }
 
-/// Definition of a function.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Default)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub enum Visibility {
+    Public,
+    #[default]
+    Private,
+}
+
+/// Represents an import declaration in the Abstract Syntax Tree.
+///
+/// This structure defines how items from other modules or files are brought into the
+/// current scope. Note that in this architecture, the first identifier in the path
+/// is always treated as an alias bound to a specific physical path.
+///
+/// # Example
+/// ```text
+/// pub use std::collections::{HashMap, HashSet};
+/// ```
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct UseDecl {
+    /// The visibility of the import (e.g., `pub use` vs `use`).
+    visibility: Visibility,
+
+    /// The base path to the target file or module.
+    ///
+    /// The first element is always the registered alias for the import path.
+    /// Subsequent elements represent nested modules or directories.
+    path: Vec<Identifier>,
+
+    /// The specific item or list of items being imported from the resolved path.
+    items: UseItems,
+    span: Span,
+}
+
+impl UseDecl {
+    pub fn visibility(&self) -> &Visibility {
+        &self.visibility
+    }
+
+    pub fn path(&self) -> &Vec<Identifier> {
+        &self.path
+    }
+
+    pub fn items(&self) -> &UseItems {
+        &self.items
+    }
+
+    pub fn span(&self) -> &Span {
+        &self.span
+    }
+}
+
+impl_eq_hash!(UseDecl; visibility, path, items);
+
+/// Specified the items being brought into scope at the end of a `use` declaration
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub enum UseItems {
+    /// A single item import.
+    ///
+    /// # Example
+    /// ```text
+    /// use core::math::add;
+    /// ```
+    Single(Identifier),
+
+    /// A multiple item import grouped in a list.
+    ///
+    /// # Example
+    /// ```text
+    /// use core::math::{add, subtract};
+    /// ```
+    List(Vec<Identifier>),
+}
+
 #[derive(Clone, Debug)]
 pub struct Function {
+    visibility: Visibility,
     name: FunctionName,
     params: Arc<[FunctionParam]>,
     ret: Option<AliasedType>,
@@ -67,6 +146,10 @@ pub struct Function {
 }
 
 impl Function {
+    pub fn visibility(&self) -> &Visibility {
+        &self.visibility
+    }
+
     /// Access the name of the function.
     pub fn name(&self) -> &FunctionName {
         &self.name
@@ -95,7 +178,7 @@ impl Function {
     }
 }
 
-impl_eq_hash!(Function; name, params, ret, body);
+impl_eq_hash!(Function; visibility, name, params, ret, body);
 
 /// Parameter of a function.
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
@@ -222,12 +305,17 @@ pub enum CallName {
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct TypeAlias {
+    visibility: Visibility,
     name: AliasName,
     ty: AliasedType,
     span: Span,
 }
 
 impl TypeAlias {
+    pub fn visibility(&self) -> &Visibility {
+        &self.visibility
+    }
+
     /// Access the name of the alias.
     pub fn name(&self) -> &AliasName {
         &self.name
@@ -556,6 +644,7 @@ impl fmt::Display for Item {
         match self {
             Self::TypeAlias(alias) => write!(f, "{alias}"),
             Self::Function(function) => write!(f, "{function}"),
+            Self::Use(use_declaration) => write!(f, "{use_declaration}"),
             // The parse tree contains no information about the contents of modules.
             // We print a random empty module `mod witness {}` here
             // so that `from_string(to_string(x)) = x` holds for all trees `x`.
@@ -564,15 +653,30 @@ impl fmt::Display for Item {
     }
 }
 
+impl fmt::Display for Visibility {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Public => write!(f, "pub "),
+            Self::Private => write!(f, ""),
+        }
+    }
+}
+
 impl fmt::Display for TypeAlias {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "type {} = {};", self.name(), self.ty())
+        write!(
+            f,
+            "{}type {} = {};",
+            self.visibility(),
+            self.name(),
+            self.ty()
+        )
     }
 }
 
 impl fmt::Display for Function {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "fn {}(", self.name())?;
+        write!(f, "{}fn {}(", self.visibility(), self.name())?;
         for (i, param) in self.params().iter().enumerate() {
             if 0 < i {
                 write!(f, ", ")?;
@@ -584,6 +688,43 @@ impl fmt::Display for Function {
             write!(f, " -> {ty}")?;
         }
         write!(f, " {}", self.body())
+    }
+}
+
+impl fmt::Display for UseDecl {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let _ = write!(f, "{}use ", self.visibility());
+
+        for (i, segment) in self.path.iter().enumerate() {
+            if i > 0 {
+                write!(f, "::")?;
+            }
+            write!(f, "{}", segment)?;
+        }
+
+        if !self.path.is_empty() {
+            write!(f, "::")?;
+        }
+
+        write!(f, "{};", self.items)
+    }
+}
+
+impl fmt::Display for UseItems {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            UseItems::Single(ident) => write!(f, "{}", ident),
+            UseItems::List(idents) => {
+                let _ = write!(f, "{{");
+                for (i, ident) in idents.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{}", ident)?;
+                }
+                write!(f, "}}")
+            }
+        }
     }
 }
 
@@ -1129,7 +1270,12 @@ impl ChumskyParse for Program {
         let skip_until_next_item = any()
             .then(
                 any()
-                    .filter(|t| !matches!(t, Token::Fn | Token::Type | Token::Mod))
+                    .filter(|t| {
+                        !matches!(
+                            t,
+                            Token::Pub | Token::Use | Token::Fn | Token::Type | Token::Mod
+                        )
+                    })
                     .repeated(),
             )
             // map to empty module
@@ -1153,9 +1299,10 @@ impl ChumskyParse for Item {
     {
         let func_parser = Function::parser().map(Item::Function);
         let type_parser = TypeAlias::parser().map(Item::TypeAlias);
+        let use_parser = UseDecl::parser().map(Item::Use);
         let mod_parser = Module::parser().map(|_| Item::Module);
 
-        choice((func_parser, type_parser, mod_parser))
+        choice((func_parser, use_parser, type_parser, mod_parser))
     }
 }
 
@@ -1164,6 +1311,12 @@ impl ChumskyParse for Function {
     where
         I: ValueInput<'tokens, Token = Token<'src>, Span = Span>,
     {
+        let visibility = just(Token::Pub)
+            .to(Visibility::Public)
+            .or_not()
+            .map(Option::unwrap_or_default)
+            .labelled("function visibility");
+
         let params = delimited_with_recovery(
             FunctionParam::parser()
                 .separated_by(just(Token::Comma))
@@ -1195,16 +1348,60 @@ impl ChumskyParse for Function {
             )))
             .labelled("function body");
 
-        just(Token::Fn)
-            .ignore_then(FunctionName::parser())
+        visibility
+            .then_ignore(just(Token::Fn))
+            .then(FunctionName::parser())
             .then(params)
             .then(ret)
             .then(body)
-            .map_with(|(((name, params), ret), body), e| Self {
+            .map_with(|((((visibility, name), params), ret), body), e| Self {
+                visibility,
                 name,
                 params,
                 ret,
                 body,
+                span: e.span(),
+            })
+    }
+}
+
+impl ChumskyParse for UseDecl {
+    fn parser<'tokens, 'src: 'tokens, I>() -> impl Parser<'tokens, I, Self, ParseError<'src>> + Clone
+    where
+        I: ValueInput<'tokens, Token = Token<'src>, Span = Span>,
+    {
+        let visibility = just(Token::Pub)
+            .to(Visibility::Public)
+            .or_not()
+            .map(Option::unwrap_or_default);
+
+        // Parse the base path prefix (e.g., `dependency_root_path::file::` or `dependency_root_path::dir::file::`).
+        // We require at least 2 segments here because a valid import needs a minimum
+        // of 3 items total: the dependency_root_path, the file, and the specific item/function.
+        let path = Identifier::parser()
+            .then_ignore(just(Token::DoubleColon))
+            .repeated()
+            .at_least(2)
+            .collect::<Vec<_>>();
+
+        let list = Identifier::parser()
+            .separated_by(just(Token::Comma))
+            .allow_trailing()
+            .collect()
+            .delimited_by(just(Token::LBrace), just(Token::RBrace))
+            .map(UseItems::List);
+        let single = Identifier::parser().map(UseItems::Single);
+        let items = choice((list, single));
+
+        visibility
+            .then_ignore(just(Token::Use))
+            .then(path)
+            .then(items)
+            .then_ignore(just(Token::Semi))
+            .map_with(|((visibility, path), items), e| Self {
+                visibility,
+                path,
+                items,
                 span: e.span(),
             })
     }
@@ -1450,6 +1647,11 @@ impl ChumskyParse for TypeAlias {
     where
         I: ValueInput<'tokens, Token = Token<'src>, Span = Span>,
     {
+        let visibility = just(Token::Pub)
+            .to(Visibility::Public)
+            .or_not()
+            .map(Option::unwrap_or_default);
+
         let name = AliasName::parser()
             .validate(|name, e, emit| {
                 let ident = name.as_inner();
@@ -1470,12 +1672,16 @@ impl ChumskyParse for TypeAlias {
             })
             .map_with(|name, e| (name, e.span()));
 
-        just(Token::Type)
-            .ignore_then(name)
-            .then_ignore(parse_token_with_recovery(Token::Eq))
-            .then(AliasedType::parser())
-            .then_ignore(just(Token::Semi))
-            .map_with(|(name, ty), e| Self {
+        visibility
+            .then(
+                just(Token::Type)
+                    .ignore_then(name)
+                    .then_ignore(parse_token_with_recovery(Token::Eq))
+                    .then(AliasedType::parser())
+                    .then_ignore(just(Token::Semi)),
+            )
+            .map_with(|(visibility, (name, ty)), e| Self {
+                visibility,
                 name: name.0,
                 ty,
                 span: e.span(),
@@ -1960,6 +2166,7 @@ impl crate::ArbitraryRec for Function {
     fn arbitrary_rec(u: &mut arbitrary::Unstructured, budget: usize) -> arbitrary::Result<Self> {
         use arbitrary::Arbitrary;
 
+        let visibility = Visibility::arbitrary(u)?;
         let name = FunctionName::arbitrary(u)?;
         let len = u.int_in_range(0..=3)?;
         let params = (0..len)
@@ -1968,6 +2175,7 @@ impl crate::ArbitraryRec for Function {
         let ret = Option::<AliasedType>::arbitrary(u)?;
         let body = Expression::arbitrary_rec(u, budget).map(Expression::into_block)?;
         Ok(Self {
+            visibility,
             name,
             params,
             ret,

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -3,6 +3,7 @@
 
 use std::fmt;
 use std::num::NonZeroUsize;
+use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -16,6 +17,7 @@ use chumsky::{extra, select, IterParser, Parser};
 use either::Either;
 use miniscript::iter::{Tree, TreeLike};
 
+use crate::driver::MAIN_MODULE;
 use crate::error::ErrorCollector;
 use crate::error::{Error, RichError, Span};
 use crate::impl_eq_hash;
@@ -108,6 +110,11 @@ impl UseDecl {
         self.path.iter().map(|s| s.as_inner()).collect()
     }
 
+    pub fn str_path(&self) -> String {
+        let path: PathBuf = self.path.iter().map(|s| s.as_inner()).collect();
+        path.display().to_string()
+    }
+
     /// Extracts the Dependency Root Path Name (the very first segment) from this path.
     ///
     /// # Errors
@@ -158,6 +165,7 @@ pub enum UseItems {
 
 #[derive(Clone, Debug)]
 pub struct Function {
+    file_id: usize, // The field required for the driver
     visibility: Visibility,
     name: FunctionName,
     params: Arc<[FunctionParam]>,
@@ -167,6 +175,14 @@ pub struct Function {
 }
 
 impl Function {
+    pub fn file_id(&self) -> usize {
+        self.file_id
+    }
+
+    pub fn set_file_id(&mut self, file_id: usize) {
+        self.file_id = file_id;
+    }
+
     pub fn visibility(&self) -> &Visibility {
         &self.visibility
     }
@@ -326,6 +342,7 @@ pub enum CallName {
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct TypeAlias {
+    file_id: usize, // The field required for the driver
     visibility: Visibility,
     name: AliasName,
     ty: AliasedType,
@@ -333,6 +350,14 @@ pub struct TypeAlias {
 }
 
 impl TypeAlias {
+    pub fn file_id(&self) -> usize {
+        self.file_id
+    }
+
+    pub fn set_file_id(&mut self, file_id: usize) {
+        self.file_id = file_id;
+    }
+
     pub fn visibility(&self) -> &Visibility {
         &self.visibility
     }
@@ -1396,7 +1421,8 @@ impl ChumskyParse for Function {
             .then(params)
             .then(ret)
             .then(body)
-            .map_with(|((((visibility, name), params), ret), body), e| Self {
+            .map_with(move |((((visibility, name), params), ret), body), e| Self {
+                file_id: MAIN_MODULE,
                 visibility,
                 name,
                 params,
@@ -1726,7 +1752,8 @@ impl ChumskyParse for TypeAlias {
                     .then(AliasedType::parser())
                     .then_ignore(just(Token::Semi)),
             )
-            .map_with(|(visibility, (name, ty)), e| Self {
+            .map_with(move |(visibility, (name, ty)), e| Self {
+                file_id: MAIN_MODULE,
                 visibility,
                 name: name.0,
                 ty,
@@ -2212,6 +2239,7 @@ impl crate::ArbitraryRec for Function {
     fn arbitrary_rec(u: &mut arbitrary::Unstructured, budget: usize) -> arbitrary::Result<Self> {
         use arbitrary::Arbitrary;
 
+        let file_id = u.int_in_range(0..=3)?;
         let visibility = Visibility::arbitrary(u)?;
         let name = FunctionName::arbitrary(u)?;
         let len = u.int_in_range(0..=3)?;
@@ -2221,6 +2249,7 @@ impl crate::ArbitraryRec for Function {
         let ret = Option::<AliasedType>::arbitrary(u)?;
         let body = Expression::arbitrary_rec(u, budget).map(Expression::into_block)?;
         Ok(Self {
+            file_id,
             visibility,
             name,
             params,

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -72,7 +72,7 @@ pub enum Visibility {
 ///
 /// This structure defines how items from other modules or files are brought into the
 /// current scope. Note that in this architecture, the first identifier in the path
-/// is always treated as an alias bound to a specific physical path.
+/// is always treated as an dependency root path name bound to a specific physical path.
 ///
 /// # Example
 /// ```text
@@ -86,8 +86,8 @@ pub struct UseDecl {
 
     /// The base path to the target file or module.
     ///
-    /// The first element is always the registered alias for the import path.
-    /// Subsequent elements represent nested modules or directories.
+    /// The first element is always the registered dependency root path name for
+    /// the import path. Subsequent elements represent nested modules or directories.
     path: Vec<Identifier>,
 
     /// The specific item or list of items being imported from the resolved path.
@@ -100,8 +100,25 @@ impl UseDecl {
         &self.visibility
     }
 
-    pub fn path(&self) -> &Vec<Identifier> {
-        &self.path
+    /// Returns the full logical module path as a vector of string slices.
+    ///
+    /// This includes the Dependency Root Path Name (the first segment)
+    /// followed by all subsequent sub-module segments.
+    pub fn path(&self) -> Vec<&str> {
+        self.path.iter().map(|s| s.as_inner()).collect()
+    }
+
+    /// Extracts the Dependency Root Path Name (the very first segment) from this path.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `RichError` if the use declaration path is completely empty.
+    pub fn drp_name(&self) -> Result<&str, RichError> {
+        let parts = self.path();
+        parts
+            .first()
+            .copied()
+            .ok_or_else(|| Error::CannotParse("Empty use path".to_string()).with_span(self.span))
     }
 
     pub fn items(&self) -> &UseItems {
@@ -113,7 +130,7 @@ impl UseDecl {
     }
 }
 
-impl_eq_hash!(UseDecl; visibility, path, items);
+impl_eq_hash!(UseDecl; visibility, path, drp_name, items);
 
 /// Specified the items being brought into scope at the end of a `use` declaration
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -2384,6 +2401,18 @@ impl crate::ArbitraryRec for Match {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    impl UseDecl {
+        /// Creates a dummy `UseDecl` specifically for testing `DependencyMap` resolution.
+        pub fn dummy_path(path: Vec<Identifier>) -> Self {
+            Self {
+                visibility: Visibility::default(),
+                path,
+                items: UseItems::List(Vec::new()),
+                span: Span::new(0, 0),
+            }
+        }
+    }
 
     #[test]
     fn test_reject_redefined_builtin_type() {

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1033,7 +1033,10 @@ pub trait ParseFromStr: Sized {
 /// Trait for parsing with collection of errors.
 pub trait ParseFromStrWithErrors: Sized {
     /// Parse a value from the string `s` with Errors.
-    fn parse_from_str_with_errors(s: &str, handler: &mut ErrorCollector) -> Option<Self>;
+    fn parse_from_str_with_errors(
+        source: impl Into<SourceFile>,
+        handler: &mut ErrorCollector,
+    ) -> Option<Self>;
 }
 
 /// Trait for generating parsers of themselves.
@@ -1077,10 +1080,14 @@ impl<A: ChumskyParse + std::fmt::Debug> ParseFromStr for A {
 }
 
 impl<A: ChumskyParse + std::fmt::Debug> ParseFromStrWithErrors for A {
-    fn parse_from_str_with_errors(s: &str, handler: &mut ErrorCollector) -> Option<Self> {
+    fn parse_from_str_with_errors(
+        source: impl Into<SourceFile>,
+        handler: &mut ErrorCollector,
+    ) -> Option<Self> {
+        let source: SourceFile = source.into();
+        let s = &source.content().to_string();
         let (tokens, lex_errs) = crate::lexer::lex(s);
 
-        let source = SourceFile::anonymous(Arc::from(s));
         handler.extend(source.clone(), lex_errs);
         let tokens = tokens?;
 
@@ -1093,7 +1100,7 @@ impl<A: ChumskyParse + std::fmt::Debug> ParseFromStrWithErrors for A {
             )
             .into_output_errors();
 
-        handler.extend(source, parse_errs);
+        handler.extend(source.clone(), parse_errs);
 
         // TODO: We should return parsed result if we found errors, but because analyzing in `ast` module
         // is not handling poisoned tree right now, we don't return parsed result
@@ -2428,8 +2435,9 @@ mod test {
     #[test]
     fn test_double_colon() {
         let input = "fn main() { let ab: u8 = <(u4, u4)> : :into((0b1011, 0b1101)); }";
+        let source = SourceFile::anonymous(Arc::from(input));
         let mut error_handler = ErrorCollector::new();
-        let parse_program = Program::parse_from_str_with_errors(input, &mut error_handler);
+        let parse_program = Program::parse_from_str_with_errors(source, &mut error_handler);
 
         assert!(parse_program.is_none());
         assert!(ErrorCollector::to_string(&error_handler).contains("Expected '::', found ':'"));
@@ -2438,8 +2446,9 @@ mod test {
     #[test]
     fn test_double_double_colon() {
         let input = "fn main() { let pk: Pubkey = witnes::::PK; }";
+        let source = SourceFile::anonymous(Arc::from(input));
         let mut error_handler = ErrorCollector::new();
-        let parse_program = Program::parse_from_str_with_errors(input, &mut error_handler);
+        let parse_program = Program::parse_from_str_with_errors(source, &mut error_handler);
 
         assert!(parse_program.is_none());
         assert!(ErrorCollector::to_string(&error_handler).contains("Expected ';', found '::'"));

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -25,7 +25,7 @@ use crate::pattern::Pattern;
 use crate::resolution::SourceFile;
 use crate::str::{
     AliasName, Binary, Decimal, FunctionName, Hexadecimal, Identifier, JetName, ModuleName,
-    WitnessName,
+    SymbolName, WitnessName,
 };
 use crate::types::{AliasedType, BuiltinAlias, TypeConstructible, UIntType};
 
@@ -133,7 +133,7 @@ impl UseDecl {
 impl_eq_hash!(UseDecl; visibility, path, drp_name, items);
 
 /// Aliases the specific identifier of an imported type to a new, local identifier
-pub type AliasedIdentifier = (Identifier, Option<Identifier>);
+pub type AliasedSymbolName = (SymbolName, Option<SymbolName>);
 
 /// Specified the items being brought into scope at the end of a `use` declaration
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -145,7 +145,7 @@ pub enum UseItems {
     /// ```text
     /// use core::math::add;
     /// ```
-    Single(AliasedIdentifier),
+    Single(AliasedSymbolName),
 
     /// A multiple item import grouped in a list.
     ///
@@ -153,7 +153,7 @@ pub enum UseItems {
     /// ```text
     /// use core::math::{add, subtract};
     /// ```
-    List(Vec<AliasedIdentifier>),
+    List(Vec<AliasedSymbolName>),
 }
 
 #[derive(Clone, Debug)]
@@ -1033,6 +1033,7 @@ macro_rules! impl_parse_wrapped_string {
     };
 }
 
+impl_parse_wrapped_string!(SymbolName, "unresolved symbol name");
 impl_parse_wrapped_string!(FunctionName, "function name");
 impl_parse_wrapped_string!(Identifier, "identifier");
 impl_parse_wrapped_string!(WitnessName, "witness name");
@@ -1426,7 +1427,7 @@ impl ChumskyParse for UseDecl {
             .collect::<Vec<_>>();
 
         let aliased_item =
-            Identifier::parser().then(just(Token::As).ignore_then(Identifier::parser()).or_not());
+            SymbolName::parser().then(just(Token::As).ignore_then(SymbolName::parser()).or_not());
 
         let list = aliased_item
             .clone()

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -132,6 +132,9 @@ impl UseDecl {
 
 impl_eq_hash!(UseDecl; visibility, path, drp_name, items);
 
+/// Aliases the specific identifier of an imported type to a new, local identifier
+pub type AliasedIdentifier = (Identifier, Option<Identifier>);
+
 /// Specified the items being brought into scope at the end of a `use` declaration
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
@@ -142,7 +145,7 @@ pub enum UseItems {
     /// ```text
     /// use core::math::add;
     /// ```
-    Single(Identifier),
+    Single(AliasedIdentifier),
 
     /// A multiple item import grouped in a list.
     ///
@@ -150,7 +153,7 @@ pub enum UseItems {
     /// ```text
     /// use core::math::{add, subtract};
     /// ```
-    List(Vec<Identifier>),
+    List(Vec<AliasedIdentifier>),
 }
 
 #[derive(Clone, Debug)]
@@ -731,14 +734,26 @@ impl fmt::Display for UseDecl {
 impl fmt::Display for UseItems {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            UseItems::Single(ident) => write!(f, "{}", ident),
-            UseItems::List(idents) => {
+            UseItems::Single((ident, alias)) => {
+                write!(f, "{}", ident)?;
+
+                if let Some(alias) = alias {
+                    write!(f, " as {}", alias)?;
+                }
+
+                Ok(())
+            }
+            UseItems::List(aliased_idents) => {
                 let _ = write!(f, "{{");
-                for (i, ident) in idents.iter().enumerate() {
+                for (i, (ident, alias)) in aliased_idents.iter().enumerate() {
                     if i > 0 {
                         write!(f, ", ")?;
                     }
                     write!(f, "{}", ident)?;
+
+                    if let Some(alias) = alias {
+                        write!(f, " as {}", alias)?;
+                    }
                 }
                 write!(f, "}}")
             }
@@ -1410,13 +1425,17 @@ impl ChumskyParse for UseDecl {
             .at_least(2)
             .collect::<Vec<_>>();
 
-        let list = Identifier::parser()
+        let aliased_item =
+            Identifier::parser().then(just(Token::As).ignore_then(Identifier::parser()).or_not());
+
+        let list = aliased_item
+            .clone()
             .separated_by(just(Token::Comma))
             .allow_trailing()
             .collect()
             .delimited_by(just(Token::LBrace), just(Token::RBrace))
             .map(UseItems::List);
-        let single = Identifier::parser().map(UseItems::Single);
+        let single = aliased_item.map(UseItems::Single);
         let items = choice((list, single));
 
         visibility
@@ -2407,6 +2426,8 @@ impl crate::ArbitraryRec for Match {
 
 #[cfg(test)]
 mod test {
+    use crate::parse;
+
     use super::*;
 
     impl UseDecl {
@@ -2452,5 +2473,17 @@ mod test {
 
         assert!(parse_program.is_none());
         assert!(ErrorCollector::to_string(&error_handler).contains("Expected ';', found '::'"));
+    }
+
+    #[test]
+    fn test_use_decl_display_round_trips_with_aliases() {
+        for input in [
+            "use lib::A::foo;",
+            "use lib::A::foo as bar;",
+            "use lib::A::{foo, bar as baz};",
+        ] {
+            let program = parse::Program::parse_from_str(input).expect("parsing works");
+            assert_eq!(program.to_string(), format!("{input}\n"));
+        }
     }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -22,6 +22,7 @@ use crate::impl_eq_hash;
 use crate::lexer::Token;
 use crate::num::NonZeroPow2Usize;
 use crate::pattern::Pattern;
+use crate::resolution::SourceFile;
 use crate::str::{
     AliasName, Binary, Decimal, FunctionName, Hexadecimal, Identifier, JetName, ModuleName,
     WitnessName,
@@ -1062,7 +1063,8 @@ impl<A: ChumskyParse + std::fmt::Debug> ParseFromStrWithErrors for A {
     fn parse_from_str_with_errors(s: &str, handler: &mut ErrorCollector) -> Option<Self> {
         let (tokens, lex_errs) = crate::lexer::lex(s);
 
-        handler.update(lex_errs);
+        let source = SourceFile::anonymous(Arc::from(s));
+        handler.extend(source.clone(), lex_errs);
         let tokens = tokens?;
 
         let (ast, parse_errs) = A::parser()
@@ -1074,14 +1076,14 @@ impl<A: ChumskyParse + std::fmt::Debug> ParseFromStrWithErrors for A {
             )
             .into_output_errors();
 
-        handler.update(parse_errs);
+        handler.extend(source, parse_errs);
 
         // TODO: We should return parsed result if we found errors, but because analyzing in `ast` module
         // is not handling poisoned tree right now, we don't return parsed result
-        if handler.get().is_empty() {
-            ast
-        } else {
+        if handler.has_errors() {
             None
+        } else {
+            ast
         }
     }
 }
@@ -2397,7 +2399,7 @@ mod test {
     #[test]
     fn test_double_colon() {
         let input = "fn main() { let ab: u8 = <(u4, u4)> : :into((0b1011, 0b1101)); }";
-        let mut error_handler = ErrorCollector::new(Arc::from(input));
+        let mut error_handler = ErrorCollector::new();
         let parse_program = Program::parse_from_str_with_errors(input, &mut error_handler);
 
         assert!(parse_program.is_none());
@@ -2407,7 +2409,7 @@ mod test {
     #[test]
     fn test_double_double_colon() {
         let input = "fn main() { let pk: Pubkey = witnes::::PK; }";
-        let mut error_handler = ErrorCollector::new(Arc::from(input));
+        let mut error_handler = ErrorCollector::new();
         let parse_program = Program::parse_from_str_with_errors(input, &mut error_handler);
 
         assert!(parse_program.is_none());

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -121,7 +121,7 @@ pub struct Remapping {
 /// Mappings are strictly sorted by the longest `context_prefix` match.
 /// This mathematical guarantee ensures that if multiple nested directories
 /// define the same dependency root path, the most specific (deepest) context wins.
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct DependencyMap {
     inner: Vec<Remapping>,
 }

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -2,13 +2,14 @@ use std::io;
 use std::path::Path;
 use std::sync::Arc;
 
+use crate::driver::CanonSourceFile;
 use crate::error::{Error, RichError, WithSpan as _};
 use crate::parse::UseDecl;
 
 /// Powers error reporting by mapping compiler diagnostics to the specific file.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct SourceFile {
-    /// The name or path of the source file (e.g., "./simf/main.simf").
+    /// The path of the source file (e.g., "./src/main.simf").
     name: Option<Arc<Path>>,
     /// The actual text content of the source file.
     content: Arc<str>,
@@ -16,10 +17,13 @@ pub struct SourceFile {
 
 impl From<(&Path, &str)> for SourceFile {
     fn from((name, content): (&Path, &str)) -> Self {
-        Self {
-            name: Some(Arc::from(name)),
-            content: Arc::from(content),
-        }
+        Self::new(name, Arc::from(content))
+    }
+}
+
+impl From<CanonSourceFile> for SourceFile {
+    fn from(canon_source: CanonSourceFile) -> Self {
+        Self::new(canon_source.name().as_path(), canon_source.content())
     }
 }
 
@@ -173,7 +177,7 @@ impl DependencyMap {
     /// most specific library context that owns the current file.
     pub fn resolve_path(
         &self,
-        current_file: CanonPath,
+        current_file: &CanonPath,
         use_decl: &UseDecl,
     ) -> Result<CanonPath, RichError> {
         let parts = use_decl.path();
@@ -202,11 +206,21 @@ impl DependencyMap {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use crate::str::Identifier;
     use crate::test_utils::TempWorkspace;
 
     use super::*;
+
+    pub fn canon(p: &Path) -> CanonPath {
+        CanonPath::canonicalize(p).unwrap()
+    }
+
+    impl CanonPath {
+        pub fn dummy_for_test(path: &Path) -> Self {
+            Self(Arc::from(path))
+        }
+    }
 
     /// Helper to easily construct a `UseDecl` for path resolution tests.
     fn create_dummy_use_decl(path_segments: &[&str]) -> UseDecl {
@@ -216,10 +230,6 @@ mod tests {
             .collect();
 
         UseDecl::dummy_path(path)
-    }
-
-    fn canon(p: &Path) -> CanonPath {
-        CanonPath::canonicalize(p).unwrap()
     }
 
     /// When a user registers the same library dependency root path multiple times
@@ -265,7 +275,7 @@ mod tests {
             .unwrap();
 
         let use_decl = create_dummy_use_decl(&["utils"]);
-        let result = map.resolve_path(current_file, &use_decl);
+        let result = map.resolve_path(&current_file, &use_decl);
 
         assert!(result.is_err());
         assert!(matches!(
@@ -300,12 +310,12 @@ mod tests {
 
         // 3. Test Frontend Override
         let frontend_file = canon(&ws.create_file("workspace/frontend/src/main.simf", ""));
-        let resolved_frontend = map.resolve_path(frontend_file, &use_decl).unwrap();
+        let resolved_frontend = map.resolve_path(&frontend_file, &use_decl).unwrap();
         assert_eq!(resolved_frontend, frontend_expected);
 
         // 4. Test Global Fallback
         let backend_file = canon(&ws.create_file("workspace/backend/src/main.simf", ""));
-        let resolved_backend = map.resolve_path(backend_file, &use_decl).unwrap();
+        let resolved_backend = map.resolve_path(&backend_file, &use_decl).unwrap();
         assert_eq!(resolved_backend, global_expected);
     }
 
@@ -325,7 +335,7 @@ mod tests {
         map.insert(context, "math".to_string(), target).unwrap();
 
         let use_decl = create_dummy_use_decl(&["math", "vector"]);
-        let result = map.resolve_path(current_file, &use_decl).unwrap();
+        let result = map.resolve_path(&current_file, &use_decl).unwrap();
 
         assert_eq!(result, expected);
     }

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -1,5 +1,9 @@
+use std::io;
 use std::path::Path;
 use std::sync::Arc;
+
+use crate::error::{Error, RichError, WithSpan as _};
+use crate::parse::UseDecl;
 
 /// Powers error reporting by mapping compiler diagnostics to the specific file.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
@@ -42,5 +46,287 @@ impl SourceFile {
 
     pub fn content(&self) -> Arc<str> {
         self.content.clone()
+    }
+}
+
+/// A guaranteed, fully coanonicalized absolute path.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct CanonPath(Arc<Path>);
+
+impl CanonPath {
+    /// Safely resolves an absolute path via the OS and wraps it in a `CanonPath`.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `String` containing the OS error if the path does not exist or
+    /// cannot be accessed. The caller is expected to map this into a more specific
+    /// compiler diagnostic (e.g., `RichError`).
+    pub fn canonicalize(path: &Path) -> Result<Self, String> {
+        // We use `map_err` here to intercept the generic OS error and enrich
+        // it with the specific path that failed
+        let canon_path = std::fs::canonicalize(path).map_err(|err| {
+            format!(
+                "Failed to find library target path '{}' :{}",
+                path.display(),
+                err
+            )
+        })?;
+
+        Ok(Self(Arc::from(canon_path.as_path())))
+    }
+
+    /// Appends a logical module path to this physical root directory and verifies it.
+    /// It automatically appends the `.simf` extension to the final path *before* asking
+    /// the OS to verify its existence.
+    pub fn join(&self, parts: &[&str]) -> Result<Self, String> {
+        let mut new_path = self.0.to_path_buf();
+
+        for part in parts {
+            new_path.push(part);
+        }
+
+        Self::canonicalize(&new_path.with_extension("simf"))
+    }
+
+    /// Check if the current file is executing inside the context's directory tree.
+    /// This prevents a file in `/project_a/` from using a dependency meant for `/project_b/`
+    pub fn starts_with(&self, path: &CanonPath) -> bool {
+        self.as_path().starts_with(path.as_path())
+    }
+
+    pub fn as_path(&self) -> &Path {
+        &self.0
+    }
+}
+
+/// This defines how a specific dependency root path (e.g. "math")
+/// should be resolved to a physical path on the disk, restricted to
+/// files executing within the `context_prefix`.
+#[derive(Debug, Clone)]
+pub struct Remapping {
+    /// The base directory that owns this dependency mapping.
+    pub context_prefix: CanonPath,
+    /// The dependency root path name used in the `use` statement (e.g., "math").
+    pub drp_name: String,
+    /// The physical path this dependency root path points to.
+    pub target: CanonPath,
+}
+
+/// A router for resolving dependencies across multi-file workspaces.
+///
+/// Mappings are strictly sorted by the longest `context_prefix` match.
+/// This mathematical guarantee ensures that if multiple nested directories
+/// define the same dependency root path, the most specific (deepest) context wins.
+#[derive(Debug, Default)]
+pub struct DependencyMap {
+    inner: Vec<Remapping>,
+}
+
+impl DependencyMap {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    /// Re-sort the vector in descending order so the longest context paths are always at the front.
+    /// This mathematically guarantees that the first match we find is the most specific.
+    fn sort_mappings(&mut self) {
+        self.inner.sort_by(|a, b| {
+            let len_a = a.context_prefix.as_path().as_os_str().len();
+            let len_b = b.context_prefix.as_path().as_os_str().len();
+            len_b.cmp(&len_a)
+        });
+    }
+
+    /// Add a dependency mapped to a specific calling file's path prefix.
+    /// Re-sorts the vector internally to guarantee the Longest Prefix Match.
+    ///
+    /// # Arguments
+    ///
+    /// * `context` - The physical root directory where this dependency rule applies
+    ///   (e.g., `/workspace/frontend`).
+    /// * `drp_name` - The Dependency Root Path Name. This is the logical alias the
+    ///   programmer types in their source code (e.g., the `"math"` in `use math::vector;`).
+    /// * `target` - The physical directory where the compiler should actually
+    ///   look for the code (e.g., `/libs/frontend_math`).
+    pub fn insert(
+        &mut self,
+        context: CanonPath,
+        drp_name: String,
+        target: CanonPath,
+    ) -> io::Result<()> {
+        self.inner.push(Remapping {
+            context_prefix: context,
+            drp_name,
+            target,
+        });
+
+        self.sort_mappings();
+
+        Ok(())
+    }
+
+    /// Resolve `use dependency_root_path_name::...` into a physical file path by finding the
+    /// most specific library context that owns the current file.
+    pub fn resolve_path(
+        &self,
+        current_file: CanonPath,
+        use_decl: &UseDecl,
+    ) -> Result<CanonPath, RichError> {
+        let parts = use_decl.path();
+        let drp_name = use_decl.drp_name()?;
+
+        // Because the vector is sorted by longest prefix,
+        // the VERY FIRST match we find is guaranteed to be the correct one.
+        for remapping in &self.inner {
+            if !current_file.starts_with(&remapping.context_prefix) {
+                continue;
+            }
+
+            // Check if the alias matches what the user typed
+            if remapping.drp_name == drp_name {
+                return remapping.target.join(&parts[1..]).map_err(|err| {
+                    RichError::new(
+                        Error::Internal(format!("Dependency resolution failed: {}", err)),
+                        *use_decl.span(),
+                    )
+                });
+            }
+        }
+
+        Err(Error::UnknownLibrary(drp_name.to_string())).with_span(*use_decl.span())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::str::Identifier;
+    use crate::test_utils::TempWorkspace;
+
+    use super::*;
+
+    /// Helper to easily construct a `UseDecl` for path resolution tests.
+    fn create_dummy_use_decl(path_segments: &[&str]) -> UseDecl {
+        let path: Vec<Identifier> = path_segments
+            .iter()
+            .map(|&s| Identifier::dummy(s))
+            .collect();
+
+        UseDecl::dummy_path(path)
+    }
+
+    fn canon(p: &Path) -> CanonPath {
+        CanonPath::canonicalize(p).unwrap()
+    }
+
+    /// When a user registers the same library dependency root path multiple times
+    /// for different folders, the compiler must always check the longest folder path first.
+    #[test]
+    fn test_sorting_longest_prefix() {
+        let ws = TempWorkspace::new("sorting");
+
+        let workspace_dir = canon(&ws.create_dir("workspace"));
+        let nested_dir = canon(&ws.create_dir("workspace/project_a/nested"));
+        let project_a_dir = canon(&ws.create_dir("workspace/project_a"));
+
+        let target_v1 = canon(&ws.create_dir("lib/math_v1"));
+        let target_v3 = canon(&ws.create_dir("lib/math_v3"));
+        let target_v2 = canon(&ws.create_dir("lib/math_v2"));
+
+        let mut map = DependencyMap::new();
+        map.insert(workspace_dir.clone(), "math".to_string(), target_v1)
+            .unwrap();
+        map.insert(nested_dir.clone(), "math".to_string(), target_v3)
+            .unwrap();
+        map.insert(project_a_dir.clone(), "math".to_string(), target_v2)
+            .unwrap();
+
+        // The longest prefixes should bubble to the top
+        assert_eq!(map.inner[0].context_prefix, nested_dir);
+        assert_eq!(map.inner[1].context_prefix, project_a_dir);
+        assert_eq!(map.inner[2].context_prefix, workspace_dir);
+    }
+
+    /// Projects should not be able to "steal" or accidentally access dependencies
+    /// that do not belong to them.
+    #[test]
+    fn test_context_isolation() {
+        let ws = TempWorkspace::new("isolation");
+
+        let project_a = canon(&ws.create_dir("project_a"));
+        let target_utils = canon(&ws.create_dir("libs/utils_a"));
+        let current_file = canon(&ws.create_file("project_b/main.simf", ""));
+
+        let mut map = DependencyMap::new();
+        map.insert(project_a, "utils".to_string(), target_utils)
+            .unwrap();
+
+        let use_decl = create_dummy_use_decl(&["utils"]);
+        let result = map.resolve_path(current_file, &use_decl);
+
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err().error(),
+            Error::UnknownLibrary(..)
+        ));
+    }
+
+    /// It proves that a highly specific path definition will "override" or "shadow"
+    /// a broader path definition.
+    #[test]
+    fn test_resolve_longest_prefix_match() {
+        let ws = TempWorkspace::new("resolve_prefix");
+
+        // 1. Setup Global Context
+        let global_context = canon(&ws.create_dir("workspace"));
+        let global_target = canon(&ws.create_dir("libs/global_math"));
+        let global_expected = canon(&ws.create_file("libs/global_math/vector.simf", ""));
+
+        // 2. Setup Frontend Context
+        let frontend_context = canon(&ws.create_dir("workspace/frontend"));
+        let frontend_target = canon(&ws.create_dir("libs/frontend_math"));
+        let frontend_expected = canon(&ws.create_file("libs/frontend_math/vector.simf", ""));
+
+        let mut map = DependencyMap::new();
+        map.insert(global_context, "math".to_string(), global_target)
+            .unwrap();
+        map.insert(frontend_context, "math".to_string(), frontend_target)
+            .unwrap();
+
+        let use_decl = create_dummy_use_decl(&["math", "vector"]);
+
+        // 3. Test Frontend Override
+        let frontend_file = canon(&ws.create_file("workspace/frontend/src/main.simf", ""));
+        let resolved_frontend = map.resolve_path(frontend_file, &use_decl).unwrap();
+        assert_eq!(resolved_frontend, frontend_expected);
+
+        // 4. Test Global Fallback
+        let backend_file = canon(&ws.create_file("workspace/backend/src/main.simf", ""));
+        let resolved_backend = map.resolve_path(backend_file, &use_decl).unwrap();
+        assert_eq!(resolved_backend, global_expected);
+    }
+
+    /// it proves that `start_with()` and `resolve_path()` logic correctly handles files
+    /// that are buried deep inside a project's subdirectories.
+    #[test]
+    fn test_resolve_relative_current_file_against_canonical_context() {
+        let ws = TempWorkspace::new("relative_current");
+
+        let context = canon(&ws.create_dir("workspace/frontend"));
+        let target = canon(&ws.create_dir("libs/frontend_math"));
+        let expected = canon(&ws.create_file("libs/frontend_math/vector.simf", ""));
+
+        let current_file = canon(&ws.create_file("workspace/frontend/src/main.simf", ""));
+
+        let mut map = DependencyMap::new();
+        map.insert(context, "math".to_string(), target).unwrap();
+
+        let use_decl = create_dummy_use_decl(&["math", "vector"]);
+        let result = map.resolve_path(current_file, &use_decl).unwrap();
+
+        assert_eq!(result, expected);
     }
 }

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -1,0 +1,37 @@
+use std::path::Path;
+use std::sync::Arc;
+
+/// Powers error reporting by mapping compiler diagnostics to the specific file.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct SourceFile {
+    /// The name or path of the source file (e.g., "./simf/main.simf").
+    name: Arc<Path>,
+    /// The actual text content of the source file.
+    content: Arc<str>,
+}
+
+impl From<(&Path, &str)> for SourceFile {
+    fn from((name, content): (&Path, &str)) -> Self {
+        Self {
+            name: Arc::from(name),
+            content: Arc::from(content),
+        }
+    }
+}
+
+impl SourceFile {
+    pub fn new(name: &Path, content: Arc<str>) -> Self {
+        Self {
+            name: Arc::from(name),
+            content,
+        }
+    }
+
+    pub fn name(&self) -> &Path {
+        self.name.as_ref()
+    }
+
+    pub fn content(&self) -> Arc<str> {
+        self.content.clone()
+    }
+}

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct SourceFile {
     /// The name or path of the source file (e.g., "./simf/main.simf").
-    name: Arc<Path>,
+    name: Option<Arc<Path>>,
     /// The actual text content of the source file.
     content: Arc<str>,
 }
@@ -13,22 +13,31 @@ pub struct SourceFile {
 impl From<(&Path, &str)> for SourceFile {
     fn from((name, content): (&Path, &str)) -> Self {
         Self {
-            name: Arc::from(name),
+            name: Some(Arc::from(name)),
             content: Arc::from(content),
         }
     }
 }
 
 impl SourceFile {
+    /// Creates a standard `SourceFile` from a file path and its content.
     pub fn new(name: &Path, content: Arc<str>) -> Self {
         Self {
-            name: Arc::from(name),
+            name: Some(Arc::from(name)),
             content,
         }
     }
 
-    pub fn name(&self) -> &Path {
-        self.name.as_ref()
+    /// Creates an anonymous `SourceFile` without a file path (e.g., for a single-file programs)
+    pub fn anonymous(content: Arc<str>) -> Self {
+        Self {
+            name: None,
+            content,
+        }
+    }
+
+    pub fn name(&self) -> &Option<Arc<Path>> {
+        &self.name
     }
 
     pub fn content(&self) -> Arc<str> {

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -192,16 +192,32 @@ impl DependencyMap {
 
             // Check if the alias matches what the user typed
             if remapping.drp_name == drp_name {
-                return remapping.target.join(&parts[1..]).map_err(|err| {
-                    RichError::new(
-                        Error::Internal(format!("Dependency resolution failed: {}", err)),
-                        *use_decl.span(),
-                    )
-                });
+                return Self::build_and_verify_path(&remapping.target, &parts[1..]).map_err(
+                    |failed_path| {
+                        RichError::new(Error::FileNotFound(failed_path), *use_decl.span())
+                    },
+                );
             }
         }
 
         Err(Error::UnknownLibrary(drp_name.to_string())).with_span(*use_decl.span())
+    }
+
+    /// Replace `.join` method to better error handling
+    fn build_and_verify_path(
+        base_target: &CanonPath,
+        module_parts: &[impl ToString],
+    ) -> Result<CanonPath, std::path::PathBuf> {
+        let mut theoretical_path = base_target.as_path().to_path_buf();
+        for part in module_parts {
+            theoretical_path.push(part.to_string());
+        }
+        theoretical_path.set_extension("simf");
+
+        match CanonPath::canonicalize(&theoretical_path) {
+            Ok(valid_canon_path) => Ok(valid_canon_path),
+            Err(_) => Err(theoretical_path),
+        }
     }
 }
 

--- a/src/str.rs
+++ b/src/str.rs
@@ -83,6 +83,19 @@ impl FunctionName {
 
 wrapped_string!(FunctionName, "function name");
 
+impl Default for FunctionName {
+    fn default() -> Self {
+        Self(Arc::from(""))
+    }
+}
+
+impl From<SymbolName> for FunctionName {
+    fn from(sym: SymbolName) -> Self {
+        // Just move the inner Arc! Zero cost.
+        Self(sym.0)
+    }
+}
+
 #[cfg(feature = "arbitrary")]
 impl<'a> arbitrary::Arbitrary<'a> for FunctionName {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
@@ -155,6 +168,18 @@ impl<'a> arbitrary::Arbitrary<'a> for JetName {
 pub struct AliasName(Arc<str>);
 
 wrapped_string!(AliasName, "name of a type alias");
+
+impl Default for AliasName {
+    fn default() -> Self {
+        Self(Arc::from(""))
+    }
+}
+
+impl From<SymbolName> for AliasName {
+    fn from(sym: SymbolName) -> Self {
+        Self(sym.0)
+    }
+}
 
 #[cfg(feature = "arbitrary")]
 impl<'a> arbitrary::Arbitrary<'a> for AliasName {
@@ -292,7 +317,24 @@ impl ModuleName {
     }
 }
 
+impl From<SymbolName> for ModuleName {
+    fn from(sym: SymbolName) -> Self {
+        Self(sym.0)
+    }
+}
+
 wrapped_string!(ModuleName, "module name");
+
+/// An unresolved identifier parsed from the source code.
+///
+/// During the parsing of `use` statements, the exact kind of the imported
+/// item (Function, Alias, or Module) is unknown. This type acts as a
+/// temporary placeholder until the name can be fully resolved in later stages.
+#[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
+pub struct SymbolName(Arc<str>);
+
+wrapped_string!(SymbolName, "unresolved symbol name");
+impl_arbitrary_lowercase_alpha!(SymbolName);
 
 #[cfg(test)]
 mod tests {

--- a/src/str.rs
+++ b/src/str.rs
@@ -293,3 +293,14 @@ impl ModuleName {
 }
 
 wrapped_string!(ModuleName, "module name");
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    impl Identifier {
+        pub fn dummy(name: &str) -> Self {
+            Self(std::sync::Arc::from(name))
+        }
+    }
+}

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,0 +1,55 @@
+use std::fs;
+use std::path::PathBuf;
+use std::time;
+
+/// A self-cleaning temporary workspace for unit tests.
+/// Completely replaces the need for the external `tempfile` crate.
+pub struct TempWorkspace {
+    root: PathBuf,
+}
+
+impl TempWorkspace {
+    /// Generates a mathematically unique temporary directory on the OS
+    /// and physically creates it.
+    pub fn new(test_name: &str) -> Self {
+        let unique = time::SystemTime::now()
+            .duration_since(time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let cwd = std::env::current_dir().unwrap();
+        let root = cwd.join("target").join(format!(
+            "test-{}-{}-{}",
+            test_name,
+            std::process::id(),
+            unique
+        ));
+        fs::create_dir_all(&root).unwrap();
+        Self { root }
+    }
+
+    /// Helper to physically create a nested directory inside the workspace.
+    pub fn create_dir(&self, rel_path: &str) -> PathBuf {
+        let path = self.root.join(rel_path);
+        fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    /// Helper to physically create a file (and any necessary parent directories)
+    /// with string contents.
+    pub fn create_file(&self, rel_path: &str, contents: &str) -> PathBuf {
+        let path = self.root.join(rel_path);
+
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+
+        fs::write(&path, contents).unwrap();
+        path
+    }
+}
+
+impl Drop for TempWorkspace {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.root);
+    }
+}

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -356,7 +356,7 @@ fn parse_jet_arguments(jet: Elements, input_frame: &mut FrameIter) -> Result<Vec
 /// Resolves an aliased type to its concrete form.
 fn resolve_jet_type(aliased_type: &AliasedType) -> ResolvedType {
     aliased_type
-        .resolve(|_: &AliasName| None)
+        .resolve(|name: &AliasName| Err(name.clone()))
         .expect("jet types always resolve without aliases")
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -578,15 +578,15 @@ impl AliasedType {
     }
 
     /// Resolve all aliases in the type based on the given map of `aliases` to types.
-    pub fn resolve<F>(&self, mut get_alias: F) -> Result<ResolvedType, AliasName>
+    pub fn resolve<F, E>(&self, mut get_alias: F) -> Result<ResolvedType, E>
     where
-        F: FnMut(&AliasName) -> Option<ResolvedType>,
+        F: FnMut(&AliasName) -> Result<ResolvedType, E>,
     {
         let mut output = vec![];
         for data in self.post_order_iter() {
             match &data.node.0 {
                 AliasedInner::Alias(name) => {
-                    let resolved = get_alias(name).ok_or(name.clone())?;
+                    let resolved = get_alias(name)?;
                     output.push(resolved);
                 }
                 AliasedInner::Builtin(builtin) => {
@@ -628,7 +628,7 @@ impl AliasedType {
 
     /// Resolve all aliases in the type based on the builtin type aliases only.
     pub fn resolve_builtin(&self) -> Result<ResolvedType, AliasName> {
-        self.resolve(|_| None)
+        self.resolve(|name: &AliasName| Err(name.clone()))
     }
 }
 

--- a/src/witness.rs
+++ b/src/witness.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::fmt;
 use std::sync::Arc;
 
-use crate::error::{Error, RichError, WithFile, WithSpan};
+use crate::error::{Error, RichError, WithContent, WithSpan};
 use crate::parse;
 use crate::parse::ParseFromStr;
 use crate::str::WitnessName;
@@ -144,7 +144,7 @@ impl ParseFromStr for ResolvedType {
             .resolve_builtin()
             .map_err(Error::UndefinedAlias)
             .with_span(s)
-            .with_file(s)
+            .with_content(s)
     }
 }
 

--- a/src/witness.rs
+++ b/src/witness.rs
@@ -220,17 +220,26 @@ impl crate::ArbitraryOfType for Arguments {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::error::ErrorCollector;
     use crate::parse::ParseFromStr;
     use crate::value::ValueConstructible;
-    use crate::{ast, parse, CompiledProgram, SatisfiedProgram};
+    use crate::{ast, driver, parse, CompiledProgram, SatisfiedProgram};
 
     #[test]
     fn witness_reuse() {
         let s = r#"fn main() {
     assert!(jet::eq_32(witness::A, witness::A));
 }"#;
-        let program = parse::Program::parse_from_str(s).expect("parsing works");
-        match ast::Program::analyze(&program).map_err(Error::from) {
+        let parse_program = parse::Program::parse_from_str(s).expect("parsing works");
+
+        let mut error_collector = ErrorCollector::new();
+        let driver_program = driver::resolve_order::Program::from_parse(
+            &parse_program,
+            Arc::from(s),
+            &mut error_collector,
+        )
+        .expect("driver works");
+        match ast::Program::analyze(&driver_program).map_err(Error::from) {
             Ok(_) => panic!("Witness reuse was falsely accepted"),
             Err(Error::WitnessReused(..)) => {}
             Err(error) => panic!("Unexpected error: {error}"),


### PR DESCRIPTION
## Motivation (copied from https://github.com/BlockstreamResearch/SimplicityHL/pull/258)

The main goal of this PR is to enable an analogue of the OpenZeppelin library to exist in the SimplicityHL ecosystem. By introducing official compiler support for imports, we significantly increase code reusability and speed up application development. For projects heavily focused on security, this also allows developers to eventually "flatten" the code and audit all functions without external dependencies.

## Checklist

- [x] **Visibility:** Added `pub` and `pub use` to control local scope versus re-exporting.
- [x] **Import Syntax:** Implemented parsing and resolution for `use m::name;` and explicit aliasing (`as`).
- [x] **Collision Handling:** Enforced strict errors for local scope collisions, utilizing linearization for resolving re-export conflicts.
- [x] **Transitive Dependencies**: Add support for libraries importing other libraries.
- [x] **Documentation:** Сode comments are updated accordingly.
- [x] **Quality Assurance:** Code is formatted, all tests pass, and CI shows no errors.

Related PRs (in order of the merge): #260, #256, #265, #266, #269, #278, #279, #280, #283, #287, #284, #289