### PR TITLE
fix: enable fuzzing with cargo-fuzz

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -189,3 +189,14 @@ jobs:
         run: |
           cargo check --manifest-path=fuzz/Cargo.toml
 
+      - name: "Install cargo-fuzz"
+        run: |
+          cargo install cargo-fuzz --locked
+
+      - name: "Run cargo-fuzz"
+        run: |
+          set -euo pipefail
+          cargo fuzz list --fuzz-dir fuzz | while read -r target; do
+          echo "fuzzing $target"
+          cargo fuzz run --fuzz-dir fuzz "$target" -- -runs=1
+          done


### PR DESCRIPTION
This enables fuzzing of targets using cargo-fuzz on github actions where it previously was ignored.

Changes:
- Install cargo fuzz
- Run cargo fuzz for each target

Can be updated to use mapfile or parameterized in future.