### PR TITLE
Connect the Driver to the main compilation pipeline

### DIFF
--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -29,3 +29,49 @@ In SimplicityHL, the string "main" is reserved exclusively for the program's ent
 While a `TypeAlias` is technically allowed to use this name, we explicitly forbid aliasing imports
 to "main" using the `as` keyword. This avoids complicating the compiler's resolution logic and
 prevents accidental shadowing of the entry point.
+
+## Dependency Managing
+
+Currently, the module system requires explicit dependency remapping for each library context.
+In the following example, we load the `math` library using two different Dependency Root Path (DRP) names.  
+To achieve this, we must configure the remappings for the root `multiple_deps/` directory to map `base_math` and merkle to their respective paths. Additionally, for the `multiple_deps/merkle` subdirectory, we must define its own specific mapping to the `math` library.
+
+Example:
+
+``` Rust
+// multiple_deps/math/simple_op.simf
+pub fn hash(x: u32, y: u32) -> u32 {
+    jet::xor_32(x, y)
+}
+
+// multiple_deps/merkle/build_root.simf
+use math::simple_op::hash as temp_hash;
+
+pub fn get_root(tx1: u32, tx2: u32) -> u32 {
+    temp_hash(tx1, tx2)
+}
+
+pub fn hash(tx1: u32, tx2: u32) -> u32 {
+    jet::and_32(tx1, tx2)
+}
+
+// multiple_deps/main.simf
+use merkle::build_root::{get_root, hash as and_hash};
+use base_math::simple_op::hash as or_hash;
+
+pub fn get_block_value_hash(prev_hash: u32, tx1: u32, tx2: u32) -> u32 {
+    let root: u32 = get_root(tx1, tx2);
+    or_hash(prev_hash, root)
+}
+
+fn main() {
+    let block_val_hash: u32 = get_block_value_hash(5, 10, 20);
+    assert!(jet::eq_32(block_val_hash, 27));
+    
+    let first_value: u32 = 15;
+    let second_value: u32 = 22;
+    assert!(jet::eq_32(and_hash(first_value, second_value), 6));
+}
+```
+
+> NOTE: For more details, see the `multiple_deps` test inside the `src/lib.rs` file.

--- a/examples/multiple_deps/main.simf
+++ b/examples/multiple_deps/main.simf
@@ -1,0 +1,16 @@
+use merkle::build_root::{get_root, hash as and_hash};
+use base_math::simple_op::hash as or_hash;
+
+pub fn get_block_value_hash(prev_hash: u32, tx1: u32, tx2: u32) -> u32 {
+    let root: u32 = get_root(tx1, tx2);
+    or_hash(prev_hash, root)
+}
+
+fn main() {
+    let block_val_hash: u32 = get_block_value_hash(5, 10, 20);
+    assert!(jet::eq_32(block_val_hash, 27));
+    
+    let first_value: u32 = 15;
+    let second_value: u32 = 22;
+    assert!(jet::eq_32(and_hash(first_value, second_value), 6));
+}

--- a/examples/multiple_deps/math/simple_op.simf
+++ b/examples/multiple_deps/math/simple_op.simf
@@ -1,0 +1,3 @@
+pub fn hash(x: u32, y: u32) -> u32 {
+    jet::xor_32(x, y)
+}

--- a/examples/multiple_deps/merkle/build_root.simf
+++ b/examples/multiple_deps/merkle/build_root.simf
@@ -1,0 +1,9 @@
+use math::simple_op::hash as temp_hash;
+
+pub fn get_root(tx1: u32, tx2: u32) -> u32 {
+    temp_hash(tx1, tx2)
+}
+
+pub fn hash(tx1: u32, tx2: u32) -> u32 {
+    jet::and_32(tx1, tx2)
+}

--- a/examples/simple_multidep/crypto/hashes.simf
+++ b/examples/simple_multidep/crypto/hashes.simf
@@ -1,0 +1,5 @@
+pub fn sha256(data: u32) -> u256 {
+    let ctx: Ctx8 = jet::sha_256_ctx_8_init();
+    let ctx: Ctx8 = jet::sha_256_ctx_8_add_4(ctx, data);
+    jet::sha_256_ctx_8_finalize(ctx)
+}

--- a/examples/simple_multidep/main.simf
+++ b/examples/simple_multidep/main.simf
@@ -1,0 +1,7 @@
+use math::arithmetic::add;
+use crypto::hashes::sha256;
+
+fn main() {
+    let sum: u32 = add(2, 3);
+    let hash: u256 = sha256(sum);
+}

--- a/examples/simple_multidep/math/arithmetic.simf
+++ b/examples/simple_multidep/math/arithmetic.simf
@@ -1,0 +1,4 @@
+pub fn add(a: u32, b: u32) -> u32 {
+    let (_, res): (bool, u32) = jet::add_32(a, b);
+    res
+}

--- a/examples/single_dep/main.simf
+++ b/examples/single_dep/main.simf
@@ -1,0 +1,11 @@
+pub use temp::constants::utils::two as smth;
+use temp::funcs::{get_five, Smth};
+
+fn seven() -> u32 {
+    7
+}
+
+fn main() {
+    let (_, temp): (bool, u32) = jet::add_32(smth(), get_five());
+    assert!(jet::eq_32(temp, seven()));
+}

--- a/examples/single_dep/temp/constants/utils.simf
+++ b/examples/single_dep/temp/constants/utils.simf
@@ -1,0 +1,5 @@
+pub use temp::funcs::Smth;
+
+pub fn two() -> Smth {
+    2
+}

--- a/examples/single_dep/temp/funcs.simf
+++ b/examples/single_dep/temp/funcs.simf
@@ -1,0 +1,5 @@
+pub type Smth = u32;
+
+pub fn get_five() -> u32 {
+    5
+}

--- a/functional-tests/error-test-cases/cyclic-dependency/lib/module_a.simf
+++ b/functional-tests/error-test-cases/cyclic-dependency/lib/module_a.simf
@@ -1,0 +1,2 @@
+pub use lib::module_b::TypeB;
+pub type TypeA = u32;

--- a/functional-tests/error-test-cases/cyclic-dependency/lib/module_b.simf
+++ b/functional-tests/error-test-cases/cyclic-dependency/lib/module_b.simf
@@ -1,0 +1,2 @@
+pub use lib::module_a::TypeA;
+pub type TypeB = u32;

--- a/functional-tests/error-test-cases/cyclic-dependency/main.simf
+++ b/functional-tests/error-test-cases/cyclic-dependency/main.simf
@@ -1,0 +1,3 @@
+use lib::module_a::TypeA; 
+
+fn main() {}

--- a/functional-tests/error-test-cases/file-not-found/main.simf
+++ b/functional-tests/error-test-cases/file-not-found/main.simf
@@ -1,0 +1,5 @@
+use lib::module::AssetId;
+
+fn main() {
+    let my_asset: AssetId = 5; 
+}

--- a/functional-tests/error-test-cases/lib-not-found/main.simf
+++ b/functional-tests/error-test-cases/lib-not-found/main.simf
@@ -1,0 +1,5 @@
+use lib::module::AssetId;
+
+fn main() {
+    let my_asset: AssetId = 5; 
+}

--- a/functional-tests/error-test-cases/name-collision/lib/groups.simf
+++ b/functional-tests/error-test-cases/name-collision/lib/groups.simf
@@ -1,0 +1,3 @@
+pub fn add(a: u32, b: u32) -> (bool, u32) {
+    jet::add_32(a, b)
+}

--- a/functional-tests/error-test-cases/name-collision/lib/math.simf
+++ b/functional-tests/error-test-cases/name-collision/lib/math.simf
@@ -1,0 +1,4 @@
+pub fn add(a: u32, b: u32) -> (bool, u32) {
+    let (_, c): (bool, u32) = jet::add_32(a, b);
+    jet::add_32(c, 1)
+}

--- a/functional-tests/error-test-cases/name-collision/main.simf
+++ b/functional-tests/error-test-cases/name-collision/main.simf
@@ -1,0 +1,9 @@
+use lib::groups::add;
+use lib::math::add;
+
+fn main() {
+    let x: u32 = 5;
+    let y: u32 = 10;
+    let (_, result): (bool, u32) = add(x, y);
+    assert!(jet::eq_32(result, 16));
+}

--- a/functional-tests/error-test-cases/private-visibility/lib/hidden.simf
+++ b/functional-tests/error-test-cases/private-visibility/lib/hidden.simf
@@ -1,0 +1,1 @@
+type SecretType = u32; pub fn ok() {}

--- a/functional-tests/error-test-cases/private-visibility/main.simf
+++ b/functional-tests/error-test-cases/private-visibility/main.simf
@@ -1,0 +1,3 @@
+use lib::hidden::SecretType;
+
+fn main() {}

--- a/functional-tests/error-test-cases/type-alias-duplication/lib/duplication.simf
+++ b/functional-tests/error-test-cases/type-alias-duplication/lib/duplication.simf
@@ -1,0 +1,2 @@
+pub type A = u32;
+pub type A = u64;

--- a/functional-tests/error-test-cases/type-alias-duplication/main.simf
+++ b/functional-tests/error-test-cases/type-alias-duplication/main.simf
@@ -1,0 +1,7 @@
+use lib::duplication::A;
+
+fn main() {
+    let smth: u64 = 55;
+    let another: A = 55;
+    assert!(jet::eq_64(smth, another));
+}

--- a/functional-tests/valid-test-cases/deep-reexport-chain/lib/level1.simf
+++ b/functional-tests/valid-test-cases/deep-reexport-chain/lib/level1.simf
@@ -1,0 +1,2 @@
+pub use lib::level2::CoreSmth;
+pub use lib::level2::core_val;

--- a/functional-tests/valid-test-cases/deep-reexport-chain/lib/level2.simf
+++ b/functional-tests/valid-test-cases/deep-reexport-chain/lib/level2.simf
@@ -1,0 +1,2 @@
+pub use lib::level3::CoreSmth;
+pub use lib::level3::core_val;

--- a/functional-tests/valid-test-cases/deep-reexport-chain/lib/level3.simf
+++ b/functional-tests/valid-test-cases/deep-reexport-chain/lib/level3.simf
@@ -1,0 +1,2 @@
+pub type CoreSmth = u32;
+pub fn core_val() -> CoreSmth { 42 }

--- a/functional-tests/valid-test-cases/deep-reexport-chain/main.simf
+++ b/functional-tests/valid-test-cases/deep-reexport-chain/main.simf
@@ -1,0 +1,7 @@
+use lib::level1::CoreSmth;
+use lib::level1::core_val;
+
+fn main() {
+    let val: CoreSmth = core_val();
+    assert!(jet::eq_32(val, 42));
+}

--- a/functional-tests/valid-test-cases/diamond-dependency-resolution/lib/base.simf
+++ b/functional-tests/valid-test-cases/diamond-dependency-resolution/lib/base.simf
@@ -1,0 +1,1 @@
+pub type BaseType = u32;

--- a/functional-tests/valid-test-cases/diamond-dependency-resolution/lib/left.simf
+++ b/functional-tests/valid-test-cases/diamond-dependency-resolution/lib/left.simf
@@ -1,0 +1,2 @@
+pub use lib::base::BaseType;
+pub fn get_left() -> BaseType { 1 }

--- a/functional-tests/valid-test-cases/diamond-dependency-resolution/lib/right.simf
+++ b/functional-tests/valid-test-cases/diamond-dependency-resolution/lib/right.simf
@@ -1,0 +1,2 @@
+pub use lib::base::BaseType;
+pub fn get_right() -> BaseType { 2 }

--- a/functional-tests/valid-test-cases/diamond-dependency-resolution/main.simf
+++ b/functional-tests/valid-test-cases/diamond-dependency-resolution/main.simf
@@ -1,0 +1,10 @@
+use lib::left::get_left;
+use lib::right::get_right;
+use lib::base::BaseType;
+
+fn main() {
+    let a: BaseType = get_left();
+    let b: BaseType = get_right();
+    let (_, c): (bool, BaseType) = jet::add_32(a, b);
+    assert!(jet::eq_32(c, 3));
+}

--- a/functional-tests/valid-test-cases/interleaved-waterfall/auth/verify.simf
+++ b/functional-tests/valid-test-cases/interleaved-waterfall/auth/verify.simf
@@ -1,0 +1,6 @@
+use types::def::UserId;
+use db::store::get_record;
+
+pub fn is_valid(id: UserId) -> UserId { 
+    get_record(id)
+}

--- a/functional-tests/valid-test-cases/interleaved-waterfall/db/store.simf
+++ b/functional-tests/valid-test-cases/interleaved-waterfall/db/store.simf
@@ -1,0 +1,2 @@
+use types::def::UserId;
+pub fn get_record(id: UserId) -> UserId { id }

--- a/functional-tests/valid-test-cases/interleaved-waterfall/main.simf
+++ b/functional-tests/valid-test-cases/interleaved-waterfall/main.simf
@@ -1,0 +1,5 @@
+use orch::handler::run_system;
+
+fn main() {
+    assert!(jet::eq_32(run_system(5), 5));
+}

--- a/functional-tests/valid-test-cases/interleaved-waterfall/orch/handler.simf
+++ b/functional-tests/valid-test-cases/interleaved-waterfall/orch/handler.simf
@@ -1,0 +1,8 @@
+use auth::verify::is_valid;
+use db::store::get_record;
+use types::def::UserId;
+
+pub fn run_system(id: UserId) -> UserId {
+    let checked: UserId = is_valid(id);
+    get_record(checked)
+}

--- a/functional-tests/valid-test-cases/interleaved-waterfall/types/def.simf
+++ b/functional-tests/valid-test-cases/interleaved-waterfall/types/def.simf
@@ -1,0 +1,1 @@
+pub type UserId = u32;

--- a/functional-tests/valid-test-cases/leaky-signature/lib/internal.simf
+++ b/functional-tests/valid-test-cases/leaky-signature/lib/internal.simf
@@ -1,0 +1,5 @@
+type SecretKey = u64;
+
+pub fn unlock(key: SecretKey) -> u64 {
+    jet::max_64(key, 0)
+}

--- a/functional-tests/valid-test-cases/leaky-signature/main.simf
+++ b/functional-tests/valid-test-cases/leaky-signature/main.simf
@@ -1,0 +1,4 @@
+use lib::internal::unlock;
+
+fn main() {
+}

--- a/functional-tests/valid-test-cases/module-simple/lib/module.simf
+++ b/functional-tests/valid-test-cases/module-simple/lib/module.simf
@@ -1,0 +1,1 @@
+pub fn add() {}

--- a/functional-tests/valid-test-cases/module-simple/main.simf
+++ b/functional-tests/valid-test-cases/module-simple/main.simf
@@ -1,0 +1,2 @@
+use lib::module::add;
+fn main() {}

--- a/functional-tests/valid-test-cases/multi-lib-facade/api/api.simf
+++ b/functional-tests/valid-test-cases/multi-lib-facade/api/api.simf
@@ -1,0 +1,3 @@
+pub use crypto::crypto::mock_hash;
+pub use math::math::MathInt;
+pub use math::math::add_two;

--- a/functional-tests/valid-test-cases/multi-lib-facade/crypto/crypto.simf
+++ b/functional-tests/valid-test-cases/multi-lib-facade/crypto/crypto.simf
@@ -1,0 +1,5 @@
+use math::math::MathInt;
+
+pub fn mock_hash(x: MathInt) -> (bool, MathInt) {
+    jet::add_32(x, 5)
+}

--- a/functional-tests/valid-test-cases/multi-lib-facade/main.simf
+++ b/functional-tests/valid-test-cases/multi-lib-facade/main.simf
@@ -1,0 +1,8 @@
+use api::api::{add_two, mock_hash, MathInt};
+
+fn main() {
+    let val: MathInt = 10;
+    let (_, step1): (bool, MathInt) = add_two(val);
+    let (_, step2): (bool, MathInt) = mock_hash(step1);
+    assert!(jet::eq_32(step2, 17));
+}

--- a/functional-tests/valid-test-cases/multi-lib-facade/math/math.simf
+++ b/functional-tests/valid-test-cases/multi-lib-facade/math/math.simf
@@ -1,0 +1,4 @@
+pub type MathInt = u32;
+pub fn add_two(x: MathInt) -> (bool, MathInt) { 
+    jet::add_32(x, 2) 
+}

--- a/functional-tests/valid-test-cases/reexport-diamond/lib/core.simf
+++ b/functional-tests/valid-test-cases/reexport-diamond/lib/core.simf
@@ -1,0 +1,2 @@
+pub type Coin = u64;
+pub fn mint(val: u64) -> Coin { val }

--- a/functional-tests/valid-test-cases/reexport-diamond/lib/route_a.simf
+++ b/functional-tests/valid-test-cases/reexport-diamond/lib/route_a.simf
@@ -1,0 +1,2 @@
+pub use lib::core::Coin;
+pub use lib::core::mint;

--- a/functional-tests/valid-test-cases/reexport-diamond/lib/route_b.simf
+++ b/functional-tests/valid-test-cases/reexport-diamond/lib/route_b.simf
@@ -1,0 +1,5 @@
+pub use lib::core::Coin;
+
+pub fn burn(c: Coin) -> (bool, Coin) {
+    jet::subtract_64(c, 1)
+}

--- a/functional-tests/valid-test-cases/reexport-diamond/main.simf
+++ b/functional-tests/valid-test-cases/reexport-diamond/main.simf
@@ -1,0 +1,9 @@
+use lib::route_a::Coin;
+use lib::route_a::mint;
+use lib::route_b::burn;
+
+fn main() {
+    let my_coin: Coin = mint(10);
+    let (_, remaining): (bool, Coin) = burn(my_coin);
+    assert!(jet::eq_64(remaining, 9));
+}

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1573,6 +1573,9 @@ fn analyze_named_module(
     from: &parse::ModuleProgram,
 ) -> Result<HashMap<WitnessName, Value>, RichError> {
     let unit = ResolvedType::unit();
+
+    // IMPORTANT! If modules allow imports, then we need to consider
+    // passing the resolution conetxt by calling `Scope::new(resolutions)`
     let mut scope = Scope::default();
     let items = from
         .items()

--- a/src/driver/linearization.rs
+++ b/src/driver/linearization.rs
@@ -14,7 +14,7 @@ use crate::driver::DependencyGraph;
 /// This is a core component of the [`DependencyGraph`].
 impl DependencyGraph {
     /// Returns the deterministic, BOTTOM-UP load order of dependencies.
-    pub(crate) fn linearize(&self) -> Result<Vec<usize>, LinearizationError> {
+    pub(super) fn linearize(&self) -> Result<Vec<usize>, LinearizationError> {
         let mut visited = HashSet::new();
         let mut visiting = Vec::new();
         let mut order = Vec::new();

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -43,10 +43,10 @@ use crate::resolution::{CanonPath, DependencyMap, SourceFile};
 pub use crate::driver::resolve_order::{FileScoped, Program, SymbolTable};
 
 /// The reserved identifier for the program's entry point.
-pub const MAIN_STR: &str = "main";
+pub(crate) const MAIN_STR: &str = "main";
 
 /// The root node index in the [`DependencyGraph`] representing the entry file.
-pub const MAIN_MODULE: usize = 0;
+pub(crate) const MAIN_MODULE: usize = 0;
 
 /// Caches the canonicalized path of a source file to prevent redundant,
 /// expensive, and potentially failing filesystem operations.
@@ -120,7 +120,7 @@ struct Module {
 ///   `A` if `A` depends on `B`).
 /// * **Cycle Detection:** Preventing infinite compiler loops by ensuring no circular
 ///   imports exist before heavy semantic processing begins.
-pub struct DependencyGraph {
+pub(crate) struct DependencyGraph {
     /// Implements the Arena Pattern to act as the sole, centralized owner of all parsed modules.
     ///
     /// In C++ or Java, a graph would typically link dependencies using direct memory

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,9 +36,10 @@ pub extern crate simplicity;
 pub use simplicity::elements;
 
 use crate::debug::DebugSymbols;
-use crate::error::{ErrorCollector, WithContent};
+use crate::driver::DependencyGraph;
+use crate::error::{ErrorCollector, WithContent, WithSource as _};
 use crate::parse::ParseFromStrWithErrors;
-use crate::resolution::SourceFile;
+use crate::resolution::{DependencyMap, SourceFile};
 pub use crate::types::ResolvedType;
 pub use crate::value::Value;
 pub use crate::witness::{Arguments, Parameters, WitnessTypes, WitnessValues};
@@ -53,6 +54,49 @@ pub struct TemplateProgram {
 }
 
 impl TemplateProgram {
+    // TODO: Consider passing `CanonSourceFile`` deeper into the driver to avoid paying the path canonicalization cost multiple times.
+    /// Parse the template of a SimplicityHL program.
+    ///
+    /// ## Errors
+    ///
+    /// The string is not a valid SimplicityHL program.
+    pub fn new_with_dep(
+        source: SourceFile,
+        dependency_map: &DependencyMap,
+    ) -> Result<Self, String> {
+        let mut error_handler = ErrorCollector::new();
+
+        // 1. Parse root file
+        let parsed_program =
+            parse::Program::parse_from_str_with_errors(source.clone(), &mut error_handler)
+                .ok_or_else(|| error_handler.to_string())?;
+
+        // 2. Create the driver program
+        let driver_program: driver::Program = if dependency_map.is_empty() {
+            driver::Program::from_parse(&parsed_program, source.content(), &mut error_handler)
+                .ok_or_else(|| error_handler.to_string())?
+        } else {
+            let graph = DependencyGraph::new(
+                source.clone(),
+                Arc::from(dependency_map.clone()),
+                &parsed_program,
+                &mut error_handler,
+            )?
+            .ok_or_else(|| error_handler.to_string())?;
+
+            graph
+                .linearize_and_build(&mut error_handler)?
+                .ok_or_else(|| error_handler.to_string())?
+        };
+
+        // 3. AST Analysis
+        let ast_program = ast::Program::analyze(&driver_program).with_source(source.clone())?;
+        Ok(Self {
+            simfony: ast_program,
+            file: source.content(),
+        })
+    }
+
     /// Parse the template of a SimplicityHL program.
     ///
     /// ## Errors
@@ -137,6 +181,22 @@ pub struct CompiledProgram {
 }
 
 impl CompiledProgram {
+    /// Parse and compile a SimplicityHL program from the given
+    ///
+    /// ## See
+    ///
+    /// - [`TemplateProgram::new_with_dep`]
+    /// - [`TemplateProgram::instantiate`]
+    pub fn new_with_dep(
+        source: SourceFile,
+        dependency_map: &DependencyMap,
+        arguments: Arguments,
+        include_debug_symbols: bool,
+    ) -> Result<Self, String> {
+        TemplateProgram::new_with_dep(source, dependency_map)
+            .and_then(|template| template.instantiate(arguments, include_debug_symbols))
+    }
+
     /// Parse and compile a SimplicityHL program from the given string.
     ///
     /// ## See
@@ -339,11 +399,12 @@ pub trait ArbitraryOfType: Sized {
 #[cfg(test)]
 pub(crate) mod tests {
     use crate::parse::ParseFromStr;
+    use crate::resolution::CanonPath;
     use base64::display::Base64Display;
     use base64::engine::general_purpose::STANDARD;
     use simplicity::BitMachine;
     use std::borrow::Cow;
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
 
     use crate::*;
 
@@ -358,6 +419,23 @@ pub(crate) mod tests {
         pub fn template_file<P: AsRef<Path>>(program_file_path: P) -> Self {
             let program_text = std::fs::read_to_string(program_file_path).unwrap();
             Self::template_text(Cow::Owned(program_text))
+        }
+
+        pub fn template_deps(prog_path: &Path, dependency_map: &DependencyMap) -> Self {
+            let program_text = std::fs::read_to_string(prog_path).unwrap();
+            let source = SourceFile::new(prog_path, Arc::from(program_text));
+
+            let program = match TemplateProgram::new_with_dep(source, dependency_map) {
+                Ok(x) => x,
+                Err(error) => panic!("{error}"),
+            };
+
+            Self {
+                program,
+                lock_time: elements::LockTime::ZERO,
+                sequence: elements::Sequence::MAX,
+                include_fee_output: false,
+            }
         }
 
         pub fn template_text(program_text: Cow<str>) -> Self {
@@ -408,6 +486,26 @@ pub(crate) mod tests {
 
         pub fn program_text(program_text: Cow<str>) -> Self {
             TestCase::<TemplateProgram>::template_text(program_text)
+                .with_arguments(Arguments::default())
+        }
+
+        pub fn program_file_with_deps<P, I, K>(prog_path: P, dependencies: I) -> Self
+        where
+            P: AsRef<Path>,
+            I: IntoIterator<Item = (P, K, P)>,
+            K: Into<String>,
+        {
+            let mut dependency_map = DependencyMap::new();
+            for (context, alias, target) in dependencies {
+                let context = CanonPath::canonicalize(context.as_ref()).unwrap();
+                let target = CanonPath::canonicalize(target.as_ref()).unwrap();
+
+                dependency_map
+                    .insert(context, alias.into(), target)
+                    .unwrap();
+            }
+
+            TestCase::<TemplateProgram>::template_deps(prog_path.as_ref(), &dependency_map)
                 .with_arguments(Arguments::default())
         }
 
@@ -508,6 +606,101 @@ pub(crate) mod tests {
                 Base64Display::new(&witness_bytes, &STANDARD).to_string(),
             )
         }
+    }
+
+    /// THE DEFAULT HELPER
+    /// Automatically sets up the standard `lib` self-referencing dependency.
+    fn run_dependency_test(root_path: &str, lib_alias: &str) {
+        let root_path = PathBuf::from(root_path);
+        let lib_path = root_path.join(lib_alias);
+        let main_path = root_path.join("main.simf");
+
+        TestCase::program_file_with_deps(
+            &main_path,
+            [
+                (&root_path, lib_alias, &lib_path),
+                (&lib_path, lib_alias, &lib_path),
+            ],
+        )
+        .with_witness_values(WitnessValues::default())
+        .assert_run_success();
+    }
+
+    /// THE ADVANCED HELPER
+    /// A helper function to run standard library dependency tests.
+    /// `deps` expects an array of tuples: `(context_folder, alias, target_folder)`.
+    /// Use `"."` for the `context_folder` if the context is the root test directory.
+    fn run_multidep_test(root_path: &str, deps: &[(&str, &str, &str)]) {
+        let root_path = PathBuf::from(root_path);
+        let main_path = root_path.join("main.simf");
+
+        // Convert the string slices into proper PathBufs dynamically
+        let mapped_deps: Vec<(PathBuf, &str, PathBuf)> = deps
+            .iter()
+            .map(|(ctx, alias, target)| {
+                let ctx_path = if *ctx == "." {
+                    root_path.clone()
+                } else {
+                    root_path.join(ctx)
+                };
+
+                let target_path = root_path.join(target);
+
+                (ctx_path, *alias, target_path)
+            })
+            .collect();
+
+        let ref_deps = mapped_deps.iter().map(|(c, a, t)| (c, *a, t));
+
+        TestCase::program_file_with_deps(&main_path, ref_deps)
+            .with_witness_values(WitnessValues::default())
+            .assert_run_success();
+    }
+
+    /// Run with `simc` command:
+    ///
+    /// ```
+    /// simc examples/single_dep/main.simf \
+    ///   --dep examples/single_dep/:temp=examples/single_dep/temp/
+    /// ```
+    #[test]
+    fn single_dep() {
+        run_dependency_test("./examples/single_dep", "temp");
+    }
+
+    /// Run with `simc` command:
+    ///
+    /// ```
+    /// simc examples/simple_multidep/main.simf \
+    ///   --dep examples/simple_multidep/:math=examples/simple_multidep/math/ \
+    ///   --dep examples/simple_multidep/:crypto=examples/simple_multidep/crypto/
+    /// ```
+    #[test]
+    fn simple_multidep() {
+        run_multidep_test(
+            "./examples/simple_multidep",
+            &[(".", "math", "math"), (".", "crypto", "crypto")],
+        );
+    }
+
+    /// Run with `simc` command:
+    ///
+    /// ```
+    /// simc examples/multiple_deps/main.simf \
+    ///   --dep examples/multiple_deps/:merkle=examples/multiple_deps/merkle/ \
+    ///   --dep examples/multiple_deps/:base_math=examples/multiple_deps/math/ \
+    ///   --dep examples/multiple_deps/merkle/:math=examples/multiple_deps/math/
+    /// ```
+    #[test]
+    fn multiple_deps() {
+        run_multidep_test(
+            "./examples/multiple_deps",
+            &[
+                (".", "merkle", "merkle"),
+                (".", "base_math", "math"),
+                ("merkle", "math", "math"),
+            ],
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1103,6 +1103,99 @@ fn main() {
 }
 
 #[cfg(test)]
+mod error_tests {
+    use std::path::Path;
+
+    use super::*;
+
+    use crate::resolution::tests::canon;
+    use crate::resolution::CanonPath;
+    use crate::test_utils::TempWorkspace;
+
+    fn dependency_map(root_dir: &Path, drp: &str, lib_dir: &Path) -> DependencyMap {
+        let mut dependency_map = DependencyMap::new();
+
+        let context = CanonPath::canonicalize(root_dir).unwrap();
+        let target = CanonPath::canonicalize(lib_dir).unwrap();
+
+        dependency_map.insert(context, drp.into(), target).unwrap();
+
+        dependency_map
+    }
+
+    fn source_file(path: &Path) -> SourceFile {
+        let content = std::fs::read_to_string(path).expect("Failed to read test file");
+        SourceFile::new(path, Arc::from(content))
+    }
+
+    #[test]
+    #[ignore = "TODO: Bug in Error Handler. Expected to be fixed in a future update to correctly point to dependency source files."]
+    fn dependency_ast_errors_use_dependency_source_file() {
+        let ws = TempWorkspace::new("dependency_ast_error_source");
+        let root_dir = ws.create_dir("workspace");
+        let lib_dir = ws.create_dir("workspace/lib");
+        let main_path = ws.create_file(
+            "workspace/main.simf",
+            "use lib::bad::f;\nfn main() { f(); }\n",
+        );
+        let bad_path = ws.create_file(
+            "workspace/lib/bad.simf",
+            "pub fn f() { let x: u32 = true; }\n",
+        );
+
+        let dependencies = dependency_map(&root_dir, "lib", &lib_dir);
+
+        let err = TemplateProgram::new_with_dep(source_file(&main_path), &dependencies)
+            .expect_err("dependency body has a type error");
+        let dependency_source = canon(&bad_path).as_path().display().to_string();
+
+        assert!(
+            err.contains(&dependency_source),
+            "expected diagnostic to point at dependency source {dependency_source}, got:\n{err}"
+        );
+    }
+
+    #[test]
+    fn omitted_context_dependency_applies_inside_dependency_files() {
+        let ws = TempWorkspace::new("omitted_context_dependency");
+        let lib_dir = ws.create_dir("workspace/lib");
+        let main_path = ws.create_file(
+            "workspace/main.simf",
+            "use lib::nested::two;\nfn main() { assert!(jet::eq_32(two(), 2)); }\n",
+        );
+        ws.create_file(
+            "workspace/lib/nested.simf",
+            "use lib::base::one;\npub fn two() -> u32 {\n    let (_, out): (bool, u32) = jet::add_32(one(), 1);\n    out\n}\n",
+        );
+        ws.create_file("workspace/lib/base.simf", "pub fn one() -> u32 { 1 }\n");
+
+        let dependencies = dependency_map(&main_path, "lib", &lib_dir);
+        let _err = TemplateProgram::new_with_dep(source_file(&main_path), &dependencies)
+            .expect_err("omitted-context dependencies");
+    }
+
+    #[test]
+    fn missing_mapped_module_is_reported_as_file_not_found() {
+        let ws = TempWorkspace::new("missing_mapped_module");
+        let root_dir = ws.create_dir("workspace");
+        let lib_dir = ws.create_dir("workspace/lib");
+        let main_path = ws.create_file(
+            "workspace/main.simf",
+            "use lib::missing::Thing;\nfn main() {}\n",
+        );
+        let dependencies = dependency_map(&root_dir, "lib", &lib_dir);
+
+        let err = TemplateProgram::new_with_dep(source_file(&main_path), &dependencies)
+            .expect_err("missing imported module should fail");
+
+        assert!(
+            err.contains("missing.simf"),
+            "diagnostic should mention the missing module path, got:\n{err}"
+        );
+    }
+}
+
+#[cfg(test)]
 mod functional_tests {
     use crate::tests::{run_dependency_test, run_multidep_test};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -610,7 +610,7 @@ pub(crate) mod tests {
 
     /// THE DEFAULT HELPER
     /// Automatically sets up the standard `lib` self-referencing dependency.
-    fn run_dependency_test(root_path: &str, lib_alias: &str) {
+    pub(crate) fn run_dependency_test(root_path: &str, lib_alias: &str) {
         let root_path = PathBuf::from(root_path);
         let lib_path = root_path.join(lib_alias);
         let main_path = root_path.join("main.simf");
@@ -630,7 +630,7 @@ pub(crate) mod tests {
     /// A helper function to run standard library dependency tests.
     /// `deps` expects an array of tuples: `(context_folder, alias, target_folder)`.
     /// Use `"."` for the `context_folder` if the context is the root test directory.
-    fn run_multidep_test(root_path: &str, deps: &[(&str, &str, &str)]) {
+    pub(crate) fn run_multidep_test(root_path: &str, deps: &[(&str, &str, &str)]) {
         let root_path = PathBuf::from(root_path);
         let main_path = root_path.join("main.simf");
 
@@ -1099,5 +1099,133 @@ fn main() {
         fn transfer_with_timeout_regression() {
             regression_test("transfer_with_timeout");
         }
+    }
+}
+
+#[cfg(test)]
+mod functional_tests {
+    use crate::tests::{run_dependency_test, run_multidep_test};
+
+    const VALID_TESTS_DIR: &str = "./functional-tests/valid-test-cases";
+    const ERROR_TESTS_DIR: &str = "./functional-tests/error-test-cases";
+
+    // Real test cases
+    #[test]
+    fn module_simple() {
+        run_dependency_test(format!("{}/module-simple", VALID_TESTS_DIR).as_str(), "lib");
+    }
+
+    #[test]
+    fn diamond_dependency_resolution() {
+        run_dependency_test(
+            format!("{}/diamond-dependency-resolution", VALID_TESTS_DIR).as_str(),
+            "lib",
+        );
+    }
+
+    #[test]
+    fn deep_reexport_chain() {
+        run_dependency_test(
+            format!("{}/deep-reexport-chain", VALID_TESTS_DIR).as_str(),
+            "lib",
+        );
+    }
+
+    #[test]
+    fn leaky_signature() {
+        run_dependency_test(
+            format!("{}/leaky-signature", VALID_TESTS_DIR).as_str(),
+            "lib",
+        );
+    }
+
+    #[test]
+    fn reexport_diamond() {
+        run_dependency_test(
+            format!("{}/reexport-diamond", VALID_TESTS_DIR).as_str(),
+            "lib",
+        );
+    }
+
+    #[test]
+    fn multi_lib_facade_resolution() {
+        run_multidep_test(
+            format!("{}/multi-lib-facade", VALID_TESTS_DIR).as_str(),
+            &[
+                (".", "api", "api"),
+                ("crypto", "math", "math"),
+                ("api", "crypto", "crypto"),
+                ("api", "math", "math"),
+            ],
+        );
+    }
+
+    #[test]
+    fn interleaved_waterfall() {
+        run_multidep_test(
+            format!("{}/interleaved-waterfall", VALID_TESTS_DIR).as_str(),
+            &[
+                (".", "orch", "orch"),
+                ("orch", "db", "db"),
+                ("orch", "auth", "auth"),
+                ("orch", "types", "types"),
+                ("db", "types", "types"),
+                ("auth", "types", "types"),
+                ("auth", "db", "db"),
+            ],
+        );
+    }
+
+    // Error tests
+    #[test]
+    #[should_panic(expected = "Circular dependency detected:")]
+    fn cyclic_dependency_error() {
+        run_dependency_test(
+            format!("{}/cyclic-dependency", ERROR_TESTS_DIR).as_str(),
+            "lib",
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "No such file or directory")]
+    fn file_not_found_error() {
+        run_dependency_test(
+            format!("{}/file-not-found", ERROR_TESTS_DIR).as_str(),
+            "lib",
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "No such file or directory")]
+    fn lib_not_found_error() {
+        run_dependency_test(format!("{}/lib-not-found", ERROR_TESTS_DIR).as_str(), "lib");
+    }
+
+    #[test]
+    #[should_panic(expected = "Item `SecretType` is private")]
+    fn private_type_visibility_error() {
+        run_dependency_test(
+            format!("{}/private-visibility", ERROR_TESTS_DIR).as_str(),
+            "lib",
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "The alias `add` was defined multiple times")]
+    fn name_collision_error() {
+        run_dependency_test(
+            format!("{}/name-collision", ERROR_TESTS_DIR).as_str(),
+            "lib",
+        );
+    }
+
+    // Reference to the following bug: https://github.com/BlockstreamResearch/SimplicityHL/issues/220
+    #[test]
+    #[should_panic(expected = "Type alias `A` was defined multiple times")]
+    fn type_alias_duplication_error() {
+        run_dependency_test(
+            format!("{}/type-alias-duplication", ERROR_TESTS_DIR).as_str(),
+            "lib",
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,11 @@ use base64::display::Base64Display;
 use base64::engine::general_purpose::STANDARD;
 use clap::{Arg, ArgAction, Command};
 
-use simplicityhl::{AbiMeta, CompiledProgram};
+use simplicityhl::{
+    resolution::{CanonPath, DependencyMap, SourceFile},
+    AbiMeta, CompiledProgram,
+};
+use std::path::Path;
 use std::{env, fmt};
 
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
@@ -50,6 +54,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     .help("SimplicityHL program file to build"),
             )
             .arg(
+                Arg::new("dependencies")
+                    .long("dep")
+                    .value_name("[CONTEXT:]ALIAS=PATH")
+                    .action(ArgAction::Append)
+                    .help("Link a dependency, optionally scoped to a specific module (e.g., --dep ./libs/merkle:math=./libs/math)"),
+            )
+            .arg(
                 Arg::new("wit_file")
                     .long("wit")
                     .short('w')
@@ -88,8 +99,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let matches = command.get_matches();
 
     let prog_file = matches.get_one::<String>("prog_file").unwrap();
-    let prog_path = std::path::Path::new(prog_file);
-    let prog_text = std::fs::read_to_string(prog_path).map_err(|e| e.to_string())?;
+    let main_path = CanonPath::canonicalize(Path::new(prog_file))?;
+    let main_text = std::fs::read_to_string(main_path.as_path()).map_err(|e| e.to_string())?;
     let include_debug_symbols = matches.get_flag("debug");
     let output_json = matches.get_flag("json");
     let abi_param = matches.get_flag("abi");
@@ -98,7 +109,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args_opt: simplicityhl::Arguments = match matches.get_one::<String>("args_file") {
         None => simplicityhl::Arguments::default(),
         Some(args_file) => {
-            let args_path = std::path::Path::new(&args_file);
+            let args_path = Path::new(&args_file);
             let args_text = std::fs::read_to_string(args_path).map_err(|e| e.to_string())?;
             serde_json::from_str::<simplicityhl::Arguments>(&args_text)?
         }
@@ -113,19 +124,56 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         simplicityhl::Arguments::default()
     };
 
-    let compiled = match CompiledProgram::new(prog_text, args_opt, include_debug_symbols) {
-        Ok(program) => program,
-        Err(e) => {
-            eprintln!("{}", e);
+    let dep_args = matches
+        .get_many::<String>("dependencies")
+        .unwrap_or_default();
+
+    let mut dependencies = DependencyMap::new();
+
+    for arg in dep_args {
+        let (left_side, path_str) = arg.split_once('=').unwrap_or_else(|| {
+            eprintln!(
+                "Error: Library argument must be in format [CONTEXT:]ALIAS=PATH, got '{arg}'"
+            );
+            std::process::exit(1);
+        });
+
+        let (context_path, alias) = if let Some((ctx_str, alias_str)) = left_side.split_once(':') {
+            // Specific context provided (e.g., merkle:base_math=...)
+            // We convert it to PathBuf so it shares the same type as main_path
+            let canon_path = CanonPath::canonicalize(Path::new(ctx_str))?;
+            (canon_path, alias_str)
+        } else {
+            // No context provided (e.g., math=...). Bind it to the main file!
+            (main_path.clone(), left_side)
+        };
+
+        let target_path = CanonPath::canonicalize(Path::new(path_str))?;
+
+        // Insert and handle the potential io::Error!
+        // We convert path_str to PathBuf so it maches the tyep of context_path
+        if let Err(e) = dependencies.insert(context_path, alias.to_string(), target_path) {
+            eprintln!("Error: {e}");
             std::process::exit(1);
         }
-    };
+    }
+
+    let source = SourceFile::new(main_path.as_path(), std::sync::Arc::from(main_text));
+    let compiled =
+        match CompiledProgram::new_with_dep(source, &dependencies, args_opt, include_debug_symbols)
+        {
+            Ok(program) => program,
+            Err(e) => {
+                eprintln!("{}", e);
+                std::process::exit(1);
+            }
+        };
 
     #[cfg(feature = "serde")]
     let witness_opt = matches
         .get_one::<String>("wit_file")
         .map(|wit_file| -> Result<simplicityhl::WitnessValues, String> {
-            let wit_path = std::path::Path::new(wit_file);
+            let wit_path = Path::new(wit_file);
             let wit_text = std::fs::read_to_string(wit_path).map_err(|e| e.to_string())?;
             let witness = serde_json::from_str::<simplicityhl::WitnessValues>(&wit_text).unwrap();
             Ok(witness)

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -121,7 +121,7 @@ pub struct Remapping {
 /// Mappings are strictly sorted by the longest `context_prefix` match.
 /// This mathematical guarantee ensures that if multiple nested directories
 /// define the same dependency root path, the most specific (deepest) context wins.
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct DependencyMap {
     inner: Vec<Remapping>,
 }

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -192,16 +192,32 @@ impl DependencyMap {
 
             // Check if the alias matches what the user typed
             if remapping.drp_name == drp_name {
-                return remapping.target.join(&parts[1..]).map_err(|err| {
-                    RichError::new(
-                        Error::Internal(format!("Dependency resolution failed: {}", err)),
-                        *use_decl.span(),
-                    )
-                });
+                return Self::build_and_verify_path(&remapping.target, &parts[1..]).map_err(
+                    |failed_path| {
+                        RichError::new(Error::FileNotFound(failed_path), *use_decl.span())
+                    },
+                );
             }
         }
 
         Err(Error::UnknownLibrary(drp_name.to_string())).with_span(*use_decl.span())
+    }
+
+    /// Replace `.join` method to better error handling
+    fn build_and_verify_path(
+        base_target: &CanonPath,
+        module_parts: &[impl ToString],
+    ) -> Result<CanonPath, std::path::PathBuf> {
+        let mut theoretical_path = base_target.as_path().to_path_buf();
+        for part in module_parts {
+            theoretical_path.push(part.to_string());
+        }
+        theoretical_path.set_extension("simf");
+
+        match CanonPath::canonicalize(&theoretical_path) {
+            Ok(valid_canon_path) => Ok(valid_canon_path),
+            Err(_) => Err(theoretical_path),
+        }
     }
 }
 


### PR DESCRIPTION
This PR introduces the `--dep` flag to the compiler, enabling proper dependency resolution.

Added:
- three new examples: `single_dep`, `simple_multidep`, `multiple_deps`
- functional tests
- error tests