### PR TITLE
Add aliases to imports

### DIFF
--- a/src/driver/resolve_order.rs
+++ b/src/driver/resolve_order.rs
@@ -1,10 +1,10 @@
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::sync::Arc;
 
 use crate::driver::DependencyGraph;
 use crate::error::{Error, ErrorCollector, RichError, Span};
 use crate::impl_eq_hash;
-use crate::parse::{self, Visibility};
+use crate::parse::{self, AliasedIdentifier, Visibility};
 use crate::resolution::CanonPath;
 
 /// The final, flattened representation of a SimplicityHL program.
@@ -19,6 +19,8 @@ pub struct Program {
     /// The files that make up this program, along with their scoping rules.
     files: Arc<[ResolvedFile]>,
 
+    import_aliases: AliasRegistry,
+
     span: Span,
 }
 
@@ -31,12 +33,16 @@ impl Program {
         &self.files
     }
 
+    pub fn import_aliases(&self) -> &AliasRegistry {
+        &self.import_aliases
+    }
+
     pub fn span(&self) -> &Span {
         &self.span
     }
 }
 
-impl_eq_hash!(Program; items, files);
+impl_eq_hash!(Program; items, files, import_aliases);
 
 /// Represents a single source file alongside its resolved scoping and visibility rules.
 #[derive(Clone, Debug)]
@@ -60,6 +66,37 @@ impl ResolvedFile {
 
 impl_eq_hash!(ResolvedFile; path, resolutions);
 
+/// A registry mapping an alias [`ItemNameWithFileId`] to its target item across different files.
+///
+/// We use a type alias here to provide a convenient abstraction for the `AST::analyze`
+/// phase, making it easier to modify the underlying structure in the future if needed.
+pub type AliasMap = BTreeMap<ItemNameWithFileId, ItemNameWithFileId>;
+pub type ItemNameWithFileId = (Arc<str>, usize);
+
+/// Manages the resolution of import aliases across the entire program.
+#[derive(Clone, Debug, Default)]
+pub struct AliasRegistry {
+    /// Maps an alias to its immediate target.
+    /// (e.g., `use B as C;` stores C -> B)
+    direct_targets: AliasMap,
+
+    /// Caches the final, original definition of an alias to avoid walking the chain.
+    /// (e.g., If C -> B and B -> A, this stores C -> A)
+    resolved_roots: AliasMap,
+}
+
+impl AliasRegistry {
+    pub fn direct_targets(&self) -> &AliasMap {
+        &self.direct_targets
+    }
+
+    pub fn resolved_roots(&self) -> &AliasMap {
+        &self.resolved_roots
+    }
+}
+
+impl_eq_hash!(AliasRegistry; direct_targets, resolved_roots);
+
 /// This is a core component of the [`DependencyGraph`].
 impl DependencyGraph {
     /// Resolves the dependency graph and constructs the final AST program.
@@ -78,6 +115,8 @@ impl DependencyGraph {
         let mut items: Vec<parse::Item> = Vec::new();
         let mut resolutions: Vec<HashMap<Arc<str>, Visibility>> =
             vec![HashMap::new(); self.modules.len()];
+        let mut import_aliases = AliasRegistry::default();
+        let mut items_registry = BTreeSet::<ItemNameWithFileId>::new();
 
         for &source_id in order {
             let module = &self.modules[source_id];
@@ -101,12 +140,14 @@ impl DependencyGraph {
                         parse::UseItems::List(elems) => elems.as_slice(),
                     };
 
-                    for item in use_decl_items {
+                    for aliased_item in use_decl_items {
                         if let Err(err) = Self::process_use_item(
+                            &mut items_registry,
+                            &mut import_aliases,
                             &mut resolutions,
                             source_id,
                             ind,
-                            Arc::from(item.as_inner()),
+                            aliased_item,
                             use_decl,
                         ) {
                             handler.push(err.with_source(source.clone()));
@@ -116,13 +157,22 @@ impl DependencyGraph {
                 }
 
                 // Handle Types & Functions
-                let (name, vis) = match elem {
-                    parse::Item::TypeAlias(a) => (a.name().as_inner(), a.visibility()),
-                    parse::Item::Function(f) => (f.name().as_inner(), f.visibility()),
+                let (name, vis, span) = match elem {
+                    parse::Item::TypeAlias(a) => (a.name().as_inner(), a.visibility(), *a.span()),
+                    parse::Item::Function(f) => (f.name().as_inner(), f.visibility(), *f.span()),
 
                     // Safe to skip: `Use` items are handled earlier in the loop, and `Module` currently has no functionality.
                     parse::Item::Module | parse::Item::Use(_) => continue,
                 };
+
+                let item_name = (Arc::from(name), source_id);
+                if items_registry.contains(&item_name) {
+                    handler.push(
+                        RichError::new(Error::RedefinedItem(name.to_string()), span)
+                            .with_source(source.clone()),
+                    );
+                }
+                items_registry.insert(item_name);
 
                 items.push(elem.clone());
                 resolutions[source_id].insert(Arc::from(name), vis.clone());
@@ -132,43 +182,101 @@ impl DependencyGraph {
         (!handler.has_errors()).then(|| Program {
             items: items.into(),
             files: construct_resolved_file_array(&self.paths, &resolutions),
+            import_aliases,
             span: *self.modules[0].parsed_program.as_ref(),
         })
     }
 
-    /// Processes a single imported item during the module resolution phase.
+    /// Processes a single imported item (or alias) during the module resolution phase.
+    ///
+    /// This function verifies that the requested item exists in the source module and
+    /// that it has the appropriate public visibility to be imported. If validation passes,
+    /// the item is registered in the importing module's resolution table and global alias registry.
     ///
     /// # Arguments
     ///
-    /// * `resolutions` - A mutable slice of hash maps, where each index corresponds to a module's ID and holds its resolved items and their visibilities.
+    /// * `import_aliases` - The global registry tracking alias chains and their canonical roots.
+    /// * `resolutions` - The global, mutable array mapping each `file_id` to its localized `FileResolutions` table.
     /// * `source_id` - The `usize` identifier of the destination source.
-    /// * `ind` - The unique identifier (`usize`) of the source module being imported *from*.
-    /// * `name` - The specific item name (`Arc<str>`) being imported from the source.
-    /// * `use_decl` - The AST node of the `use` statement. This dictates the visibility of the newly imported item in the destination module.
+    /// * `ind` - The unique identifier of the source module being imported *from*.
+    /// * `aliased_identifier` - The specific identifier (and potential alias) being imported from the source.
+    /// * `use_decl` - The node of the `use` statement. This dictates the visibility of the new import
+    ///   (e.g., `pub use` re-exports the item publicly).
     ///
     /// # Returns
     ///
     /// Returns `None` on success. Returns `Some(RichError)` if:
-    /// * [`Error::UnresolvedItem`]: The target `name` does not exist in the source module (`ind`).
-    /// * [`Error::PrivateItem`]: The target exists in the source module, but its visibility is expl
+    /// * [`Error::UnresolvedItem`]: The target `elem` does not exist in the source module (`ind`).
+    /// * [`Error::PrivateItem`]: The target exists, but its visibility is explicitly `Private`,
+    /// * [`Error::DuplicateAlias`]: The target `alias` (or imported name) has already been used in the current module.
     fn process_use_item(
+        items_registry: &mut BTreeSet<ItemNameWithFileId>,
+        import_aliases: &mut AliasRegistry,
         resolutions: &mut [HashMap<Arc<str>, Visibility>],
         source_id: usize,
         ind: usize,
-        name: Arc<str>,
+        (name, alias): &AliasedIdentifier,
         use_decl: &parse::UseDecl,
     ) -> Result<(), RichError> {
+        // NOTE: The order of errors is important!
         let span = *use_decl.span();
 
+        let name: Arc<str> = Arc::from(name.as_inner());
+        let orig_id = (name.clone(), ind);
+
+        // 1. Verify Existence: Does the item exist in the source file?
         let visibility = resolutions[ind]
             .get(&name)
             .ok_or_else(|| RichError::new(Error::UnresolvedItem(name.to_string()), span))?;
 
+        // 2. Verify Visibility: Are we allowed to see it?
         if matches!(visibility, parse::Visibility::Private) {
             return Err(RichError::new(Error::PrivateItem(name.to_string()), span));
         }
 
-        resolutions[source_id].insert(name, use_decl.visibility().clone());
+        // 3. Determine the local name and ID up front
+        let local_name = if let Some(alias) = alias {
+            Arc::from(alias.as_inner())
+        } else {
+            name.clone()
+        };
+        let local_id = (local_name.clone(), source_id);
+
+        // 4. Check for collisions
+        if import_aliases.direct_targets.contains_key(&local_id) {
+            return Err(RichError::new(
+                Error::DuplicateAlias(local_name.to_string()),
+                span,
+            ));
+        }
+
+        if items_registry.contains(&local_id) {
+            return Err(RichError::new(
+                Error::RedefinedItem(local_name.to_string()),
+                span,
+            ));
+        }
+        items_registry.insert(local_id.clone());
+
+        // 5. Update the registers
+        import_aliases
+            .direct_targets
+            .insert(local_id.clone(), orig_id.clone());
+
+        // 6. Find the true root using a single lookup!
+        // If `orig_id` exists in resolved_roots, it means it's an alias and we get its true root.
+        // If it returns None, it means `orig_id` is the original item, so it IS the root.
+        let true_root = import_aliases
+            .resolved_roots
+            .get(&orig_id)
+            .cloned()
+            .unwrap_or_else(|| orig_id.clone());
+
+        // Always cache the final root for instant O(1) lookups later
+        import_aliases.resolved_roots.insert(local_id, true_root);
+
+        // 7. Register the item in the local  module's namespace
+        resolutions[source_id].insert(local_name, use_decl.visibility().clone());
         Ok(())
     }
 }
@@ -192,7 +300,7 @@ fn construct_resolved_file_array(
 }
 
 #[cfg(test)]
-mod tests {
+mod resolve_order_tests {
     use crate::driver::tests::setup_graph;
 
     use super::*;
@@ -287,5 +395,287 @@ mod tests {
         assert!(error_handler
             .to_string()
             .contains(&"Item `foo` is private".to_string()));
+    }
+}
+
+#[cfg(test)]
+mod alias_tests {
+    use super::*;
+    use crate::driver::tests::setup_graph;
+    use std::sync::Arc;
+
+    #[test]
+    fn test_renaming_with_use() {
+        // Scenario: Renaming imports.
+        // main.simf: use lib::A::foo as bar;
+        // Expected: Scope should contain "bar", but not "foo".
+
+        let (graph, ids, _dir) = setup_graph(vec![
+            ("libs/lib/A.simf", "pub fn foo() {}"),
+            ("main.simf", "use lib::A::foo as bar;"),
+        ]);
+
+        let mut error_handler = ErrorCollector::new();
+        let program_option = graph.linearize_and_build(&mut error_handler).unwrap();
+
+        let Some(program) = program_option else {
+            panic!("{}", error_handler);
+        };
+
+        let id_root = ids["main"];
+        let scope = &program.files[id_root].resolutions;
+
+        assert!(
+            scope.get(&Arc::from("foo")).is_none(),
+            "Original name 'foo' should not be in scope"
+        );
+        assert!(
+            scope.get(&Arc::from("bar")).is_some(),
+            "Alias 'bar' should be in scope"
+        );
+    }
+
+    #[test]
+    fn test_multiple_aliases_in_list() {
+        // Scenario: Renaming multiple imports inside brackets.
+        let (graph, ids, _dir) = setup_graph(vec![
+            ("libs/lib/A.simf", "pub fn foo() {} pub fn baz() {}"),
+            ("main.simf", "use lib::A::{foo as bar, baz as qux};"),
+        ]);
+
+        let mut error_handler = ErrorCollector::new();
+        let program_option = graph.linearize_and_build(&mut error_handler).unwrap();
+
+        let Some(program) = program_option else {
+            panic!("{}", error_handler);
+        };
+
+        let id_root = ids["main"];
+        let scope = &program.files[id_root].resolutions;
+
+        // The original names should NOT be in scope
+        assert!(scope.get(&Arc::from("foo")).is_none());
+        assert!(scope.get(&Arc::from("baz")).is_none());
+
+        // The aliases MUST be in scope
+        assert!(scope.get(&Arc::from("bar")).is_some());
+        assert!(scope.get(&Arc::from("qux")).is_some());
+    }
+
+    #[test]
+    fn test_alias_private_item_fails() {
+        // Scenario: Attempting to alias a private item should fail.
+        let (graph, _ids, _dir) = setup_graph(vec![
+            ("libs/lib/A.simf", "fn secret() {}"), // Note: Missing `pub`
+            ("main.simf", "use lib::A::secret as my_secret;"),
+        ]);
+
+        let mut error_handler = ErrorCollector::new();
+        let program_option = graph.linearize_and_build(&mut error_handler).unwrap();
+
+        assert!(
+            program_option.is_none(),
+            "Compiler should emit an error and return None when aliasing a private item"
+        );
+
+        assert!(
+            error_handler
+                .to_string()
+                .contains("Item `secret` is private"),
+            "Error should mention the private item restriction"
+        );
+    }
+
+    #[test]
+    fn test_deep_reexport_with_aliases() {
+        // Scenario: Chaining aliases across multiple files.
+        let (graph, ids, _dir) = setup_graph(vec![
+            ("libs/lib/A.simf", "pub fn original() {}"),
+            ("libs/lib/B.simf", "pub use lib::A::original as middle;"),
+            ("main.simf", "use lib::B::middle as final_name;"),
+        ]);
+
+        let mut error_handler = ErrorCollector::new();
+        let program_option = graph.linearize_and_build(&mut error_handler).unwrap();
+
+        let Some(program) = program_option else {
+            panic!("{}", error_handler);
+        };
+
+        let id_b = ids["B"];
+        let id_root = ids["main"];
+
+        // Assert Main Scope
+        let main_scope = &program.files[id_root].resolutions;
+        assert!(main_scope.get(&Arc::from("original")).is_none());
+        assert!(main_scope.get(&Arc::from("middle")).is_none());
+        assert!(
+            main_scope.get(&Arc::from("final_name")).is_some(),
+            "Main must see the final alias"
+        );
+
+        // Assert B Scope (It should have the intermediate alias!)
+        let b_scope = &program.files[id_b].resolutions;
+        assert!(
+            b_scope.get(&Arc::from("middle")).is_some(),
+            "File B must contain its own public alias"
+        );
+    }
+
+    #[test]
+    fn test_deep_reexport_private_link_fails() {
+        // Scenario: Main tries to import an alias from B, but B's alias is private!
+        let (graph, _ids, _dir) = setup_graph(vec![
+            ("libs/lib/A.simf", "pub fn target() {}"),
+            // Note: Missing `pub` keyword here! This makes `hidden_alias` private to B.
+            ("libs/lib/B.simf", "use lib::A::target as hidden_alias;"),
+            ("main.simf", "use lib::B::hidden_alias;"),
+        ]);
+
+        let mut error_handler = ErrorCollector::new();
+        let program_option = graph.linearize_and_build(&mut error_handler).unwrap();
+
+        assert!(
+            program_option.is_none(),
+            "Compiler must return None when trying to import a private alias from an intermediate module"
+        );
+
+        assert!(
+            error_handler
+                .to_string()
+                .contains("Item `hidden_alias` is private"),
+            "Error should correctly identify the private intermediate alias"
+        );
+    }
+
+    #[test]
+    fn test_alias_cycle_detection() {
+        // Scenario: A malicious or confused user creates an infinite alias/import loop.
+        let (graph, _ids, _dir) = setup_graph(vec![
+            // A imports from B, B imports from A. This creates a file-level cycle!
+            ("libs/lib/A.simf", "pub use lib::B::pong as ping;"),
+            ("libs/lib/B.simf", "pub use lib::A::ping as pong;"),
+            ("main.simf", "use lib::A::ping;"),
+        ]);
+
+        let mut error_handler = ErrorCollector::new();
+
+        // Because A and B depend on each other, `linearize()` should catch the cycle
+        // and return an Err(...) directly, rather than causing a Stack Overflow.
+        let result = graph.linearize_and_build(&mut error_handler);
+
+        match result {
+            Err(e) => {
+                println!("{e}");
+                assert!(
+                    e.contains("Cycle") || e.contains("Circular"),
+                    "DFS Linearizer must catch infinite alias cycles"
+                );
+            }
+            Ok(None) => {
+                assert!(
+                    error_handler.has_errors(),
+                    "If linearization passes, the builder must catch the cycle"
+                );
+            }
+            Ok(Some(_)) => {
+                panic!("Expected compilation to fail due to a dependency cycle, but it succeeded!")
+            }
+        }
+    }
+
+    #[test]
+    fn test_plain_import_and_alias_to_same_name_is_rejected() {
+        let (graph, _ids, _dir) = setup_graph(vec![
+            ("libs/lib/A.simf", "pub fn foo() {}"),
+            ("libs/lib/B.simf", "pub fn foo() {}"),
+            ("main.simf", "use lib::A::foo; use lib::B::foo as foo;"),
+        ]);
+
+        let mut error_handler = ErrorCollector::new();
+        let program_option = graph.linearize_and_build(&mut error_handler).unwrap();
+
+        assert!(
+            program_option.is_none(),
+            "build should fail when two imports bind the same local name"
+        );
+        assert!(
+            error_handler
+                .to_string()
+                .contains("The alias `foo` was defined multiple times"),
+            "expected a duplicate-alias diagnostic"
+        );
+    }
+
+    #[test]
+    fn test_failed_alias_import_does_not_poison_following_imports() {
+        let (graph, _ids, _dir) = setup_graph(vec![
+            ("libs/lib/A.simf", "pub fn nope() {}"),
+            ("libs/lib/B.simf", "pub fn bar() {}"),
+            (
+                "main.simf",
+                "use lib::A::missing as foo; use lib::B::bar as foo;",
+            ),
+        ]);
+
+        let mut error_handler = ErrorCollector::new();
+        let program_option = graph.linearize_and_build(&mut error_handler).unwrap();
+        let errors = error_handler.to_string();
+
+        assert!(
+            program_option.is_none(),
+            "build should fail on the unresolved import"
+        );
+        assert!(errors.contains("Item `missing` could not be found"));
+        assert!(
+            !errors.contains("The alias `foo` was defined multiple times"),
+            "a failed import must not reserve the alias name"
+        );
+    }
+
+    #[test]
+    fn test_alias_cannot_reuse_local_definition_name() {
+        let (graph, _ids, _dir) = setup_graph(vec![
+            ("libs/lib/A.simf", "pub fn bar() {}"),
+            ("main.simf", "pub fn foo() {} use lib::A::bar as foo;"),
+        ]);
+
+        let mut error_handler = ErrorCollector::new();
+        let program_option = graph.linearize_and_build(&mut error_handler).unwrap();
+
+        dbg!(&error_handler.to_string());
+
+        assert!(
+            program_option.is_none(),
+            "build should fail when an alias reuses a local definition name"
+        );
+        assert!(
+            error_handler
+                .to_string()
+                .contains("Item `foo` was defined multiple times"),
+            "expected a redefined-item diagnostic"
+        );
+    }
+
+    #[test]
+    fn test_local_definition_cannot_reuse_alias_name() {
+        let (graph, _ids, _dir) = setup_graph(vec![
+            ("libs/lib/A.simf", "pub fn bar() {}"),
+            ("main.simf", "use lib::A::bar as foo; pub fn foo() {}"),
+        ]);
+
+        let mut error_handler = ErrorCollector::new();
+        let program_option = graph.linearize_and_build(&mut error_handler).unwrap();
+
+        assert!(
+            program_option.is_none(),
+            "build should fail when a local definition reuses an alias name"
+        );
+        assert!(
+            error_handler
+                .to_string()
+                .contains("Item `foo` was defined multiple times"),
+            "expected a redefined-item diagnostic"
+        );
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -494,6 +494,7 @@ pub enum Error {
     JetDoesNotExist(JetName),
     InvalidCast(ResolvedType, ResolvedType),
     FileNotFound(PathBuf),
+    RedefinedItem(String),
     UnresolvedItem(String),
     PrivateItem(String),
     MainNoInputs,
@@ -610,15 +611,17 @@ impl fmt::Display for Error {
                 f,
                 "Function `{name}` was called but not defined"
             ),
+            Error::RedefinedItem(name) => write!(
+                f,
+                "Item `{name}` was defined multiple times"
+            ),
             Error::UnresolvedItem(name) => write!(
                 f,
-                "Item `{}` could not be found",
-                name
+                "Item `{name}` could not be found"
             ),
             Error::PrivateItem(name) => write!(
                 f,
-                "Item `{}` is private",
-                name
+                "Item `{name}` is private"
             ),
             Error::InvalidNumberOfArguments(expected, found) => write!(
                 f,
@@ -666,8 +669,7 @@ impl fmt::Display for Error {
             ),
             Error::DuplicateAlias(name) => write!(
                 f,
-                "The alias `{}` was defined multiple times",
-                name,
+                "The alias `{name}` was defined multiple times"
             ),
             Error::VariableReuseInPattern(identifier) => write!(
                 f,

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -13,6 +13,7 @@ pub enum Token<'src> {
     // Keywords
     Pub,
     Use,
+    As,
     Fn,
     Let,
     Type,
@@ -70,6 +71,7 @@ impl<'src> fmt::Display for Token<'src> {
         match self {
             Token::Pub => write!(f, "pub"),
             Token::Use => write!(f, "use"),
+            Token::As => write!(f, "as"),
             Token::Fn => write!(f, "fn"),
             Token::Let => write!(f, "let"),
             Token::Type => write!(f, "type"),
@@ -144,6 +146,7 @@ pub fn lexer<'src>(
     let keyword = text::ident().map(|s| match s {
         "pub" => Token::Pub,
         "use" => Token::Use,
+        "as" => Token::As,
         "fn" => Token::Fn,
         "let" => Token::Let,
         "type" => Token::Type,
@@ -253,7 +256,7 @@ pub fn lex<'src>(input: &'src str) -> (Option<Tokens<'src>>, Vec<crate::error::R
 pub fn is_keyword(s: &str) -> bool {
     matches!(
         s,
-        "pub" | "use" | "fn" | "let" | "type" | "mod" | "const" | "match" | "true" | "false"
+        "pub" | "use" | "as" | "fn" | "let" | "type" | "mod" | "const" | "match" | "true" | "false"
     )
 }
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -132,6 +132,9 @@ impl UseDecl {
 
 impl_eq_hash!(UseDecl; visibility, path, drp_name, items);
 
+/// Aliases the specific identifier of an imported type to a new, local identifier
+pub type AliasedIdentifier = (Identifier, Option<Identifier>);
+
 /// Specified the items being brought into scope at the end of a `use` declaration
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
@@ -142,7 +145,7 @@ pub enum UseItems {
     /// ```text
     /// use core::math::add;
     /// ```
-    Single(Identifier),
+    Single(AliasedIdentifier),
 
     /// A multiple item import grouped in a list.
     ///
@@ -150,7 +153,7 @@ pub enum UseItems {
     /// ```text
     /// use core::math::{add, subtract};
     /// ```
-    List(Vec<Identifier>),
+    List(Vec<AliasedIdentifier>),
 }
 
 #[derive(Clone, Debug)]
@@ -731,14 +734,26 @@ impl fmt::Display for UseDecl {
 impl fmt::Display for UseItems {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            UseItems::Single(ident) => write!(f, "{}", ident),
-            UseItems::List(idents) => {
+            UseItems::Single((ident, alias)) => {
+                write!(f, "{}", ident)?;
+
+                if let Some(alias) = alias {
+                    write!(f, " as {}", alias)?;
+                }
+
+                Ok(())
+            }
+            UseItems::List(aliased_idents) => {
                 let _ = write!(f, "{{");
-                for (i, ident) in idents.iter().enumerate() {
+                for (i, (ident, alias)) in aliased_idents.iter().enumerate() {
                     if i > 0 {
                         write!(f, ", ")?;
                     }
                     write!(f, "{}", ident)?;
+
+                    if let Some(alias) = alias {
+                        write!(f, " as {}", alias)?;
+                    }
                 }
                 write!(f, "}}")
             }
@@ -1410,13 +1425,17 @@ impl ChumskyParse for UseDecl {
             .at_least(2)
             .collect::<Vec<_>>();
 
-        let list = Identifier::parser()
+        let aliased_item =
+            Identifier::parser().then(just(Token::As).ignore_then(Identifier::parser()).or_not());
+
+        let list = aliased_item
+            .clone()
             .separated_by(just(Token::Comma))
             .allow_trailing()
             .collect()
             .delimited_by(just(Token::LBrace), just(Token::RBrace))
             .map(UseItems::List);
-        let single = Identifier::parser().map(UseItems::Single);
+        let single = aliased_item.map(UseItems::Single);
         let items = choice((list, single));
 
         visibility
@@ -2407,6 +2426,8 @@ impl crate::ArbitraryRec for Match {
 
 #[cfg(test)]
 mod test {
+    use crate::parse;
+
     use super::*;
 
     impl UseDecl {
@@ -2452,5 +2473,17 @@ mod test {
 
         assert!(parse_program.is_none());
         assert!(ErrorCollector::to_string(&error_handler).contains("Expected ';', found '::'"));
+    }
+
+    #[test]
+    fn test_use_decl_display_round_trips_with_aliases() {
+        for input in [
+            "use lib::A::foo;",
+            "use lib::A::foo as bar;",
+            "use lib::A::{foo, bar as baz};",
+        ] {
+            let program = parse::Program::parse_from_str(input).expect("parsing works");
+            assert_eq!(program.to_string(), format!("{input}\n"));
+        }
     }
 }


### PR DESCRIPTION
This PR adds the ability to create aliases for imports, and tests them inside the driver crate