### PR TITLE
Fix fuzz arbitrary

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -81,7 +81,6 @@ pub enum Visibility {
 /// pub use std::collections::{HashMap, HashSet};
 /// ```
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct UseDecl {
     /// The visibility of the import (e.g., `pub use` vs `use`).
     visibility: Visibility,
@@ -138,6 +137,25 @@ impl UseDecl {
 }
 
 impl_eq_hash!(UseDecl; visibility, path, drp_name, items);
+
+#[cfg(feature = "arbitrary")]
+impl<'a> arbitrary::Arbitrary<'a> for UseDecl {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let visibility = Visibility::arbitrary(u)?;
+        let path_len = u.int_in_range(2..=4)?;
+        let path = (0..path_len)
+            .map(|_| Identifier::arbitrary(u))
+            .collect::<arbitrary::Result<_>>()?;
+        let items = UseItems::arbitrary(u)?;
+
+        Ok(Self {
+            visibility,
+            path,
+            items,
+            span: Span::DUMMY,
+        })
+    }
+}
 
 /// Aliases the specific identifier of an imported type to a new, local identifier
 pub type AliasedSymbolName = (SymbolName, Option<SymbolName>);

--- a/src/types.rs
+++ b/src/types.rs
@@ -487,7 +487,8 @@ impl crate::ArbitraryRec for ResolvedType {
                 }
                 6 => {
                     let element = Self::arbitrary_rec(u, new_budget)?;
-                    let bound = NonZeroPow2Usize::arbitrary(u)?;
+                    let exp = u.int_in_range(1u32..=4)?;
+                    let bound = NonZeroPow2Usize::new_unchecked(2usize.saturating_pow(exp));
                     Ok(Self::list(element, bound))
                 }
                 _ => unreachable!(),


### PR DESCRIPTION
Following the motivation of https://github.com/BlockstreamResearch/SimplicityHL/pull/298

https://github.com/BlockstreamResearch/SimplicityHL/commit/31e97f66061a3451efb59b1d864427edbbdf083f -> `UseDecl` previously derived `Arbitrary`, so fuzzing could construct `UseDecl` values that the parser can never produce, especially import paths with too few segments. The parser requires a valid `use` path shape, but the arbitrary generator ignored that invariant. This made `display_parse_tree` fail on impossible AST values instead of testing real parser/display behavior.

Command that I ran on master:
`cargo +nightly fuzz run display_parse_tree -- -max_total_time=30 -max_len=50 -verbosity=0`


<details>
  <summary>Output for 31e97f66061a3451efb59b1d864427edbbdf083f</summary>

```
   Compiling simplicityhl v0.5.0 (/Volumes/Somebody/Desktop/Simp/simplicityhl)
   Compiling simplicityhl-fuzz v0.0.0 (/Volumes/Somebody/Desktop/Simp/simplicityhl/fuzz)
    Finished `release` profile [optimized + debuginfo] target(s) in 1m 30s
    Finished `release` profile [optimized + debuginfo] target(s) in 0.11s
     Running `target/aarch64-apple-darwin/release/display_parse_tree -artifact_prefix=/Volumes/Somebody/Desktop/Simp/simplicityhl/fuzz/artifacts/display_parse_tree/ -max_total_time=30 -max_len=50 -verbosity=0 /Volumes/Somebody/Desktop/Simp/simplicityhl/fuzz/corpus/display_parse_tree`
INFO: Running with entropic power schedule (0xFF, 100).
INFO:     1592 files found in /Volumes/Somebody/Desktop/Simp/simplicityhl/fuzz/corpus/display_parse_tree
INFO: seed corpus: files: 1592 min: 1b max: 50b total: 56406b rss: 49Mb

thread '<unnamed>' (1616923) panicked at fuzz/fuzz_targets/display_parse_tree.rs:9:10:
Output of fmt::Display should be parseable: RichError { error: Syntax { expected: ["something else"], label: Some("identifier"), found: Some("{") }, span: Span { start: 7, end: 8 }, source: None }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
==17028== ERROR: libFuzzer: deadly signal
    #0 0x0001077bb2f4 in __sanitizer_print_stack_trace+0x28 (librustc-nightly_rt.asan.dylib:arm64+0x872f4)
    #1 0x000104ae5050 in fuzzer::PrintStackTrace()+0x30 (display_parse_tree:arm64+0x1001b9050)
    #2 0x000104ad9250 in fuzzer::Fuzzer::CrashCallback()+0x54 (display_parse_tree:arm64+0x1001ad250)
    #3 0x00018960d760 in _sigtramp+0x34 (libsystem_platform.dylib:arm64e+0x3760)
    #4 0x000189603884 in pthread_kill+0x124 (libsystem_pthread.dylib:arm64e+0x6884)
    #5 0x00018950884c in abort+0x78 (libsystem_c.dylib:arm64e+0x7984c)
    #6 0x000105ca9118 in _RNvNtNtNtCsgX2aokyoR4d_3std3sys3pal4unix14abort_internal+0x8 (display_parse_tree:arm64+0x10137d118)
    #7 0x000105ca8eb8 in _RNvNtCsgX2aokyoR4d_3std7process5abort+0x8 (display_parse_tree:arm64+0x10137ceb8)
    #8 0x000105c5b480 in _RNCNvCsgemHMRU4na9_13libfuzzer_sys10initialize0B3_+0xb8 (display_parse_tree:arm64+0x10132f480)
    #9 0x000105c3de6c in _RNvNtCsgX2aokyoR4d_3std9panicking15panic_with_hook+0x264 (display_parse_tree:arm64+0x101311e6c)
    #10 0x000105c31488 in _RNCNvNtCsgX2aokyoR4d_3std9panicking13panic_handler0B5_+0x40 (display_parse_tree:arm64+0x101305488)
    #11 0x000105c28fa8 in _RINvNtNtCsgX2aokyoR4d_3std3sys9backtrace26___rust_end_short_backtraceNCNvNtB6_9panicking13panic_handler0zEB6_+0x8 (display_parse_tree:arm64+0x1012fcfa8)
    #12 0x000105c31ad8 in _RNvCskeEk8KZeDhw_7___rustc17rust_begin_unwind+0x1c (display_parse_tree:arm64+0x101305ad8)
    #13 0x000105ca98e4 in _RNvNtCseeK9tltLRk_4core9panicking9panic_fmt+0x24 (display_parse_tree:arm64+0x10137d8e4)
    #14 0x000105ca96bc in _RNvNtCseeK9tltLRk_4core6result13unwrap_failed+0x44 (display_parse_tree:arm64+0x10137d6bc)
    #15 0x000104a980d4 in expect<simplicityhl::parse::Program, simplicityhl::error::RichError> result.rs:1185
    #16 0x000104a980d4 in do_test display_parse_tree.rs:9
    #17 0x000104a980d4 in _RNvNvCs8opqPiHGX1W_18display_parse_tree1__19___libfuzzer_sys_run display_parse_tree.rs:21
    #18 0x000104ad6530 in rust_fuzzer_test_input lib.rs:363
    #19 0x000104ad7894 in _RINvNvNtCsgX2aokyoR4d_3std9panicking12catch_unwind7do_callNCNvCsgemHMRU4na9_13libfuzzer_sys15test_input_wrap0lEBY_+0xc4 (display_parse_tree:arm64+0x1001ab894)
    #20 0x000104ad84cc in __rust_try+0x18 (display_parse_tree:arm64+0x1001ac4cc)
    #21 0x000104ad7154 in LLVMFuzzerTestOneInput+0x16c (display_parse_tree:arm64+0x1001ab154)
    #22 0x000104adab00 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long)+0x158 (display_parse_tree:arm64+0x1001aeb00)
    #23 0x000104ada1a4 in fuzzer::Fuzzer::RunOne(unsigned char const*, unsigned long, bool, fuzzer::InputInfo*, bool, bool*)+0x48 (display_parse_tree:arm64+0x1001ae1a4)
    #24 0x000104adc350 in fuzzer::Fuzzer::ReadAndExecuteSeedCorpora(std::__1::vector<fuzzer::SizedFile, std::__1::allocator<fuzzer::SizedFile>>&)+0x818 (display_parse_tree:arm64+0x1001b0350)
    #25 0x000104adc4e8 in fuzzer::Fuzzer::Loop(std::__1::vector<fuzzer::SizedFile, std::__1::allocator<fuzzer::SizedFile>>&)+0x88 (display_parse_tree:arm64+0x1001b04e8)
    #26 0x000104afb184 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long))+0x1aa4 (display_parse_tree:arm64+0x1001cf184)
    #27 0x000104b07b8c in main+0x24 (display_parse_tree:arm64+0x1001dbb8c)
    #28 0x000189239d50 in start+0x1c0c (dyld:arm64e+0x8d50)

NOTE: libFuzzer has rudimentary signal handlers.
      Combine libFuzzer with AddressSanitizer or similar for better crash reports.
SUMMARY: libFuzzer: deadly signal
MS: 0 ; base unit: 0000000000000000000000000000000000000000
0x3d,0x0,0xff,0xfe,0x8c,0x40,0xff,0x32,0xff,0x1,0x0,0x10,0x0,0x0,0x0,0x0,0xbf,0x8,0x40,0xff,0x1e,
=\000\377\376\214@\3772\377\001\000\020\000\000\000\000\277\010@\377\036
artifact_prefix='/Volumes/Somebody/Desktop/Simp/simplicityhl/fuzz/artifacts/display_parse_tree/'; Test unit written to /Volumes/Somebody/Desktop/Simp/simplicityhl/fuzz/artifacts/display_parse_tree/crash-d17d88fc6b97a58344fa234365dfabe2054524f9
Base64: PQD//oxA/zL/AQAQAAAAAL8IQP8e

────────────────────────────────────────────────────────────────────────────────

Failing input:

	fuzz/artifacts/display_parse_tree/crash-d17d88fc6b97a58344fa234365dfabe2054524f9

Output of `std::fmt::Debug`:

	Program {
	    items: [
	        Use(
	            UseDecl {
	                visibility: Private,
	                path: [
	                    q,
	                ],
	                items: List(
	                    [],
	                ),
	                span: Span {
	                    start: 0,
	                    end: 0,
	                },
	            },
	        ),
	    ],
	    span: Span {
	        start: 0,
	        end: 0,
	    },
	}

Reproduce with:

	cargo fuzz run display_parse_tree fuzz/artifacts/display_parse_tree/crash-d17d88fc6b97a58344fa234365dfabe2054524f9

Minimize test case with:

	cargo fuzz tmin display_parse_tree fuzz/artifacts/display_parse_tree/crash-d17d88fc6b97a58344fa234365dfabe2054524f9

────────────────────────────────────────────────────────────────────────────────

Error: Fuzz target exited with exit status: 77
Output of `std::fmt::Debug`:

	Program {
	    items: [
	        Use(
	            UseDecl {
	                visibility: Private,
	                path: [
	                    q,
	                ],
	                items: List(
	                    [],
	                ),
	                span: Span {
	                    start: 0,
	                    end: 0,
	                },
	            },
	        ),
	    ],
	    span: Span {
	        start: 0,
	        end: 0,
	    },
	}

Reproduce with:

	cargo fuzz run display_parse_tree fuzz/artifacts/display_parse_tree/crash-d17d88fc6b97a58344fa234365dfabe2054524f9

Minimize test case with:

	cargo fuzz tmin display_parse_tree fuzz/artifacts/display_parse_tree/crash-d17d88fc6b97a58344fa234365dfabe2054524f9

────────────────────────────────────────────────────────────────────────────────

Error: Fuzz target exited with exit status: 77
```
</details>


After the fix, the command passes successfully


https://github.com/BlockstreamResearch/SimplicityHL/commit/e520bd40d5f2b71f3a988cde490f29bedaa6bfe6 -> `ResolvedType::arbitrary_rec` could generate nested `List<..., 256>` types. Even when those values are technically valid, converting them into structural Simplicity values can require enormous expanded structural types. The `reconstruct_value` fuzz target hit libFuzzer’s 2 GB memory limit from this, which blocks useful fuzzing.

The commit caps only fuzz-generated list bounds to a smaller power-of-two range. Runtime type support is unchanged: users can still parse and compile larger list bounds. This just keeps arbitrary fuzz inputs within a size that exercises the code instead of exhausting memory.

Command that I ran on master: 
`cargo +nightly fuzz run reconstruct_value -- -max_total_time=300 -max_len=50 -verbosity=0`


<details>
  <summary>Output for e520bd40d5f2b71f3a988cde490f29bedaa6bfe6</summary>

```
   Compiling simplicityhl v0.5.0 (/Volumes/Somebody/Desktop/Simp/simplicityhl)
   Compiling simplicityhl-fuzz v0.0.0 (/Volumes/Somebody/Desktop/Simp/simplicityhl/fuzz)
    Finished `release` profile [optimized + debuginfo] target(s) in 1m 12s
    Finished `release` profile [optimized + debuginfo] target(s) in 0.11s
     Running `target/aarch64-apple-darwin/release/reconstruct_value -artifact_prefix=/Volumes/Somebody/Desktop/Simp/simplicityhl/fuzz/artifacts/reconstruct_value/ -max_total_time=300 -max_len=50 -verbosity=0 /Volumes/Somebody/Desktop/Simp/simplicityhl/fuzz/corpus/reconstruct_value`
INFO: Running with entropic power schedule (0xFF, 100).
INFO:     1371 files found in /Volumes/Somebody/Desktop/Simp/simplicityhl/fuzz/corpus/reconstruct_value
INFO: seed corpus: files: 1371 min: 1b max: 50b total: 23439b rss: 48Mb
==20608== ERROR: libFuzzer: out-of-memory (used: 2054Mb; limit: 2048Mb)
   To change the out-of-memory limit use -rss_limit_mb=<N>

Live Heap Allocations: 1090686690 bytes in 8483 chunks; quarantined: 264294176 bytes in 3 chunks; 1645143 other chunks; total chunks: 1653629; showing top 95% (at most 8 unique contexts)
530669281 byte(s) (48%) in 1 allocation(s)
    #0 0x0001070eaea0 in calloc+0x74 (librustc-nightly_rt.asan.dylib:arm64+0x3eea0)
    #1 0x000104d42b54 in _RNvNtCs6MES67PXkuZ_10simplicity5value7product+0xbc (reconstruct_value:arm64+0x10099eb54)
    #2 0x000104d345ac in _RNvMs7_NtCs6MES67PXkuZ_10simplicity5valueNtB5_5Value7product+0x278 (reconstruct_value:arm64+0x1009905ac)
    #3 0x000104c458a8 in _RNvXss_NtCscp0zVqi0ESx_12simplicityhl5valueNtB5_15StructuralValueINtNtCseeK9tltLRk_4core7convert4FromRNtB5_5ValueE4from+0x1a5c (reconstruct_value:arm64+0x1008a18a8)
    #4 0x0001043a6224 in do_test reconstruct_value.rs:6
    #5 0x0001043a6224 in _RNvNvCs6karDxHTx3U_17reconstruct_value1__19___libfuzzer_sys_run reconstruct_value.rs:15
    #6 0x0001043a9b4c in rust_fuzzer_test_input lib.rs:363
    #7 0x0001043aac00 in _RINvNvNtCsgX2aokyoR4d_3std9panicking12catch_unwind7do_callNCNvCsgemHMRU4na9_13libfuzzer_sys15test_input_wrap0lEBY_+0xc4 (reconstruct_value:arm64+0x100006c00)
    #8 0x0001043ab838 in __rust_try+0x18 (reconstruct_value:arm64+0x100007838)
    #9 0x0001043aa4c0 in LLVMFuzzerTestOneInput+0x16c (reconstruct_value:arm64+0x1000064c0)
    #10 0x0001043ade6c in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long)+0x158 (reconstruct_value:arm64+0x100009e6c)
    #11 0x0001043ad510 in fuzzer::Fuzzer::RunOne(unsigned char const*, unsigned long, bool, fuzzer::InputInfo*, bool, bool*)+0x48 (reconstruct_value:arm64+0x100009510)
    #12 0x0001043aedbc in fuzzer::Fuzzer::MutateAndTestOne()+0x22c (reconstruct_value:arm64+0x10000adbc)
    #13 0x0001043afb20 in fuzzer::Fuzzer::Loop(std::__1::vector<fuzzer::SizedFile, std::__1::allocator<fuzzer::SizedFile>>&)+0x354 (reconstruct_value:arm64+0x10000bb20)
    #14 0x0001043ce4f0 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long))+0x1aa4 (reconstruct_value:arm64+0x10002a4f0)
    #15 0x0001043daef8 in main+0x24 (reconstruct_value:arm64+0x100036ef8)
    #16 0x000189239d50 in start+0x1c0c (dyld:arm64e+0x8d50)

266375192 byte(s) (24%) in 1 allocation(s)
    #0 0x0001070eabd8 in malloc+0x6c (librustc-nightly_rt.asan.dylib:arm64+0x3ebd8)
    #1 0x000104d42488 in _RNvNtCs6MES67PXkuZ_10simplicity5value13right_shift_1+0xd4c (reconstruct_value:arm64+0x10099e488)
    #2 0x000104d2e9e8 in _RNvMs7_NtCs6MES67PXkuZ_10simplicity5valueNtB5_5Value4left+0x268 (reconstruct_value:arm64+0x10098a9e8)
    #3 0x000104d2f40c in _RNvMs7_NtCs6MES67PXkuZ_10simplicity5valueNtB5_5Value4none+0x150 (reconstruct_value:arm64+0x10098b40c)
    #4 0x000104c459c0 in _RNvXss_NtCscp0zVqi0ESx_12simplicityhl5valueNtB5_15StructuralValueINtNtCseeK9tltLRk_4core7convert4FromRNtB5_5ValueE4from+0x1b74 (reconstruct_value:arm64+0x1008a19c0)
    #5 0x0001043a6224 in do_test reconstruct_value.rs:6
    #6 0x0001043a6224 in _RNvNvCs6karDxHTx3U_17reconstruct_value1__19___libfuzzer_sys_run reconstruct_value.rs:15
    #7 0x0001043a9b4c in rust_fuzzer_test_input lib.rs:363
    #8 0x0001043aac00 in _RINvNvNtCsgX2aokyoR4d_3std9panicking12catch_unwind7do_callNCNvCsgemHMRU4na9_13libfuzzer_sys15test_input_wrap0lEBY_+0xc4 (reconstruct_value:arm64+0x100006c00)
    #9 0x0001043ab838 in __rust_try+0x18 (reconstruct_value:arm64+0x100007838)
    #10 0x0001043aa4c0 in LLVMFuzzerTestOneInput+0x16c (reconstruct_value:arm64+0x1000064c0)
    #11 0x0001043ade6c in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long)+0x158 (reconstruct_value:arm64+0x100009e6c)
    #12 0x0001043ad510 in fuzzer::Fuzzer::RunOne(unsigned char const*, unsigned long, bool, fuzzer::InputInfo*, bool, bool*)+0x48 (reconstruct_value:arm64+0x100009510)
    #13 0x0001043aedbc in fuzzer::Fuzzer::MutateAndTestOne()+0x22c (reconstruct_value:arm64+0x10000adbc)
    #14 0x0001043afb20 in fuzzer::Fuzzer::Loop(std::__1::vector<fuzzer::SizedFile, std::__1::allocator<fuzzer::SizedFile>>&)+0x354 (reconstruct_value:arm64+0x10000bb20)
    #15 0x0001043ce4f0 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long))+0x1aa4 (reconstruct_value:arm64+0x10002a4f0)
    #16 0x0001043daef8 in main+0x24 (reconstruct_value:arm64+0x100036ef8)
    #17 0x000189239d50 in start+0x1c0c (dyld:arm64e+0x8d50)

264294136 byte(s) (24%) in 1 allocation(s)
    #0 0x0001070eabd8 in malloc+0x6c (librustc-nightly_rt.asan.dylib:arm64+0x3ebd8)
    #1 0x000104d3ff24 in _RNvMsp_NtCskVezZiUJdSa_5alloc4syncINtB5_3ArcShE11from_box_inCs6MES67PXkuZ_10simplicity+0x80 (reconstruct_value:arm64+0x10099bf24)
    #2 0x000104d42ff8 in _RNvNtCs6MES67PXkuZ_10simplicity5value7product+0x560 (reconstruct_value:arm64+0x10099eff8)
    #3 0x000104d345ac in _RNvMs7_NtCs6MES67PXkuZ_10simplicity5valueNtB5_5Value7product+0x278 (reconstruct_value:arm64+0x1009905ac)
    #4 0x000104c458a8 in _RNvXss_NtCscp0zVqi0ESx_12simplicityhl5valueNtB5_15StructuralValueINtNtCseeK9tltLRk_4core7convert4FromRNtB5_5ValueE4from+0x1a5c (reconstruct_value:arm64+0x1008a18a8)
    #5 0x0001043a6224 in do_test reconstruct_value.rs:6
    #6 0x0001043a6224 in _RNvNvCs6karDxHTx3U_17reconstruct_value1__19___libfuzzer_sys_run reconstruct_value.rs:15
    #7 0x0001043a9b4c in rust_fuzzer_test_input lib.rs:363
    #8 0x0001043aac00 in _RINvNvNtCsgX2aokyoR4d_3std9panicking12catch_unwind7do_callNCNvCsgemHMRU4na9_13libfuzzer_sys15test_input_wrap0lEBY_+0xc4 (reconstruct_value:arm64+0x100006c00)
    #9 0x0001043ab838 in __rust_try+0x18 (reconstruct_value:arm64+0x100007838)
    #10 0x0001043aa4c0 in LLVMFuzzerTestOneInput+0x16c (reconstruct_value:arm64+0x1000064c0)
    #11 0x0001043ade6c in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long)+0x158 (reconstruct_value:arm64+0x100009e6c)
    #12 0x0001043ad510 in fuzzer::Fuzzer::RunOne(unsigned char const*, unsigned long, bool, fuzzer::InputInfo*, bool, bool*)+0x48 (reconstruct_value:arm64+0x100009510)
    #13 0x0001043aedbc in fuzzer::Fuzzer::MutateAndTestOne()+0x22c (reconstruct_value:arm64+0x10000adbc)
    #14 0x0001043afb20 in fuzzer::Fuzzer::Loop(std::__1::vector<fuzzer::SizedFile, std::__1::allocator<fuzzer::SizedFile>>&)+0x354 (reconstruct_value:arm64+0x10000bb20)
    #15 0x0001043ce4f0 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long))+0x1aa4 (reconstruct_value:arm64+0x10002a4f0)
    #16 0x0001043daef8 in main+0x24 (reconstruct_value:arm64+0x100036ef8)
    #17 0x000189239d50 in start+0x1c0c (dyld:arm64e+0x8d50)

MS: 5 InsertRepeatedBytes-InsertByte-PersAutoDict-ChangeByte-PersAutoDict- DE: "\001\000\000\000\000\000\000\000"-"\000\000\000\000"-; base unit: 89dd254444f3a665d17a778161d1bc825bf3c5ac
0xed,0xb5,0xed,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0x0,0x0,0x0,0x0,0xff,0xff,0xff,0x5b,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0x5b,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0x1,0x0,0x0,0x0,0x0,0x0,0x0,0x0,
\355\265\355\377\377\377\377\377\377\377\377\000\000\000\000\377\377\377[\377\377\377\377\377\377\377\377\377[\377\377\377\377\377\377\377\001\000\000\000\000\000\000\000
artifact_prefix='/Volumes/Somebody/Desktop/Simp/simplicityhl/fuzz/artifacts/reconstruct_value/'; Test unit written to /Volumes/Somebody/Desktop/Simp/simplicityhl/fuzz/artifacts/reconstruct_value/oom-211d0e89ee6e0de8339165d21a7b508e9df3216f
Base64: 7bXt//////////8AAAAA////W////////////1v/////////AQAAAAAAAAA=
SUMMARY: libFuzzer: out-of-memory

────────────────────────────────────────────────────────────────────────────────

Failing input:

        fuzz/artifacts/reconstruct_value/oom-211d0e89ee6e0de8339165d21a7b508e9df3216f

Output of `std::fmt::Debug`:

        list![]: List<List<List<u256, 256>, 256>, 256>

Reproduce with:

        cargo fuzz run reconstruct_value fuzz/artifacts/reconstruct_value/oom-211d0e89ee6e0de8339165d21a7b508e9df3216f

Minimize test case with:

        cargo fuzz tmin reconstruct_value fuzz/artifacts/reconstruct_value/oom-211d0e89ee6e0de8339165d21a7b508e9df3216f

────────────────────────────────────────────────────────────────────────────────

Error: Fuzz target exited with exit status: 71
```
</details>


After the fix, the command passes successfully, see below 

<details>
   <summary>cargo +nightly fuzz run reconstruct_value -- -max_total_time=300 -max_len=50 -verbosity=0</summary>

```
   Compiling simplicityhl v0.5.0 (/Volumes/Somebody/Desktop/Simp/simplicityhl)
   Compiling simplicityhl-fuzz v0.0.0 (/Volumes/Somebody/Desktop/Simp/simplicityhl/fuzz)
    Finished `release` profile [optimized + debuginfo] target(s) in 1m 13s
    Finished `release` profile [optimized + debuginfo] target(s) in 0.03s
     Running `target/aarch64-apple-darwin/release/reconstruct_value -artifact_prefix=/Volumes/Somebody/Desktop/Simp/simplicityhl/fuzz/artifacts/reconstruct_value/ -max_total_time=300 -max_len=50 -verbosity=0 /Volumes/Somebody/Desktop/Simp/simplicityhl/fuzz/corpus/reconstruct_value`
INFO: Running with entropic power schedule (0xFF, 100).
INFO:     1401 files found in /Volumes/Somebody/Desktop/Simp/simplicityhl/fuzz/corpus/reconstruct_value
INFO: seed corpus: files: 1401 min: 1b max: 50b total: 24250b rss: 48Mb
###### Recommended dictionary. ######
"\377\377" # Uses: 14247
"\377\377\377\377" # Uses: 12339
"\001\000\000\000\000\000\000\001" # Uses: 10754
"\377\377\377\377\377\377\377\000" # Uses: 10495
"\001\000" # Uses: 11488
"\001\000\000\000" # Uses: 9976
"\017\000\000\000\000\000\000\000" # Uses: 8588
"\007\000\000\000\000\000\000\000" # Uses: 7903
"\000\000\000\000\000\000\000\000" # Uses: 7473
"\000\000\000\000\000\000\000\011" # Uses: 6933
"\000\000\000\000" # Uses: 7420
"\014\000\000\000\000\000\000\000" # Uses: 6380
"\000\000" # Uses: 5756
"\000\000\000\000\000\000\000\004" # Uses: 4233
"\013\252\252\252\252\252\252\252" # Uses: 2218
###### End of recommended dictionary. ######
```

</details>