### PR TITLE
Add JetHL trait implementation and usage across modules

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -11,6 +11,7 @@ use simplicity::jet::Elements;
 use crate::debug::{CallTracker, DebugSymbols, TrackedCallName};
 use crate::driver::{FileScoped, SymbolTable, MAIN_MODULE, MAIN_STR};
 use crate::error::{Error, RichError, Span, WithSpan};
+use crate::jet::JetHL;
 use crate::num::{NonZeroPow2Usize, Pow2Usize};
 use crate::parse::MatchPattern;
 use crate::pattern::Pattern;
@@ -1266,14 +1267,16 @@ impl AbstractSyntaxTree for Call {
         let name = CallName::analyze(from, ty, scope)?;
         let args = match name.clone() {
             CallName::Jet(jet) => {
-                let args_tys = crate::jet::source_type(jet)
+                let args_tys = jet
+                    .source_type()
                     .iter()
                     .map(AliasedType::resolve_builtin)
                     .collect::<Result<Vec<ResolvedType>, AliasName>>()
                     .map_err(Error::UndefinedAlias)
                     .with_span(from)?;
                 check_argument_types(from.args(), &args_tys).with_span(from)?;
-                let out_ty = crate::jet::target_type(jet)
+                let out_ty = jet
+                    .target_type()
                     .resolve_builtin()
                     .map_err(Error::UndefinedAlias)
                     .with_span(from)?;
@@ -1440,10 +1443,8 @@ impl AbstractSyntaxTree for CallName {
     ) -> Result<Self, RichError> {
         match from.name() {
             parse::CallName::Jet(name) => match Elements::from_str(name.as_inner()) {
-                Ok(Elements::CheckSigVerify | Elements::Verify) | Err(_) => {
-                    Err(Error::JetDoesNotExist(name.clone())).with_span(from)
-                }
-                Ok(jet) => Ok(Self::Jet(jet)),
+                Ok(jet) if !jet.is_disabled() => Ok(Self::Jet(jet)),
+                _ => Err(Error::JetDoesNotExist(name.clone())).with_span(from),
             },
             parse::CallName::UnwrapLeft(right_ty) => scope
                 .resolve(right_ty)

--- a/src/compile/mod.rs
+++ b/src/compile/mod.rs
@@ -17,6 +17,7 @@ use crate::ast::{
 };
 use crate::debug::CallTracker;
 use crate::error::{Error, RichError, Span, WithSpan};
+use crate::jet::JetHL;
 use crate::named::{self, CoreExt, PairBuilder};
 use crate::num::{NonZeroPow2Usize, Pow2Usize};
 use crate::pattern::{BasePattern, Pattern};
@@ -410,7 +411,7 @@ impl Call {
                 args.comp(&body).with_span(self)
             }
             CallName::Assert => {
-                let jet = ProgNode::jet(scope.ctx(), &Elements::Verify);
+                let jet = ProgNode::jet(scope.ctx(), &*Elements::verify());
                 scope.with_debug_symbol(args, &jet, self)
             }
             CallName::Panic => {

--- a/src/jet.rs
+++ b/src/jet.rs
@@ -4,6 +4,32 @@ use crate::types::UIntType::*;
 use crate::types::*;
 
 use simplicity::jet::Elements;
+use simplicity::jet::Jet;
+
+pub trait JetHL {
+    fn source_type(&self) -> Vec<AliasedType>;
+    fn target_type(&self) -> AliasedType;
+    fn verify() -> Box<dyn Jet>;
+    fn is_disabled(&self) -> bool;
+}
+
+impl JetHL for Elements {
+    fn source_type(&self) -> Vec<AliasedType> {
+        source_type(*self)
+    }
+
+    fn target_type(&self) -> AliasedType {
+        target_type(*self)
+    }
+
+    fn verify() -> Box<dyn Jet> {
+        Box::new(Elements::Verify)
+    }
+
+    fn is_disabled(&self) -> bool {
+        matches!(self, Elements::CheckSigVerify | Elements::Verify)
+    }
+}
 
 fn tuple<A: Into<AliasedType>, I: IntoIterator<Item = A>>(elements: I) -> AliasedType {
     AliasedType::tuple(elements.into_iter().map(A::into))
@@ -1044,7 +1070,7 @@ mod tests {
     fn compatible_source_type() {
         for jet in Elements::ALL {
             let resolved_ty = ResolvedType::tuple(
-                source_type(jet)
+                jet.source_type()
                     .into_iter()
                     .map(|t| t.resolve_builtin().unwrap()),
             );
@@ -1059,7 +1085,7 @@ mod tests {
     #[test]
     fn compatible_target_type() {
         for jet in Elements::ALL {
-            let resolved_ty = target_type(jet).resolve_builtin().unwrap();
+            let resolved_ty = jet.target_type().resolve_builtin().unwrap();
             let structural_ty = StructuralType::from(&resolved_ty);
             let simplicity_ty = jet.target_ty().to_final();
 

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -6,7 +6,7 @@ use simplicity::{Ihr, RedeemNode, Value as SimValue};
 use crate::array::Unfolder;
 use crate::debug::{DebugSymbols, TrackedCallName};
 use crate::either::Either;
-use crate::jet::{source_type, target_type};
+use crate::jet::JetHL;
 use crate::str::AliasName;
 use crate::types::AliasedType;
 use crate::value::StructuralValue;
@@ -212,7 +212,7 @@ impl<'a> DefaultTracker<'a> {
         match output.clone() {
             NodeOutput::Success(mut output_frame) => {
                 let target_ty = &node.arrow().target;
-                let jet_target_ty = resolve_jet_type(&target_type(jet));
+                let jet_target_ty = resolve_jet_type(&jet.target_type());
 
                 let output_value = SimValue::from_padded_bits(&mut output_frame, target_ty)
                     .expect("output from bit machine is always well-formed");
@@ -319,7 +319,7 @@ impl ExecTracker for DefaultTracker<'_> {
 
 /// Parses jet input arguments from the bit machine's read frame.
 fn parse_jet_arguments(jet: Elements, input_frame: &mut FrameIter) -> Result<Vec<Value>, String> {
-    let source_types = source_type(jet);
+    let source_types = jet.source_type();
     if source_types.is_empty() {
         return Ok(vec![]);
     }


### PR DESCRIPTION
This PR advances progress on issue #224. It introduces a new `JetHL` trait, which encapsulates all logic required for `simc` to function in addition to the default Jet methods. The follow-up would include inserting `JetHL` between interface invocations and the topmost `simc` entrypoint.