### PR TITLE
﻿chore(ci): add windows build job to rust workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,6 +44,19 @@ jobs:
       - name: "Run test script"
         run: ./maintainer-tools/ci/run_task.sh stable
 
+  Windows:
+    name: Test - Windows stable toolchain
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: "Checkout repo"
+        uses: actions/checkout@v4
+      - name: "Select toolchain"
+        uses: dtolnay/rust-toolchain@stable
+      - name: "Run tests"
+        run: cargo test
+
   Nightly:
     name: Test - nightly toolchain
     needs: Prepare


### PR DESCRIPTION
Add a CI job to run tests on windows.

#303 broke `cargo test` on windows (fixed in #307). This is a job to check that tests pass on windows