### PR TITLE
fuzz: add more chance to generate real programs

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -2216,10 +2216,32 @@ impl AsRef<Span> for ModuleAssignment {
 #[cfg(feature = "arbitrary")]
 impl<'a> arbitrary::Arbitrary<'a> for Program {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        let len = u.int_in_range(0..=3)?;
-        let items = (0..len)
-            .map(|_| Item::arbitrary(u))
-            .collect::<arbitrary::Result<Arc<[Item]>>>()?;
+        let mut items_vec: Vec<Item> = Vec::new();
+        let len = u.int_in_range(0..=2)?;
+        for _ in 0..len {
+            items_vec.push(Item::arbitrary(u)?);
+        }
+        // Three equally-likely modes for how `fn main()` is injected:
+        //   0 — no explicit main (arbitrary items only)
+        //   1 — main with arbitrary params and return type
+        //   2 — main with no params and no return type (closest to valid)
+        match u.int_in_range(0..=2u8)? {
+            0 => {}
+            1 => {
+                let mut main_fn = <Function as crate::ArbitraryRec>::arbitrary_rec(u, 3)?;
+                main_fn.name = FunctionName::main();
+                items_vec.push(Item::Function(main_fn));
+            }
+            _ => {
+                let mut main_fn = <Function as crate::ArbitraryRec>::arbitrary_rec(u, 3)?;
+                main_fn.name = FunctionName::main();
+                main_fn.params = Arc::from([]);
+                main_fn.ret = None;
+                items_vec.push(Item::Function(main_fn));
+            }
+        }
+
+        let items: Arc<[Item]> = items_vec.into();
         Ok(Self {
             items,
             span: Span::DUMMY,
@@ -2242,7 +2264,7 @@ impl crate::ArbitraryRec for Function {
         let file_id = u.int_in_range(0..=3)?;
         let visibility = Visibility::arbitrary(u)?;
         let name = FunctionName::arbitrary(u)?;
-        let len = u.int_in_range(0..=3)?;
+        let len = u.int_in_range(0..=6)?;
         let params = (0..len)
             .map(|_| FunctionParam::arbitrary(u))
             .collect::<arbitrary::Result<Arc<[FunctionParam]>>>()?;


### PR DESCRIPTION
Currently, most of the programs generated by Arbitrary for fuzzing are completely trivial types and aliases.

For example:
```
pub fn oj(h: (Either<[u8; 2], List<nux, 256>>, Either<bool, [mquqkypr; 2]>)) {
0b000100111}

pub type jwsgz = Either<Confidential1, t>;


```

While this may help catch some bugs during fuzzing, I think it would be better to generate more likely programs. I did consider changing it to always generate a valid `main` function, but in the end, I opted for an equally likely chance to generate one of:
1. The current junk items.
2. A main function, but with arbitrary parameters and return types
3. A main function with no params and no return type.

Even with this constraint it seldom generates a compiling program. I can't tell the original intention here, but I would suggest that we add a further constraint on the expression body to always have non-returning last statement. 

NOTE: I didn't commit this, but this method can be used to see some of the programs generated.
```rust
  #[test]
    fn print_arbitrary_parse_programs() {
        let mut printed = 0;
        let mut attempts = 0;
        while printed < 12 {
            attempts += 1;
            let bytes = random_bytes(256);
            let mut u = Unstructured::new(&bytes);
            if let Ok(prog) = Program::arbitrary(&mut u) {
                println!("=== attempt {attempts} ===");
                println!("{prog}");
                println!();
                printed += 1;
            }
        }
        println!("({printed} programs generated in {attempts} attempts)");
    }

```
Some of the programs generated:
```


=== attempt 8 ===
fn main(syvnmvut: bool, ldnuusp: bool, jnitbims: bool, o: List<List<Nonce, 16>, 64>) -> bool {
<bool>::into({
let ([[_, gyerkky, emt], ndznsdei, hfg], _, _): [List<[u1; 3], 8>; 1] = (None);
    Left(0x6d67f31e8);
    {
let [_, []]: tlwbfeyl = 232803066;
}
}
)}



=== attempt 9 ===
pub fn main() -> Either<Either<bool, Option<u2>>, bool> {
let uwjw: bool = {
unwrap_right::<Option<List<Either<u128, Distance>, 64>>>(0x2b75de7ed, uodv);
}
;
    let [z]: List<[upzlrercpx; 3], 128> = {
let [_]: Option<Pubkey> = {
witness::g;
    0xccd1b79bc;
    let (_, ): u2 = 0b1;
    false}
;
    let _: Distance = {
witness::iyjqphs;
    0xc685a;
}
;
}
;
    panic!();
}



=== attempt 10 ===


=== attempt 11 ===
mod witness {}
pub fn main() {
}



=== attempt 12 ===
mod witness {}
use {};
pub fn main() {
}



=== attempt 13 ===
pub fn oj(h: (Either<[u8; 2], List<nux, 256>>, Either<bool, [mquqkypr; 2]>)) {
0b000100111}

pub type jwsgz = Either<Confidential1, t>;


=== attempt 15 ===
```