### PR TITLE
chore: update rust-simplicity dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,18 +508,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
 name = "regex-automata"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -541,15 +529,6 @@ name = "ryu"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
-
-[[package]]
-name = "santiago"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de36022292bc2086eb8f55bffa460fef3475e4459b478820711f4c421feb87ec"
-dependencies = [
- "regex",
-]
 
 [[package]]
 name = "secp256k1"
@@ -632,9 +611,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "simplicity-lang"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e57bd4d84853974a212eab24ed89da54f49fbccf5e33e93bcd29f0a6591cd5"
+checksum = "07f79806a665b34e4d8950edd053a991e57915e3924b8b21ac6f2bdd23d9e842"
 dependencies = [
  "bitcoin",
  "bitcoin_hashes",
@@ -644,15 +623,14 @@ dependencies = [
  "ghost-cell",
  "hex-conservative",
  "miniscript",
- "santiago",
  "simplicity-sys",
 ]
 
 [[package]]
 name = "simplicity-sys"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3401ee7331f183a5458c0f5a4b3d5d00bde0fd12e2e03728c537df34efae289"
+checksum = "96d1ec5477c7650b8ef511aa56dccb28f2e8cdb6e87f260ecffdaf0ebfef2d3b"
 dependencies = [
  "bitcoin_hashes",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ docs = []
 base64 = "0.21.2"
 serde = { version = "1.0.188", features = ["derive"], optional = true }
 serde_json = { version = "1.0.105", optional = true }
-simplicity-lang = { version = "0.7.0" }
+simplicity-lang = { version = "0.7.1" }
 miniscript = "12.3.1"
 either = "1.12.0"
 itertools = "0.13.0"

--- a/examples/escrow_with_delay.simf
+++ b/examples/escrow_with_delay.simf
@@ -51,7 +51,7 @@ fn timeout_spend(sender_sig: Signature) {
     let sender_pk: Pubkey = 0x79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798; // 1 * G
     checksig(sender_pk, sender_sig);
     let timeout: Distance = 1000;
-    jet::check_lock_distance(timeout);
+    jet::broken_do_not_use_check_lock_distance(timeout);
 }
 
 fn main() {

--- a/examples/last_will.simf
+++ b/examples/last_will.simf
@@ -24,7 +24,7 @@ fn recursive_covenant() {
 
 fn inherit_spend(inheritor_sig: Signature) {
     let days_180: Distance = 25920;
-    jet::check_lock_distance(days_180);
+    jet::broken_do_not_use_check_lock_distance(days_180);
     let inheritor_pk: Pubkey = 0x79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798; // 1 * G
     checksig(inheritor_pk, inheritor_sig);
 }

--- a/examples/presigned_vault.simf
+++ b/examples/presigned_vault.simf
@@ -23,7 +23,7 @@ fn checksig(pk: Pubkey, sig: Signature) {
 
 fn complete_spend(hot_sig: Signature) {
     let timeout: Distance = 1000;
-    jet::check_lock_distance(timeout);
+    jet::broken_do_not_use_check_lock_distance(timeout);
     let hot_pk: Pubkey = 0x79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798; // 1 * G
     checksig(hot_pk, hot_sig);
 }

--- a/src/compile/mod.rs
+++ b/src/compile/mod.rs
@@ -26,7 +26,7 @@ use crate::value::StructuralValue;
 use crate::witness::Arguments;
 use crate::Value;
 
-type ProgNode<'brand> = Arc<named::ConstructNode<'brand, Elements>>;
+type ProgNode<'brand> = Arc<named::ConstructNode<'brand>>;
 
 /// Each SimplicityHL expression expects an _input value_.
 /// A SimplicityHL expression is translated into a Simplicity expression
@@ -263,7 +263,7 @@ impl Program {
         &self,
         arguments: Arguments,
         include_debug_symbols: bool,
-    ) -> Result<Arc<named::CommitNode<Elements>>, RichError> {
+    ) -> Result<Arc<named::CommitNode>, RichError> {
         types::Context::with_context(|ctx| {
             let mut scope = Scope::new(
                 ctx,
@@ -379,7 +379,7 @@ impl Call {
 
         match self.name() {
             CallName::Jet(name) => {
-                let jet = ProgNode::jet(scope.ctx(), *name);
+                let jet = ProgNode::jet(scope.ctx(), name);
                 scope.with_debug_symbol(args, &jet, self)
             }
             CallName::UnwrapLeft(..) => {
@@ -410,7 +410,7 @@ impl Call {
                 args.comp(&body).with_span(self)
             }
             CallName::Assert => {
-                let jet = ProgNode::jet(scope.ctx(), Elements::Verify);
+                let jet = ProgNode::jet(scope.ctx(), &Elements::Verify);
                 scope.with_debug_symbol(args, &jet, self)
             }
             CallName::Panic => {

--- a/src/docs/jet.rs
+++ b/src/docs/jet.rs
@@ -607,11 +607,11 @@ Using the notation of BIP-0341, it returns the SHA256 hash of c[33: 33 + 32m]."#
 - The result of [`output_surjection_proofs_hash`] (32 bytes).
 - The result of [`input_utxos_hash`] (32 bytes)."#,
         // Time locks
-        Elements::CheckLockDistance => r#"**Deprecated; do not use.** Assert that the value returned by [`tx_lock_distance`] is greater than or equal to the given value.
+        Elements::BrokenDoNotUseCheckLockDistance => r#"**Deprecated; do not use.** Assert that the value returned by [`tx_lock_distance`] is greater than or equal to the given value.
 
 ## Panics
 The assertion fails."#,
-        Elements::CheckLockDuration => r#"**Deprecated; do not use.** Assert that the value returned by [`tx_lock_duration`] is greater than or equal to the given value.
+        Elements::BrokenDoNotUseCheckLockDuration => r#"**Deprecated; do not use.** Assert that the value returned by [`tx_lock_duration`] is greater than or equal to the given value.
 
 ## Panics
 The assertion fails"#,
@@ -624,8 +624,8 @@ The assertion fails."#,
 ## Panics
 The assertion fails."#,
         Elements::TxIsFinal => "Check if the sequence numbers of all transaction inputs are at their maximum value.",
-        Elements::TxLockDistance => "**Deprecated; do not use.** If [`version`] returns 2 or greater, then return the greatest valid [`Distance`] value of any transaction input. Return zeroes otherwise.",
-        Elements::TxLockDuration => "**Deprecated; do not use.** If [`version`] returns 2 or greater, then return the greatest valid [`Duration`] value of any transaction input. Return zeroes otherwise.",
+        Elements::BrokenDoNotUseTxLockDistance => "**Deprecated; do not use.** If [`version`] returns 2 or greater, then return the greatest valid [`Distance`] value of any transaction input. Return zeroes otherwise.",
+        Elements::BrokenDoNotUseTxLockDuration => "**Deprecated; do not use.** If [`version`] returns 2 or greater, then return the greatest valid [`Duration`] value of any transaction input. Return zeroes otherwise.",
         Elements::TxLockHeight => "If [`tx_is_final`] returns false, then try to parse the transaction's lock time as a [`Height`] value. Return zeroes otherwise.",
         Elements::TxLockTime   => "If [`tx_is_final`] returns false, then try to parse the transaction's lock time as a [`Time`] value. Return zeroes otherwise.",
         // Issuance
@@ -794,10 +794,10 @@ Return zero for any asset without fees."#,
     fn is_deprecated(&self) -> bool {
         matches!(
             self,
-            Elements::CheckLockDistance
-                | Elements::CheckLockDuration
-                | Elements::TxLockDistance
-                | Elements::TxLockDuration
+            Elements::BrokenDoNotUseCheckLockDistance
+                | Elements::BrokenDoNotUseCheckLockDuration
+                | Elements::BrokenDoNotUseTxLockDistance
+                | Elements::BrokenDoNotUseTxLockDuration
                 | Elements::CheckSigVerify
                 | Elements::Verify
         )
@@ -991,7 +991,7 @@ const SIGNATURE_HASH_MODES: [Elements; 35] = [
 ];
 #[rustfmt::skip]
 const TIME_LOCKS: [Elements; 9] = [
-    Elements::CheckLockDistance, Elements::CheckLockDuration, Elements::CheckLockHeight, Elements::CheckLockTime, Elements::TxIsFinal, Elements::TxLockDistance, Elements::TxLockDuration, Elements::TxLockHeight, Elements::TxLockTime
+    Elements::BrokenDoNotUseCheckLockDistance, Elements::BrokenDoNotUseCheckLockDuration, Elements::CheckLockHeight, Elements::CheckLockTime, Elements::TxIsFinal, Elements::BrokenDoNotUseTxLockDistance, Elements::BrokenDoNotUseTxLockDuration, Elements::TxLockHeight, Elements::TxLockTime
 ];
 #[rustfmt::skip]
 const ISSUANCE: [Elements; 9] = [

--- a/src/jet.rs
+++ b/src/jet.rs
@@ -450,12 +450,12 @@ pub fn source_type(jet: Elements) -> Vec<AliasedType> {
          * Time locks
          */
         Elements::CheckLockTime => vec![Time.into()],
-        Elements::CheckLockDistance => vec![Distance.into()],
-        Elements::CheckLockDuration => vec![Duration.into()],
+        Elements::BrokenDoNotUseCheckLockDistance => vec![Distance.into()],
+        Elements::BrokenDoNotUseCheckLockDuration => vec![Duration.into()],
         Elements::CheckLockHeight => vec![Height.into()],
         Elements::TxLockTime
-        | Elements::TxLockDistance
-        | Elements::TxLockDuration
+        | Elements::BrokenDoNotUseTxLockDistance
+        | Elements::BrokenDoNotUseTxLockDuration
         | Elements::TxLockHeight
         | Elements::TxIsFinal => vec![],
         /*
@@ -956,13 +956,13 @@ pub fn target_type(jet: Elements) -> AliasedType {
          * Time locks
          */
         Elements::CheckLockTime
-        | Elements::CheckLockDistance
-        | Elements::CheckLockDuration
+        | Elements::BrokenDoNotUseCheckLockDistance
+        | Elements::BrokenDoNotUseCheckLockDuration
         | Elements::CheckLockHeight => AliasedType::unit(),
         Elements::TxIsFinal => bool(),
         Elements::TxLockTime => Time.into(),
-        Elements::TxLockDistance => Distance.into(),
-        Elements::TxLockDuration => Duration.into(),
+        Elements::BrokenDoNotUseTxLockDistance => Distance.into(),
+        Elements::BrokenDoNotUseTxLockDuration => Duration.into(),
         Elements::TxLockHeight => Height.into(),
         /*
          * Issuance

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ mod witness;
 use std::sync::Arc;
 
 use simplicity::jet::elements::ElementsEnv;
-use simplicity::{jet::Elements, CommitNode, RedeemNode};
+use simplicity::{CommitNode, RedeemNode};
 
 pub extern crate either;
 pub extern crate simplicity;
@@ -174,7 +174,7 @@ impl TemplateProgram {
 /// A SimplicityHL program, compiled to Simplicity.
 #[derive(Clone, Debug)]
 pub struct CompiledProgram {
-    simplicity: Arc<named::CommitNode<Elements>>,
+    simplicity: Arc<named::CommitNode>,
     witness_types: WitnessTypes,
     debug_symbols: DebugSymbols,
     parameter_types: Parameters,
@@ -218,7 +218,7 @@ impl CompiledProgram {
     }
 
     /// Access the Simplicity target code, without witness data.
-    pub fn commit(&self) -> Arc<CommitNode<Elements>> {
+    pub fn commit(&self) -> Arc<CommitNode> {
         named::forget_names(&self.simplicity)
     }
 
@@ -275,7 +275,7 @@ pub struct AbiMeta {
 /// A SimplicityHL program, compiled to Simplicity and satisfied with witness data.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SatisfiedProgram {
-    simplicity: Arc<RedeemNode<Elements>>,
+    simplicity: Arc<RedeemNode>,
     debug_symbols: DebugSymbols,
 }
 
@@ -298,7 +298,7 @@ impl SatisfiedProgram {
     }
 
     /// Access the Simplicity target code, including witness data.
-    pub fn redeem(&self) -> &Arc<RedeemNode<Elements>> {
+    pub fn redeem(&self) -> &Arc<RedeemNode> {
         &self.simplicity
     }
 

--- a/src/named.rs
+++ b/src/named.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use simplicity::dag::{InternalSharing, PostOrderIterItem};
-use simplicity::jet::Jet;
 use simplicity::node::{
     self, Converter, CoreConstructible, Inner, NoDisconnect, NoWitness, Node, WitnessConstructible,
 };
@@ -22,7 +21,6 @@ impl<M: node::Marker> node::Marker for WithNames<M> {
     // we don't use disconnect in this library right now, so punt on it for now.
     type Disconnect = NoDisconnect;
     type SharingId = M::SharingId;
-    type Jet = M::Jet;
 
     fn compute_sharing_id(cmr: Cmr, cached_data: &Self::CachedData) -> Option<Self::SharingId> {
         M::compute_sharing_id(cmr, cached_data)
@@ -56,17 +54,17 @@ impl Nullable for NoDisconnect {
 /// [`simplicity::ConstructNode`] with named witness nodes.
 ///
 /// Nodes other than witness don't have names.
-pub type ConstructNode<'brand, J> = Node<WithNames<node::Construct<'brand, J>>>;
+pub type ConstructNode<'brand> = Node<WithNames<node::Construct<'brand>>>;
 
 /// [`simplicity::CommitNode`] with named witness nodes.
 ///
 /// Nodes other than witness don't have names.
-pub type CommitNode<J> = Node<WithNames<node::Commit<J>>>;
+pub type CommitNode = Node<WithNames<node::Commit>>;
 
 // FIXME: The following methods cannot be implemented for simplicity::node::Node because that is a foreign type
-pub fn finalize_types<J: Jet>(
-    node: &Node<WithNames<node::Construct<J>>>,
-) -> Result<Arc<Node<WithNames<node::Commit<J>>>>, types::Error> {
+pub fn finalize_types<'brand>(
+    node: &Node<WithNames<node::Construct<'brand>>>,
+) -> Result<Arc<Node<WithNames<node::Commit>>>, types::Error> {
     // We finalize all types but don't bother to set the root source and target
     // to unit. This is a bit annoying to do, and anyway these types will already
     // be unit by construction.
@@ -82,11 +80,11 @@ fn translate<M, N, F, E>(
 ) -> Result<Arc<Node<WithNames<N>>>, E>
 where
     M: node::Marker,
-    N: node::Marker<Jet = M::Jet>,
+    N: node::Marker,
     N::Witness: Nullable,
     F: FnMut(
         &Node<WithNames<M>>,
-        Inner<&N::CachedData, N::Jet, &NoDisconnect, &WitnessName>,
+        Inner<&N::CachedData, &NoDisconnect, &WitnessName>,
     ) -> Result<N::CachedData, E>,
 {
     struct Translator<F>(F);
@@ -94,11 +92,11 @@ where
     impl<M, N, F, E> Converter<WithNames<M>, WithNames<N>> for Translator<F>
     where
         M: node::Marker,
-        N: node::Marker<Jet = M::Jet>,
+        N: node::Marker,
         N::Witness: Nullable,
         F: FnMut(
             &Node<WithNames<M>>,
-            Inner<&N::CachedData, N::Jet, &NoDisconnect, &WitnessName>,
+            Inner<&N::CachedData, &NoDisconnect, &WitnessName>,
         ) -> Result<N::CachedData, E>,
     {
         type Error = E;
@@ -123,7 +121,7 @@ where
         fn convert_data(
             &mut self,
             data: &PostOrderIterItem<&Node<WithNames<M>>>,
-            inner: Inner<&Arc<Node<WithNames<N>>>, N::Jet, &NoDisconnect, &WitnessName>,
+            inner: Inner<&Arc<Node<WithNames<N>>>, &NoDisconnect, &WitnessName>,
         ) -> Result<N::CachedData, Self::Error> {
             let new_inner = inner.map(|node| node.cached_data());
             self.0(data.node, new_inner)
@@ -170,7 +168,7 @@ where
         fn convert_data(
             &mut self,
             data: &PostOrderIterItem<&Node<WithNames<M>>>,
-            _: Inner<&Arc<Node<M>>, M::Jet, &M::Disconnect, &M::Witness>,
+            _: Inner<&Arc<Node<M>>, &M::Disconnect, &M::Witness>,
         ) -> Result<M::CachedData, Self::Error> {
             Ok(data.node.cached_data().clone())
         }
@@ -194,20 +192,20 @@ where
 /// It is the responsibility of the caller to ensure that the given witness `values` match the
 /// types in the construct `node`. This can be done by calling [`WitnessValues::is_consistent`]
 /// on the original SimplicityHL program before it is compiled to Simplicity.
-pub fn populate_witnesses<J: Jet>(
-    node: &CommitNode<J>,
+pub fn populate_witnesses(
+    node: &CommitNode,
     values: WitnessValues,
-) -> Result<Arc<node::RedeemNode<J>>, String> {
+) -> Result<Arc<node::RedeemNode>, String> {
     struct Populator {
         values: WitnessValues,
     }
 
-    impl<J: Jet> Converter<WithNames<node::Commit<J>>, node::Redeem<J>> for Populator {
+    impl Converter<WithNames<node::Commit>, node::Redeem> for Populator {
         type Error = String;
 
         fn convert_witness(
             &mut self,
-            _: &PostOrderIterItem<&CommitNode<J>>,
+            _: &PostOrderIterItem<&CommitNode>,
             witness: &WitnessName,
         ) -> Result<simplicity::Value, Self::Error> {
             match self.values.get(witness) {
@@ -218,23 +216,18 @@ pub fn populate_witnesses<J: Jet>(
 
         fn convert_disconnect(
             &mut self,
-            _: &PostOrderIterItem<&CommitNode<J>>,
-            _: Option<&Arc<node::RedeemNode<J>>>,
+            _: &PostOrderIterItem<&CommitNode>,
+            _: Option<&Arc<node::RedeemNode>>,
             _: &NoDisconnect,
-        ) -> Result<Arc<node::RedeemNode<J>>, Self::Error> {
+        ) -> Result<Arc<node::RedeemNode>, Self::Error> {
             unreachable!("SimplicityHL does not use disconnect right now")
         }
 
         fn convert_data(
             &mut self,
-            data: &PostOrderIterItem<&CommitNode<J>>,
-            inner: Inner<
-                &Arc<node::RedeemNode<J>>,
-                J,
-                &Arc<node::RedeemNode<J>>,
-                &simplicity::Value,
-            >,
-        ) -> Result<Arc<node::RedeemData<J>>, Self::Error> {
+            data: &PostOrderIterItem<&CommitNode>,
+            inner: Inner<&Arc<node::RedeemNode>, &Arc<node::RedeemNode>, &simplicity::Value>,
+        ) -> Result<Arc<node::RedeemData>, Self::Error> {
             let inner = inner
                 .map(|node| node.cached_data())
                 .map_disconnect(|node| node.cached_data())
@@ -253,7 +246,7 @@ pub fn populate_witnesses<J: Jet>(
 // This awkward construction is required by rust-simplicity to implement WitnessConstructible
 // for Node<WithNames<Construct>>. See
 //     https://docs.rs/simplicity-lang/latest/simplicity/node/trait.WitnessConstructible.html#foreign-impls
-impl<'brand, J: Jet> WitnessConstructible<'brand, WitnessName> for node::ConstructData<'brand, J> {
+impl<'brand> WitnessConstructible<'brand, WitnessName> for node::ConstructData<'brand> {
     fn witness(inference_context: &types::Context<'brand>, _: WitnessName) -> Self {
         WitnessConstructible::<Option<_>>::witness(inference_context, None)
     }

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -443,7 +443,6 @@ impl From<&Pattern> for BasePattern {
 mod tests {
     use super::*;
     use crate::named;
-    use simplicity::jet::Elements;
 
     #[test]
     fn translate_pattern() {
@@ -468,7 +467,7 @@ mod tests {
         for (target, expected_expr) in target_expr {
             simplicity::types::Context::with_context(|ctx| {
                 let expr = env
-                    .translate::<Arc<named::ConstructNode<Elements>>>(&ctx, &target)
+                    .translate::<Arc<named::ConstructNode>>(&ctx, &target)
                     .unwrap();
                 assert_eq!(expected_expr, expr.as_ref().display_expr().to_string());
             });

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -174,7 +174,7 @@ impl<'a> DefaultTracker<'a> {
     /// Handles jet node execution by decoding arguments and results.
     fn handle_jet(
         &mut self,
-        node: &RedeemNode<Elements>,
+        node: &RedeemNode,
         jet: Elements,
         input: &FrameIter,
         output: &NodeOutput,
@@ -184,11 +184,6 @@ impl<'a> DefaultTracker<'a> {
         }
 
         let mut input_frame = input.clone();
-
-        // The reason we need to advance by a bit is that the AssertL combinator is actually a Case combinator,
-        // which takes a bit of input to decide which branch to take. But this bit is "meaningless" and
-        // is always 0 because it's an assertion.
-        let _ = input_frame.next();
 
         let args = match parse_jet_arguments(jet, &mut input_frame) {
             Ok(args) => args,
@@ -213,22 +208,11 @@ impl<'a> DefaultTracker<'a> {
     }
 
     /// Parses the result of a jet execution from the output frame.
-    fn parse_jet_result(
-        node: &RedeemNode<Elements>,
-        jet: Elements,
-        output: &NodeOutput,
-    ) -> Option<Value> {
+    fn parse_jet_result(node: &RedeemNode, jet: Elements, output: &NodeOutput) -> Option<Value> {
         match output.clone() {
             NodeOutput::Success(mut output_frame) => {
                 let target_ty = &node.arrow().target;
                 let jet_target_ty = resolve_jet_type(&target_type(jet));
-
-                // Skip the leading bit when the frame has extra padding.
-                // This occurs because some jets (like eq_64 etc.) are wrapped in AssertL (a Case combinator),
-                // see compile::with_debug_symbol
-                if target_ty.as_sum().is_some() {
-                    let _ = output_frame.next();
-                }
 
                 let output_value = SimValue::from_padded_bits(&mut output_frame, target_ty)
                     .expect("output from bit machine is always well-formed");
@@ -247,12 +231,7 @@ impl<'a> DefaultTracker<'a> {
     }
 
     /// Handles debug node execution by resolving symbols and decoding values.
-    fn handle_debug(
-        &mut self,
-        node: &RedeemNode<Elements>,
-        input: &FrameIter,
-        cmr: &simplicity::Cmr,
-    ) {
+    fn handle_debug(&mut self, node: &RedeemNode, input: &FrameIter, cmr: &simplicity::Cmr) {
         if self.debug_sink.is_none() {
             return;
         }
@@ -268,7 +247,10 @@ impl<'a> DefaultTracker<'a> {
 
         let mut input_frame = input.clone();
 
-        // Skip the Case combinator's branch selection bit (see handle_jet).
+        // Skip the Case combinator's branch selection bit
+        // The reason we need to advance by a bit is that the AssertL combinator is actually a Case combinator,
+        // which takes a bit of input to decide which branch to take. But this bit is "meaningless" and
+        // is always 0 because it's an assertion.
         let _ = input_frame.next();
 
         // The debug call has signature `dbg!(T) -> T`, so the target type
@@ -291,9 +273,9 @@ impl<'a> DefaultTracker<'a> {
     }
 }
 
-impl PruneTracker<Elements> for DefaultTracker<'_> {
+impl PruneTracker for DefaultTracker<'_> {
     fn contains_left(&self, ihr: Ihr) -> bool {
-        if PruneTracker::<Elements>::contains_left(&self.inner, ihr) {
+        if PruneTracker::contains_left(&self.inner, ihr) {
             return true;
         }
 
@@ -305,7 +287,7 @@ impl PruneTracker<Elements> for DefaultTracker<'_> {
     }
 
     fn contains_right(&self, ihr: Ihr) -> bool {
-        if PruneTracker::<Elements>::contains_right(&self.inner, ihr) {
+        if PruneTracker::contains_right(&self.inner, ihr) {
             return true;
         }
 
@@ -317,10 +299,14 @@ impl PruneTracker<Elements> for DefaultTracker<'_> {
     }
 }
 
-impl ExecTracker<Elements> for DefaultTracker<'_> {
-    fn visit_node(&mut self, node: &RedeemNode<Elements>, input: FrameIter, output: NodeOutput) {
+impl ExecTracker for DefaultTracker<'_> {
+    fn visit_node(&mut self, node: &RedeemNode, input: FrameIter, output: NodeOutput) {
         match node.inner() {
-            Inner::Jet(jet) => self.handle_jet(node, *jet, &input, &output),
+            Inner::Jet(jet) => {
+                if let Some(&elements_jet) = jet.as_any().downcast_ref::<Elements>() {
+                    self.handle_jet(node, elements_jet, &input, &output);
+                }
+            }
             Inner::AssertL(_, cmr) => self.handle_debug(node, &input, cmr),
             _ => {}
         }

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -305,6 +305,8 @@ impl ExecTracker for DefaultTracker<'_> {
             Inner::Jet(jet) => {
                 if let Some(&elements_jet) = jet.as_any().downcast_ref::<Elements>() {
                     self.handle_jet(node, elements_jet, &input, &output);
+                } else {
+                    panic!("Expected an Elements jet, found a different type of jet: {jet:?}");
                 }
             }
             Inner::AssertL(_, cmr) => self.handle_debug(node, &input, cmr),


### PR DESCRIPTION
Switch to latest  master branch of rust-simplicity, which removes the `Jet` type parameter from nodes and renames broken lock distance/ duration jets. Update all call sites to match the new API and deprecate example files that use the renamed jets.