### PR TITLE
release: bump crate to 0.6.0-rc.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-# Unreleased
+# 0.6.0-rc.0 - 2026-04-24
 
+* Add imports and dependency resolution, including `pub`/`use` syntax, re-exports, aliases, transitive dependencies, collision diagnostics, functional tests, examples, and `simc --dep` for compiling multi-file programs. [#264](https://github.com/BlockstreamResearch/SimplicityHL/pull/264)
 * Replaced the deprecated `WithFile` trait with `WithContent` and `WithSource` to cleanly separate single-file execution from multi-file environments. Additionally, replaced the `file()` method on `RichError` with `source()`. [#266](https://github.com/BlockstreamResearch/SimplicityHL/pull/266)
+* Clean up whitespace in the generated jet documentation. [#276](https://github.com/BlockstreamResearch/SimplicityHL/pull/276)
 
 # 0.5.0 - 2026-04-17
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -660,7 +660,7 @@ dependencies = [
 
 [[package]]
 name = "simplicityhl"
-version = "0.5.0"
+version = "0.6.0-rc.0"
 dependencies = [
  "arbitrary",
  "base64 0.21.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simplicityhl"
-version = "0.5.0"
+version = "0.6.0-rc.0"
 authors = ["sanket1729 <sanket1729@gmail.com>"]
 license = "CC0-1.0"
 homepage = "https://github.com/BlockstreamResearch/SimplicityHL"


### PR DESCRIPTION
## Copy from the CHANGELOG

* Add imports and dependency resolution, including `pub`/`use` syntax, re-exports, aliases, transitive dependencies, collision diagnostics, functional tests, examples, and `simc --dep` for compiling multi-file programs. [#264](https://github.com/BlockstreamResearch/SimplicityHL/pull/264)
* Replaced the deprecated `WithFile` trait with `WithContent` and `WithSource` to cleanly separate single-file execution from multi-file environments. Additionally, replaced the `file()` method on `RichError` with `source()`. [#266](https://github.com/BlockstreamResearch/SimplicityHL/pull/266)
* Clean up whitespace in the generated jet documentation. [#276](https://github.com/BlockstreamResearch/SimplicityHL/pull/276)

---

Overall, we are bumping the "major" version again due to module support. Technically, this should not be a breaking change, and all previous features should be supported, though I do not want it to look like a minor patch release, so I just bumped the middle digit in the release

It is an RC just to give us time to run it and adapt it on different closely related components: VS Code extension, LSP, simplex, std lib

After trying out the changes in the wild for a few weeks, we can release a stable version
