### PR TITLE
Change AST to match the functionality of the Driver

### DIFF
--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -1,4 +1,7 @@
-# Architecture Note: Omitted Keywords
+# Architecture Notes
+
+## Omitted Keywords
+
 The `crate` and `super` keywords were not added to the compiler because they
 are unnecessary at this stage. Typically, they are used to resolve relative
 paths during import parsing. However, in our architecture, the prefix before
@@ -6,7 +9,7 @@ the first `::` in a `use` statement is always an dependency root path. Since all
 dependency root paths are unique and strictly bound to specific paths, the resolver
 can always unambiguously resolve the path without needing relative pointers.
 
-# Architecture Note: Namespace Separation in SimplicityHL
+## Namespace Separation in SimplicityHL
 
 SimplicityHL uses distinct namespaces for types and values. This allows the same identifier to refer to different things depending on where it appears in the code — the compiler determines the correct interpretation from syntactic context, with no risk of collision.
 
@@ -19,3 +22,10 @@ fn main() {
     assert!(foo());     // value namespace - function
 }
 ```
+
+## The "main" identifier in aliases
+
+In SimplicityHL, the string "main" is reserved exclusively for the program's entry point function.
+While a `TypeAlias` is technically allowed to use this name, we explicitly forbid aliasing imports
+to "main" using the `as` keyword. This avoids complicating the compiler's resolution logic and
+prevents accidental shadowing of the entry point.

--- a/fuzz/fuzz_targets/compile_parse_tree.rs
+++ b/fuzz/fuzz_targets/compile_parse_tree.rs
@@ -3,16 +3,27 @@
 #[cfg(any(fuzzing, test))]
 fn do_test(data: &[u8]) {
     use arbitrary::Arbitrary;
+    use std::sync::Arc;
 
-    use simplicityhl::error::WithContent;
-    use simplicityhl::{ast, named, parse, ArbitraryOfType, Arguments};
+    use simplicityhl::error::{ErrorCollector, WithContent};
+    use simplicityhl::{ast, driver, named, parse, ArbitraryOfType, Arguments};
 
     let mut u = arbitrary::Unstructured::new(data);
     let parse_program = match parse::Program::arbitrary(&mut u) {
         Ok(x) => x,
         Err(_) => return,
     };
-    let ast_program = match ast::Program::analyze(&parse_program) {
+
+    let mut error_handler = ErrorCollector::new();
+    let driver_program = if let Some(program) =
+        driver::Program::from_parse(&parse_program, Arc::from(""), &mut error_handler)
+    {
+        program
+    } else {
+        return;
+    };
+
+    let ast_program = match ast::Program::analyze(&driver_program) {
         Ok(x) => x,
         Err(_) => return,
     };

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -9,6 +9,7 @@ use miniscript::iter::{Tree, TreeLike};
 use simplicity::jet::Elements;
 
 use crate::debug::{CallTracker, DebugSymbols, TrackedCallName};
+use crate::driver::{FileScoped, SymbolTable, MAIN_MODULE, MAIN_STR};
 use crate::error::{Error, RichError, Span, WithSpan};
 use crate::num::{NonZeroPow2Usize, Pow2Usize};
 use crate::parse::MatchPattern;
@@ -19,7 +20,7 @@ use crate::types::{
 };
 use crate::value::{UIntValue, Value};
 use crate::witness::{Parameters, WitnessTypes, WitnessValues};
-use crate::{impl_eq_hash, parse};
+use crate::{driver, impl_eq_hash, parse};
 
 /// A program consists of the main function.
 ///
@@ -520,18 +521,52 @@ impl TreeLike for ExprTree<'_> {
 /// 2. Resolving type aliases
 /// 3. Assigning types to each witness expression
 /// 4. Resolving calls to custom functions
-#[derive(Clone, Debug, Eq, PartialEq, Default)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 struct Scope {
+    file_id: usize,
     variables: Vec<HashMap<Identifier, ResolvedType>>,
-    aliases: HashMap<AliasName, ResolvedType>,
+    aliases: HashMap<FileScoped<AliasName>, ResolvedType>,
+    aliases_table: SymbolTable<AliasName>,
     parameters: HashMap<WitnessName, ResolvedType>,
     witnesses: HashMap<WitnessName, ResolvedType>,
-    functions: HashMap<FunctionName, CustomFunction>,
+    functions: HashMap<FileScoped<FunctionName>, CustomFunction>,
+    functions_table: SymbolTable<FunctionName>,
     is_main: bool,
     call_tracker: CallTracker,
 }
 
+impl Default for Scope {
+    fn default() -> Self {
+        Self::new(
+            SymbolTable::<AliasName>::default(),
+            SymbolTable::<FunctionName>::default(),
+        )
+    }
+}
+
 impl Scope {
+    pub fn new(
+        aliases_table: SymbolTable<AliasName>,
+        functions_table: SymbolTable<FunctionName>,
+    ) -> Self {
+        Self {
+            file_id: MAIN_MODULE,
+            variables: Vec::new(),
+            aliases: HashMap::new(),
+            aliases_table,
+            parameters: HashMap::new(),
+            witnesses: HashMap::new(),
+            functions: HashMap::new(),
+            functions_table,
+            is_main: false,
+            call_tracker: CallTracker::default(),
+        }
+    }
+
+    pub fn file_id(&self) -> usize {
+        self.file_id
+    }
+
     /// Check if the current scope is topmost.
     pub fn is_topmost(&self) -> bool {
         self.variables.is_empty()
@@ -600,15 +635,59 @@ impl Scope {
             .find_map(|scope| scope.get(identifier))
     }
 
+    /// Retrieves the definition of a type alias, enforcing strict error prioritization.
+    ///
+    /// # Errors
+    /// * [`Error::UndefinedAlias`]: The alias is not found in the global registry.
+    /// * [`Error::Internal`]: The specified `file_id` does not exist in the `files`.
+    /// * [`Error::PrivateItem`]: The alias exists globally but is not exposed to the current file's scope.
+    fn get_alias(&self, name: &AliasName) -> Result<ResolvedType, Error> {
+        // 1. Get the true global ID of the alias.
+        let initial_id = (name.clone(), self.file_id);
+        let global_id = self
+            .aliases_table
+            .imports()
+            .resolved_roots()
+            .get(&initial_id)
+            .cloned()
+            .unwrap_or(initial_id);
+
+        // 2. Fetch the alias from the global pool.
+        let resolved_type = self
+            .aliases
+            .get(&global_id)
+            .ok_or_else(|| Error::UndefinedAlias(name.clone()))?;
+
+        // 3. Fetch the file scope for visibility checking.
+        let file_scope = self
+            .aliases_table
+            .local_scopes()
+            .get(self.file_id)
+            .ok_or_else(|| {
+                Error::Internal(format!(
+                    "file_id {} not found inside current Scope aliases",
+                    self.file_id
+                ))
+            })?;
+
+        // 4. Verify local scope visibility.
+        if file_scope.contains(name) {
+            // We clone here because types usually need to be owned in AST resolution
+            Ok(resolved_type.clone())
+        } else {
+            Err(Error::PrivateItem(name.as_inner().to_string()))
+        }
+    }
+
     /// Resolve a type with aliases to a type without aliases.
     ///
     /// ## Errors
     ///
-    /// There are any undefined aliases.
+    /// * [`Error::UndefinedAlias`]: The alias is not found in the global registry.
+    /// * [`Error::Internal`]: The specified `file_id` does not exist in the `files`.
+    /// * [`Error::PrivateItem`]: The alias exists globally but is not exposed to the current file's scope.
     pub fn resolve(&self, ty: &AliasedType) -> Result<ResolvedType, Error> {
-        let get_alias =
-            |name: &AliasName| -> Option<ResolvedType> { self.aliases.get(name).cloned() };
-        ty.resolve(get_alias).map_err(Error::UndefinedAlias)
+        ty.resolve(|name| self.get_alias(name))
     }
 
     /// Push a type alias into the global map.
@@ -617,11 +696,12 @@ impl Scope {
     ///
     /// There are any undefined aliases.
     pub fn insert_alias(&mut self, name: AliasName, ty: AliasedType) -> Result<(), Error> {
-        if self.aliases.contains_key(&name) {
+        let plug = (name.clone(), self.file_id);
+        if self.aliases.contains_key(&plug) {
             return Err(Error::RedefinedAlias(name));
         }
 
-        let _ = self.aliases.insert(name, self.resolve(&ty)?);
+        let _ = self.aliases.insert(plug, self.resolve(&ty)?);
         Ok(())
     }
 
@@ -684,18 +764,66 @@ impl Scope {
         name: FunctionName,
         function: CustomFunction,
     ) -> Result<(), Error> {
-        match self.functions.entry(name.clone()) {
-            Entry::Occupied(_) => Err(Error::FunctionRedefined(name)),
-            Entry::Vacant(entry) => {
-                entry.insert(function);
-                Ok(())
-            }
+        let func_name_id = (name.clone(), self.file_id);
+
+        if self.functions.contains_key(&func_name_id) {
+            return Err(Error::FunctionRedefined(name));
         }
+
+        let _ = self.functions.insert(func_name_id, function);
+        Ok(())
     }
 
-    /// Get the definition of a custom function.
-    pub fn get_function(&self, name: &FunctionName) -> Option<&CustomFunction> {
-        self.functions.get(name)
+    /// Retrieves the definition of a custom function, enforcing strict error prioritization.
+    ///
+    /// # Architecture Note
+    /// The order of operations here is intentional to prioritize specific compiler errors:
+    /// 1. Resolve the alias to find the true global coordinates.
+    /// 2. Check for global existence (`FunctionUndefined`) *before* checking local visibility.
+    /// 3. Verify if the current file's scope is actually allowed to see it (`PrivateItem`).
+    ///
+    /// # Errors
+    ///
+    /// * [`Error::FunctionUndefined`]: The function is not found in the global registry.
+    /// * [`Error::Internal`]: The specified `file_id` does not exist in the `files`.
+    /// * [`Error::PrivateItem`]: The function exists globally but is not exposed to the current file's scope.
+    pub fn get_function(&self, name: &FunctionName) -> Result<&CustomFunction, Error> {
+        // 1. Get the true global ID of the alias (or keep the current name if it is not aliased).
+        let initial_id = (name.clone(), self.file_id);
+        let global_id = self
+            .functions_table
+            .imports()
+            .resolved_roots()
+            .get(&initial_id)
+            .cloned()
+            .unwrap_or(initial_id);
+
+        // 2. Fetch the function from the global pool.
+        // We do this first so we can throw FunctionUndefined before checking local visibility.
+        let function = self
+            .functions
+            .get(&global_id)
+            .ok_or_else(|| Error::FunctionUndefined(name.clone()))?;
+
+        // TODO: Consider changing it to a better error handler with a source file.
+        let file_scope = self
+            .functions_table
+            .local_scopes()
+            .get(self.file_id)
+            .ok_or_else(|| {
+                Error::Internal(format!(
+                    "file_id {} not found inside current Scope files",
+                    self.file_id
+                ))
+            })?;
+
+        // 3. Verify local scope visibility.
+        // We successfully found the function globally, but is this file allowed to use it?
+        if file_scope.contains(name) {
+            Ok(function)
+        } else {
+            Err(Error::PrivateItem(name.as_inner().to_string()))
+        }
     }
 
     /// Track a call expression with its span.
@@ -718,9 +846,10 @@ trait AbstractSyntaxTree: Sized {
 }
 
 impl Program {
-    pub fn analyze(from: &parse::Program) -> Result<Self, RichError> {
+    pub fn analyze(from: &driver::Program) -> Result<Self, RichError> {
         let unit = ResolvedType::unit();
-        let mut scope = Scope::default();
+        let mut scope = Scope::new(from.aliases().clone(), from.functions().clone());
+
         let items = from
             .items()
             .iter()
@@ -732,6 +861,7 @@ impl Program {
             Item::Function(Function::Main(expr)) => Some(expr),
             _ => None,
         });
+
         let main = iter.next().ok_or(Error::MainRequired).with_span(from)?;
         if iter.next().is_some() {
             return Err(Error::FunctionRedefined(FunctionName::main())).with_span(from);
@@ -751,15 +881,18 @@ impl AbstractSyntaxTree for Item {
     fn analyze(from: &Self::From, ty: &ResolvedType, scope: &mut Scope) -> Result<Self, RichError> {
         assert!(ty.is_unit(), "Items cannot return anything");
         assert!(scope.is_topmost(), "Items live in the topmost scope only");
+        let previous_file_id = scope.file_id();
 
-        match from {
+        let res = match from {
             parse::Item::TypeAlias(alias) => {
+                scope.file_id = alias.file_id();
                 scope
                     .insert_alias(alias.name().clone(), alias.ty().clone())
                     .with_span(alias)?;
                 Ok(Self::TypeAlias)
             }
             parse::Item::Function(function) => {
+                scope.file_id = function.file_id();
                 Function::analyze(function, ty, scope).map(Self::Function)
             }
             parse::Item::Use(use_decl) => Err(RichError::new(
@@ -767,7 +900,10 @@ impl AbstractSyntaxTree for Item {
                 *use_decl.span(),
             )),
             parse::Item::Module => Ok(Self::Module),
-        }
+        };
+
+        scope.file_id = previous_file_id;
+        res
     }
 }
 
@@ -778,7 +914,7 @@ impl AbstractSyntaxTree for Function {
         assert!(ty.is_unit(), "Function definitions cannot return anything");
         assert!(scope.is_topmost(), "Items live in the topmost scope only");
 
-        if from.name().as_inner() != "main" {
+        if from.name().as_inner() != MAIN_STR {
             let params = from
                 .params()
                 .iter()
@@ -795,12 +931,14 @@ impl AbstractSyntaxTree for Function {
                 .map(|aliased| scope.resolve(aliased).with_span(from))
                 .transpose()?
                 .unwrap_or_else(ResolvedType::unit);
+
             scope.push_scope();
             for param in params.iter() {
                 scope.insert_variable(param.identifier().clone(), param.ty().clone());
             }
             let body = Expression::analyze(from.body(), &ret, scope).map(Arc::new)?;
             scope.pop_scope();
+
             debug_assert!(scope.is_topmost());
             let function = CustomFunction { params, body };
             scope
@@ -818,6 +956,10 @@ impl AbstractSyntaxTree for Function {
             if !resolved.is_unit() {
                 return Err(Error::MainNoOutput).with_span(from);
             }
+        }
+
+        if scope.file_id() != MAIN_MODULE {
+            return Err(Error::MainOutOfEntryFile).with_span(from);
         }
 
         scope.push_main_scope();
@@ -1325,14 +1467,9 @@ impl AbstractSyntaxTree for CallName {
                 .get_function(name)
                 .cloned()
                 .map(Self::Custom)
-                .ok_or(Error::FunctionUndefined(name.clone()))
                 .with_span(from),
             parse::CallName::ArrayFold(name, size) => {
-                let function = scope
-                    .get_function(name)
-                    .cloned()
-                    .ok_or(Error::FunctionUndefined(name.clone()))
-                    .with_span(from)?;
+                let function = scope.get_function(name).cloned().with_span(from)?;
                 // A function that is used in a array fold has the signature:
                 //   fn f(element: E, accumulator: A) -> A
                 if function.params().len() != 2 || function.params()[1].ty() != function.body().ty()
@@ -1343,11 +1480,7 @@ impl AbstractSyntaxTree for CallName {
                 }
             }
             parse::CallName::Fold(name, bound) => {
-                let function = scope
-                    .get_function(name)
-                    .cloned()
-                    .ok_or(Error::FunctionUndefined(name.clone()))
-                    .with_span(from)?;
+                let function = scope.get_function(name).cloned().with_span(from)?;
                 // A function that is used in a list fold has the signature:
                 //   fn f(element: E, accumulator: A) -> A
                 if function.params().len() != 2 || function.params()[1].ty() != function.body().ty()
@@ -1358,11 +1491,7 @@ impl AbstractSyntaxTree for CallName {
                 }
             }
             parse::CallName::ForWhile(name) => {
-                let function = scope
-                    .get_function(name)
-                    .cloned()
-                    .ok_or(Error::FunctionUndefined(name.clone()))
-                    .with_span(from)?;
+                let function = scope.get_function(name).cloned().with_span(from)?;
                 // A function that is used in a for-while loop has the signature:
                 //   fn f(accumulator: A, readonly_context: C, counter: u{N}) -> Either<B, A>
                 // where
@@ -1581,5 +1710,85 @@ impl AsRef<Span> for Module {
 impl AsRef<Span> for ModuleAssignment {
     fn as_ref(&self) -> &Span {
         &self.span
+    }
+}
+
+#[cfg(test)]
+mod alias_scope_regression_tests {
+    use super::Program;
+    use crate::driver::tests::setup_graph;
+    use crate::error::ErrorCollector;
+
+    fn analyze_multifile(files: Vec<(&str, &str)>) -> Result<(), String> {
+        let (graph, _ids, _dir) = setup_graph(files);
+
+        let mut error_handler = ErrorCollector::new();
+        let driver_program = graph
+            .linearize_and_build(&mut error_handler)
+            .unwrap()
+            .expect("driver build should succeed");
+
+        Program::analyze(&driver_program)
+            .map(|_| ())
+            .map_err(|e| e.to_string())
+    }
+
+    #[test]
+    fn private_type_alias_from_dependency_does_not_leak() {
+        let result = analyze_multifile(vec![
+            (
+                "main.simf",
+                "use lib::A::helper; fn main() { helper(); let x: Secret = 0; }",
+            ),
+            ("libs/lib/A.simf", "type Secret = u32; pub fn helper() {}"),
+        ]);
+
+        assert!(
+            result.is_err(),
+            "private alias from another file leaked into root scope: {result:?}"
+        );
+    }
+
+    #[test]
+    fn same_alias_name_in_different_modules_does_not_conflict_if_only_one_is_imported() {
+        let result = analyze_multifile(vec![
+            (
+                "main.simf",
+                "use lib::A::Word; use lib::B::id; fn main() { let x: Word = 0; assert!(jet::is_zero_32(id(x))); }",
+            ),
+            ("libs/lib/A.simf", "pub type Word = u32;"),
+            ("libs/lib/B.simf", "pub type Word = u16; pub fn id(x: u32) -> u32 { x }"),
+        ]);
+
+        assert!(
+            result.is_ok(),
+            "unimported alias from another module should not collide: {result:?}"
+        );
+    }
+
+    #[test]
+    fn dependency_main_does_not_satisfy_missing_root_main() {
+        let result = analyze_multifile(vec![
+            ("main.simf", "use lib::A::helper;"),
+            ("libs/lib/A.simf", "fn main() {} pub fn helper() {}"),
+        ]);
+
+        assert!(
+            result.is_err(),
+            "Main function must be inside an entry file: {result:?}"
+        )
+    }
+
+    #[test]
+    fn main_must_be_defined_once_per_project() {
+        let result = analyze_multifile(vec![
+            ("main.simf", "use lib::A::helper; fn main() { helper(); }"),
+            ("libs/lib/A.simf", "fn main() {} pub fn helper() {}"),
+        ]);
+
+        assert!(
+            result.is_err(),
+            "Main function must be inside an entry file: {result:?}"
+        );
     }
 }

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -28,7 +28,7 @@
 //! the dependency graph construction.
 
 mod linearization;
-mod resolve_order;
+pub(crate) mod resolve_order;
 
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::PathBuf;
@@ -39,6 +39,14 @@ use chumsky::container::Container;
 use crate::error::{Error, ErrorCollector, RichError, Span};
 use crate::parse::{self, ParseFromStrWithErrors};
 use crate::resolution::{CanonPath, DependencyMap, SourceFile};
+
+pub use crate::driver::resolve_order::{FileScoped, Program, SymbolTable};
+
+/// The reserved identifier for the program's entry point.
+pub const MAIN_STR: &str = "main";
+
+/// The root node index in the [`DependencyGraph`] representing the entry file.
+pub const MAIN_MODULE: usize = 0;
 
 /// Caches the canonicalized path of a source file to prevent redundant,
 /// expensive, and potentially failing filesystem operations.
@@ -189,14 +197,13 @@ impl DependencyGraph {
             dependencies: HashMap::new(),
         };
 
-        let root_id = 0;
         graph
             .lookup
-            .insert(root_canon_source.name().clone(), root_id);
-        graph.dependencies.insert(root_id, Vec::new());
+            .insert(root_canon_source.name().clone(), MAIN_MODULE);
+        graph.dependencies.insert(MAIN_MODULE, Vec::new());
 
         let mut queue = VecDeque::new();
-        queue.push_back(root_id);
+        queue.push_back(MAIN_MODULE);
 
         // Prevent errors in the checked files from being doubled in the `load_and_parse_dependencies` function.
         let mut inalid_imports = HashSet::new();
@@ -338,7 +345,7 @@ impl DependencyGraph {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
     use crate::resolution::tests::canon;
     use crate::test_utils::TempWorkspace;

--- a/src/driver/resolve_order.rs
+++ b/src/driver/resolve_order.rs
@@ -1,10 +1,10 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::sync::Arc;
 
-use crate::driver::DependencyGraph;
+use crate::driver::{DependencyGraph, MAIN_MODULE, MAIN_STR};
 use crate::error::{Error, ErrorCollector, RichError, Span};
 use crate::impl_eq_hash;
-use crate::parse::{self, AliasedSymbolName, Visibility};
+use crate::parse::{self, AliasedSymbolName, Function, TypeAlias, Visibility};
 use crate::str::{AliasName, FunctionName, SymbolName};
 
 /// The final, flattened representation of a SimplicityHL program.
@@ -26,6 +26,58 @@ pub struct Program {
 }
 
 impl Program {
+    pub fn from_parse(
+        parsed: &parse::Program,
+        content: Arc<str>,
+        handler: &mut ErrorCollector,
+    ) -> Option<Self> {
+        let module_count = 1;
+
+        let mut items: Vec<parse::Item> = Vec::new();
+
+        let mut aliases = NamespaceTracker::<AliasName>::new(module_count);
+        let mut functions = NamespaceTracker::<FunctionName>::new(module_count);
+
+        for item in parsed.items() {
+            if let parse::Item::Use(use_decl) = item {
+                handler.push(
+                    RichError::new(Error::UnknownLibrary(use_decl.str_path()), *use_decl.span())
+                        .with_content(content.clone()),
+                );
+                continue;
+            }
+
+            let mut new_elem = item.clone();
+            match &mut new_elem {
+                parse::Item::TypeAlias(type_alias) => {
+                    if let Err(err) = register_type_alias(type_alias, &mut aliases, MAIN_MODULE) {
+                        handler.push(err.with_content(content.clone()));
+                        continue;
+                    }
+                }
+                parse::Item::Function(function) => {
+                    if let Err(err) = register_function(function, &mut functions, MAIN_MODULE) {
+                        handler.push(err.with_content(content.clone()));
+                        continue;
+                    }
+                }
+
+                // Safe to skip: `Use` items are handled earlier in the loop, and `Module` currently has no functionality.
+                parse::Item::Module | parse::Item::Use(_) => continue,
+            }
+            items.push(new_elem);
+        }
+
+        // TODO: Consider getting rid of the 'String' error here and changing it to a more appropriate error
+        // (e.g. 'Result<Self, ErrorCollector>') after resolving https://github.com/BlockstreamResearch/SimplicityHL/issues/270.
+        (!handler.has_errors()).then(|| Program {
+            items: items.into(),
+            aliases: aliases.into_symbol_table(),
+            functions: functions.into_symbol_table(),
+            span: *parsed.as_ref(),
+        })
+    }
+
     pub fn items(&self) -> &[parse::Item] {
         &self.items
     }
@@ -78,7 +130,7 @@ pub type FileScoped<T> = (T, usize);
 pub type ImportMap<T> = BTreeMap<FileScoped<T>, FileScoped<T>>;
 
 /// Manages the resolution of import aliases across the entire program.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct ImportRegistry<T> {
     direct_targets: ImportMap<T>,
     resolved_roots: ImportMap<T>,
@@ -164,53 +216,26 @@ impl DependencyGraph {
                     continue;
                 }
 
-                items.push(elem.clone());
-
                 // Handle Types & Functions by inserting them into their STRICT namespaces
-                // Architectural Note:
-                // The code may seem duplicated. To prevent this, the best approach
-                // would be to add a `NamedItem` trait. However, doing so would require
-                // duplicating getter methods for both `Function` and `TypeAlias`.
-                // As a result, it is better to leave it as is.
-                match elem {
+                let mut new_elem = elem.clone();
+                match &mut new_elem {
                     parse::Item::TypeAlias(type_alias) => {
-                        let name = type_alias.name();
-                        let local_id = (name.clone(), source_id);
-
-                        if aliases.memo.contains(&local_id) {
-                            handler.push(
-                                RichError::new(
-                                    Error::RedefinedAlias(name.clone()),
-                                    *type_alias.span(),
-                                )
-                                .with_source(source.clone()),
-                            );
+                        if let Err(err) = register_type_alias(type_alias, &mut aliases, source_id) {
+                            handler.push(err.with_source(source.clone()));
+                            continue;
                         }
-                        aliases.memo.insert(local_id);
-                        aliases.resolutions[source_id]
-                            .insert(name.clone(), type_alias.visibility().clone());
                     }
                     parse::Item::Function(function) => {
-                        let name = function.name();
-                        let local_id = (name.clone(), source_id);
-
-                        if functions.memo.contains(&local_id) {
-                            handler.push(
-                                RichError::new(
-                                    Error::FunctionRedefined(name.clone()),
-                                    *function.span(),
-                                )
-                                .with_source(source.clone()),
-                            );
+                        if let Err(err) = register_function(function, &mut functions, source_id) {
+                            handler.push(err.with_source(source.clone()));
+                            continue;
                         }
-                        functions.memo.insert(local_id);
-                        functions.resolutions[source_id]
-                            .insert(name.clone(), function.visibility().clone());
                     }
 
                     // Safe to skip: `Use` items are handled earlier in the loop, and `Module` currently has no functionality.
                     parse::Item::Module | parse::Item::Use(_) => continue,
                 }
+                items.push(new_elem);
             }
         }
 
@@ -269,6 +294,7 @@ impl DependencyGraph {
     /// Returns `Ok(())` on success. Returns `Err(RichError)` if:
     /// * [`Error::UnresolvedItem`]: The target name does not exist in the source module (`ind`).
     /// * [`Error::PrivateItem`]: The target exists, but its visibility is explicitly `Private`.
+    /// * [`Error::MainCannotBeAlias`]: The `main` cannot be alias.
     /// * [`Error::DuplicateAlias`]: The local name (or alias) has already been used in another import statement.
     /// * [`Error::RedefinedItem`]: The local name conflicts with an existing item already defined in this module.
     fn process_use_item<T>(
@@ -289,7 +315,7 @@ impl DependencyGraph {
         let orig_id = (target_name.clone(), ind);
 
         // 2. Verify Existence using T
-        let visibility = namespace.resolutions[ind]
+        let visibility: &Visibility = namespace.resolutions[ind]
             .get(&target_name)
             .ok_or_else(|| RichError::new(Error::UnresolvedItem(name.to_string()), span))?;
 
@@ -303,7 +329,17 @@ impl DependencyGraph {
         let local_symbol = alias.as_ref().unwrap_or(name);
 
         // Then convert that raw symbol to T
-        let local_name: T = local_symbol.clone().into();
+        let local_name: T = if let Some(alias_sym) = alias {
+            let t_alias: T = alias_sym.clone().into();
+
+            if t_alias.to_string() == MAIN_STR {
+                return Err(RichError::new(Error::MainCannotBeAlias, span));
+            }
+            t_alias
+        } else {
+            name.clone().into()
+        };
+
         let local_id = (local_name.clone(), source_id);
 
         // 5. Check for collisions using `namespace` fields
@@ -347,6 +383,59 @@ impl DependencyGraph {
     }
 }
 
+// Architectural Note:
+// The two functions may seem duplicated. To prevent this, the best approach
+// would be to add a `NamedItem` trait. However, doing so would require
+// duplicating getter methods for both `Function` and `TypeAlias`.
+// As a result, it is better to leave it as is.
+fn register_type_alias(
+    item: &mut TypeAlias,
+    tracker: &mut NamespaceTracker<AliasName>,
+    source_id: usize,
+) -> Result<(), RichError> {
+    item.set_file_id(source_id);
+
+    let name = item.name();
+    let local_id = (name.clone(), source_id);
+
+    if tracker.memo.contains(&local_id) {
+        return Err(RichError::new(
+            Error::RedefinedAlias(name.clone()),
+            *item.span(),
+        ));
+    }
+
+    tracker.memo.insert(local_id);
+    tracker.resolutions[source_id].insert(name.clone(), item.visibility().clone());
+    Ok(())
+}
+
+fn register_function(
+    item: &mut Function,
+    tracker: &mut NamespaceTracker<FunctionName>,
+    source_id: usize,
+) -> Result<(), RichError> {
+    item.set_file_id(source_id);
+
+    let name = item.name();
+    let local_id = (name.clone(), source_id);
+
+    if name.as_inner() == MAIN_STR && matches!(item.visibility(), Visibility::Public) {
+        return Err(RichError::new(Error::MainCannotBePublic, *item.span()));
+    }
+
+    if tracker.memo.contains(&local_id) {
+        return Err(RichError::new(
+            Error::FunctionRedefined(name.clone()),
+            *item.span(),
+        ));
+    }
+
+    tracker.memo.insert(local_id);
+    tracker.resolutions[source_id].insert(name.clone(), item.visibility().clone());
+    Ok(())
+}
+
 /// Helper struct, that tracks the resolution state, imports, and memoization for a single namespace.
 #[derive(Clone, Debug)]
 struct NamespaceTracker<T> {
@@ -379,6 +468,30 @@ impl<T: Ord + Clone + Default + std::hash::Hash> NamespaceTracker<T> {
                 .into(),
             imports: self.registry,
         }
+    }
+}
+
+impl<T> Default for ImportRegistry<T> {
+    fn default() -> Self {
+        Self {
+            direct_targets: BTreeMap::new(),
+            resolved_roots: BTreeMap::new(),
+        }
+    }
+}
+
+impl<T> Default for SymbolTable<T> {
+    fn default() -> Self {
+        Self {
+            local_scopes: Arc::from([]),
+            imports: ImportRegistry::<T>::default(),
+        }
+    }
+}
+
+impl AsRef<Span> for Program {
+    fn as_ref(&self) -> &Span {
+        &self.span
     }
 }
 
@@ -525,6 +638,55 @@ mod resolve_order_tests {
         assert!(
             program_option.is_none(),
             "build should fail when a second import reuses the function name `foo`"
+        );
+    }
+
+    #[test]
+    fn test_public_main_is_forbidden() {
+        // Scenario: A user tries to declare the entry point as `pub fn main`.
+        // Expected: The compiler must reject this because `main` must be private.
+
+        let (graph, _ids, _dir) = setup_graph(vec![("main.simf", "pub fn main() {}")]);
+
+        let mut error_handler = ErrorCollector::new();
+        let program_option = graph.linearize_and_build(&mut error_handler).unwrap();
+
+        assert!(
+            program_option.is_none(),
+            "Compiler should return None when `main` is declared public"
+        );
+
+        let error_msg = error_handler.to_string();
+        assert!(
+            error_msg.contains("main") && error_msg.contains("public"),
+            "Error message should mention that `main` cannot be public. Got: {}",
+            error_msg
+        );
+    }
+
+    #[test]
+    fn test_aliasing_to_main_is_forbidden() {
+        // Scenario: A user tries to bypass entry point rules by renaming an import to `main`.
+        // Expected: The compiler must reject this because `main` is a reserved identifier.
+
+        let (graph, _ids, _dir) = setup_graph(vec![
+            ("libs/lib/A.simf", "pub type bar = u32;"),
+            ("main.simf", "use lib::A::bar as main;"),
+        ]);
+
+        let mut error_handler = ErrorCollector::new();
+        let program_option = graph.linearize_and_build(&mut error_handler).unwrap();
+
+        assert!(
+            program_option.is_none(),
+            "Compiler should return None when a user tries to alias an import to `main`"
+        );
+
+        let error_msg = error_handler.to_string();
+        assert!(
+            error_msg.contains("main") && error_msg.contains("alias"),
+            "Error message should clearly state that `main` cannot be used as an alias. Got: {}",
+            error_msg
         );
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -500,6 +500,9 @@ pub enum Error {
     MainNoInputs,
     MainNoOutput,
     MainRequired,
+    MainOutOfEntryFile,
+    MainCannotBePublic,
+    MainCannotBeAlias,
     FunctionRedefined(FunctionName),
     FunctionUndefined(FunctionName),
     InvalidNumberOfArguments(usize, usize),
@@ -602,6 +605,18 @@ impl fmt::Display for Error {
             Error::MainRequired => write!(
                 f,
                 "Main function is required"
+            ),
+            Error::MainOutOfEntryFile => write!(
+                f,
+                "The 'main' function must be defined in the entry point file"
+            ),
+            Error::MainCannotBePublic => write!(
+                f,
+                "Main function cannot be public"
+            ),
+            Error::MainCannotBeAlias => write!(
+                f,
+                "Main function cannot be alias",
             ),
             Error::FunctionRedefined(name) => write!(
                 f,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,13 @@ impl TemplateProgram {
         let mut error_handler = ErrorCollector::new();
         let parse_program = parse::Program::parse_from_str_with_errors(source, &mut error_handler);
 
-        if let Some(program) = parse_program {
+        let driver_program = if let Some(parse_program) = parse_program {
+            driver::Program::from_parse(&parse_program, file.clone(), &mut error_handler)
+        } else {
+            None
+        };
+
+        if let Some(program) = driver_program {
             let ast_program = ast::Program::analyze(&program).with_content(Arc::clone(&file))?;
             Ok(Self {
                 simfony: ast_program,

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -3,6 +3,7 @@
 
 use std::fmt;
 use std::num::NonZeroUsize;
+use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -16,6 +17,7 @@ use chumsky::{extra, select, IterParser, Parser};
 use either::Either;
 use miniscript::iter::{Tree, TreeLike};
 
+use crate::driver::MAIN_MODULE;
 use crate::error::ErrorCollector;
 use crate::error::{Error, RichError, Span};
 use crate::impl_eq_hash;
@@ -108,6 +110,11 @@ impl UseDecl {
         self.path.iter().map(|s| s.as_inner()).collect()
     }
 
+    pub fn str_path(&self) -> String {
+        let path: PathBuf = self.path.iter().map(|s| s.as_inner()).collect();
+        path.display().to_string()
+    }
+
     /// Extracts the Dependency Root Path Name (the very first segment) from this path.
     ///
     /// # Errors
@@ -158,6 +165,7 @@ pub enum UseItems {
 
 #[derive(Clone, Debug)]
 pub struct Function {
+    file_id: usize, // The field required for the driver
     visibility: Visibility,
     name: FunctionName,
     params: Arc<[FunctionParam]>,
@@ -167,6 +175,14 @@ pub struct Function {
 }
 
 impl Function {
+    pub fn file_id(&self) -> usize {
+        self.file_id
+    }
+
+    pub fn set_file_id(&mut self, file_id: usize) {
+        self.file_id = file_id;
+    }
+
     pub fn visibility(&self) -> &Visibility {
         &self.visibility
     }
@@ -326,6 +342,7 @@ pub enum CallName {
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct TypeAlias {
+    file_id: usize, // The field required for the driver
     visibility: Visibility,
     name: AliasName,
     ty: AliasedType,
@@ -333,6 +350,14 @@ pub struct TypeAlias {
 }
 
 impl TypeAlias {
+    pub fn file_id(&self) -> usize {
+        self.file_id
+    }
+
+    pub fn set_file_id(&mut self, file_id: usize) {
+        self.file_id = file_id;
+    }
+
     pub fn visibility(&self) -> &Visibility {
         &self.visibility
     }
@@ -1396,7 +1421,8 @@ impl ChumskyParse for Function {
             .then(params)
             .then(ret)
             .then(body)
-            .map_with(|((((visibility, name), params), ret), body), e| Self {
+            .map_with(move |((((visibility, name), params), ret), body), e| Self {
+                file_id: MAIN_MODULE,
                 visibility,
                 name,
                 params,
@@ -1726,7 +1752,8 @@ impl ChumskyParse for TypeAlias {
                     .then(AliasedType::parser())
                     .then_ignore(just(Token::Semi)),
             )
-            .map_with(|(visibility, (name, ty)), e| Self {
+            .map_with(move |(visibility, (name, ty)), e| Self {
+                file_id: MAIN_MODULE,
                 visibility,
                 name: name.0,
                 ty,
@@ -2212,6 +2239,7 @@ impl crate::ArbitraryRec for Function {
     fn arbitrary_rec(u: &mut arbitrary::Unstructured, budget: usize) -> arbitrary::Result<Self> {
         use arbitrary::Arbitrary;
 
+        let file_id = u.int_in_range(0..=3)?;
         let visibility = Visibility::arbitrary(u)?;
         let name = FunctionName::arbitrary(u)?;
         let len = u.int_in_range(0..=3)?;
@@ -2221,6 +2249,7 @@ impl crate::ArbitraryRec for Function {
         let ret = Option::<AliasedType>::arbitrary(u)?;
         let body = Expression::arbitrary_rec(u, budget).map(Expression::into_block)?;
         Ok(Self {
+            file_id,
             visibility,
             name,
             params,

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -378,7 +378,7 @@ fn collect_product_elements(
 /// Resolves an aliased type to its concrete form.
 fn resolve_jet_type(aliased_type: &AliasedType) -> ResolvedType {
     aliased_type
-        .resolve(|_: &AliasName| None)
+        .resolve(|name: &AliasName| Err(name.clone()))
         .expect("jet types always resolve without aliases")
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -578,15 +578,15 @@ impl AliasedType {
     }
 
     /// Resolve all aliases in the type based on the given map of `aliases` to types.
-    pub fn resolve<F>(&self, mut get_alias: F) -> Result<ResolvedType, AliasName>
+    pub fn resolve<F, E>(&self, mut get_alias: F) -> Result<ResolvedType, E>
     where
-        F: FnMut(&AliasName) -> Option<ResolvedType>,
+        F: FnMut(&AliasName) -> Result<ResolvedType, E>,
     {
         let mut output = vec![];
         for data in self.post_order_iter() {
             match &data.node.0 {
                 AliasedInner::Alias(name) => {
-                    let resolved = get_alias(name).ok_or(name.clone())?;
+                    let resolved = get_alias(name)?;
                     output.push(resolved);
                 }
                 AliasedInner::Builtin(builtin) => {
@@ -628,7 +628,7 @@ impl AliasedType {
 
     /// Resolve all aliases in the type based on the builtin type aliases only.
     pub fn resolve_builtin(&self) -> Result<ResolvedType, AliasName> {
-        self.resolve(|_| None)
+        self.resolve(|name: &AliasName| Err(name.clone()))
     }
 }
 

--- a/src/witness.rs
+++ b/src/witness.rs
@@ -220,17 +220,26 @@ impl crate::ArbitraryOfType for Arguments {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::error::ErrorCollector;
     use crate::parse::ParseFromStr;
     use crate::value::ValueConstructible;
-    use crate::{ast, parse, CompiledProgram, SatisfiedProgram};
+    use crate::{ast, driver, parse, CompiledProgram, SatisfiedProgram};
 
     #[test]
     fn witness_reuse() {
         let s = r#"fn main() {
     assert!(jet::eq_32(witness::A, witness::A));
 }"#;
-        let program = parse::Program::parse_from_str(s).expect("parsing works");
-        match ast::Program::analyze(&program).map_err(Error::from) {
+        let parse_program = parse::Program::parse_from_str(s).expect("parsing works");
+
+        let mut error_collector = ErrorCollector::new();
+        let driver_program = driver::resolve_order::Program::from_parse(
+            &parse_program,
+            Arc::from(s),
+            &mut error_collector,
+        )
+        .expect("driver works");
+        match ast::Program::analyze(&driver_program).map_err(Error::from) {
             Ok(_) => panic!("Witness reuse was falsely accepted"),
             Err(Error::WitnessReused(..)) => {}
             Err(error) => panic!("Unexpected error: {error}"),


### PR DESCRIPTION
- Adapt the AST to enable driver functionality.
- Add architecture notes about using "main" as an alias.
- Add constants for the "main" function and the first module in the `DependencyGraph` to prevent the usage of magic numbers.

AST currently has some issues with processing source files properly, so they are not used and have been deleted along with the `ResolvedFile` structure.
I hope this will be fixed when the `ErrorCollector` is recoded to support multiple files better.