### PR TITLE
Reduce dependence on Elements type

### DIFF
--- a/fuzz/fuzz_targets/compile_parse_tree.rs
+++ b/fuzz/fuzz_targets/compile_parse_tree.rs
@@ -3,6 +3,7 @@
 #[cfg(any(fuzzing, test))]
 fn do_test(data: &[u8]) {
     use arbitrary::Arbitrary;
+    use simplicityhl::ast::ElementsJetHinter;
     use std::sync::Arc;
 
     use simplicityhl::error::{ErrorCollector, WithContent};
@@ -23,16 +24,17 @@ fn do_test(data: &[u8]) {
         return;
     };
 
-    let ast_program = match ast::Program::analyze(&driver_program) {
-        Ok(x) => x,
-        Err(_) => return,
-    };
+    let ast_program =
+        match ast::Program::analyze(&driver_program, Box::new(ElementsJetHinter::new())) {
+            Ok(x) => x,
+            Err(_) => return,
+        };
     let arguments = match Arguments::arbitrary_of_type(&mut u, ast_program.parameters()) {
         Ok(arguments) => arguments,
         Err(..) => return,
     };
     let simplicity_named_construct = ast_program
-        .compile(arguments, false)
+        .compile(arguments, false, Box::new(ElementsJetHinter::new()))
         .with_content("")
         .expect("AST should compile with given arguments");
     let _simplicity_commit = named::forget_names(&simplicity_named_construct);

--- a/fuzz/fuzz_targets/compile_text.rs
+++ b/fuzz/fuzz_targets/compile_text.rs
@@ -28,6 +28,7 @@ fn slow_input(program_text: &str) -> bool {
 fn do_test(data: &[u8]) -> libfuzzer_sys::Corpus {
     use arbitrary::Arbitrary;
     use libfuzzer_sys::Corpus;
+    use simplicityhl::ast::ElementsJetHinter;
     use simplicityhl::{ArbitraryOfType, Arguments};
 
     let mut u = arbitrary::Unstructured::new(data);
@@ -39,7 +40,10 @@ fn do_test(data: &[u8]) -> libfuzzer_sys::Corpus {
     if slow_input(&program_text) {
         return Corpus::Reject;
     }
-    let template = match simplicityhl::TemplateProgram::new(program_text) {
+    let template = match simplicityhl::TemplateProgram::new(
+        program_text,
+        Box::new(ElementsJetHinter::new()),
+    ) {
         Ok(x) => x,
         Err(..) => return Corpus::Keep,
     };

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,12 +1,11 @@
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::num::NonZeroUsize;
-use std::str::FromStr;
 use std::sync::Arc;
 
 use either::Either;
 use miniscript::iter::{Tree, TreeLike};
-use simplicity::jet::Elements;
+use simplicity::jet::{Elements, Jet};
 
 use crate::debug::{CallTracker, DebugSymbols, TrackedCallName};
 use crate::driver::{FileScoped, SymbolTable, MAIN_MODULE, MAIN_STR};
@@ -271,10 +270,11 @@ impl Call {
 impl_eq_hash!(Call; name, args);
 
 /// Name of a called function.
-#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+#[derive(Clone, Debug, Eq, Hash)]
+#[allow(clippy::derived_hash_with_manual_eq)] // see comment on manual `PartialEq` impl below
 pub enum CallName {
-    /// Elements jet.
-    Jet(Elements),
+    /// Jet type.
+    Jet(Box<dyn JetHL>),
     /// [`Either::unwrap_left`].
     UnwrapLeft(ResolvedType),
     /// [`Either::unwrap_right`].
@@ -302,6 +302,30 @@ pub enum CallName {
     ArrayFold(CustomFunction, NonZeroUsize),
     /// Loop over the given function a bounded number of times until it returns success.
     ForWhile(CustomFunction, Pow2Usize),
+}
+
+// Manually implemented because the 1.74 (MSRV) derive expands to a body that
+// moves out of the non-Copy `Box<dyn Jet>` field, later rustc versions are
+// fine.
+impl PartialEq for CallName {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Jet(a), Self::Jet(b)) => a == b,
+            (Self::UnwrapLeft(a), Self::UnwrapLeft(b)) => a == b,
+            (Self::UnwrapRight(a), Self::UnwrapRight(b)) => a == b,
+            (Self::IsNone(a), Self::IsNone(b)) => a == b,
+            (Self::Unwrap, Self::Unwrap) => true,
+            (Self::Assert, Self::Assert) => true,
+            (Self::Panic, Self::Panic) => true,
+            (Self::Debug, Self::Debug) => true,
+            (Self::TypeCast(a), Self::TypeCast(b)) => a == b,
+            (Self::Custom(a), Self::Custom(b)) => a == b,
+            (Self::Fold(a, b), Self::Fold(c, d)) => a == c && b == d,
+            (Self::ArrayFold(a, b), Self::ArrayFold(c, d)) => a == c && b == d,
+            (Self::ForWhile(a, b), Self::ForWhile(c, d)) => a == c && b == d,
+            _ => false,
+        }
+    }
 }
 
 /// Definition of a custom function.
@@ -515,6 +539,49 @@ impl TreeLike for ExprTree<'_> {
     }
 }
 
+/// Object which produces a specific kind of jet.
+///
+/// All methods return a `dyn Jet` rather than the specific jet so that the trait itself
+/// can be object-safe. However, implementors of this trait **must** ensure that
+/// all methods return the same kind of jet to avoid panics.
+///
+/// Users may rely on this property for correctness of their code, though since this
+/// is a safe trait, of course they may not rely on it for soundness.
+pub trait JetHinter: std::fmt::Debug + Send + Sync {
+    /// Attempts to parse a jet from a string.
+    fn parse_jet(&self, name: &str) -> Option<Box<dyn JetHL>>;
+    /// Constructs an instance of the `verify` jet.
+    fn construct_verify(&self) -> Box<dyn JetHL>;
+
+    /// Clones the `JetHinter` into a boxed trait object.
+    fn clone_box(&self) -> Box<dyn JetHinter>;
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ElementsJetHinter;
+
+impl ElementsJetHinter {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl JetHinter for ElementsJetHinter {
+    fn parse_jet(&self, name: &str) -> Option<Box<dyn JetHL>> {
+        Elements::parse(name)
+            .ok()
+            .map(|jet| -> Box<dyn JetHL> { Box::new(jet) })
+    }
+
+    fn construct_verify(&self) -> Box<dyn JetHL> {
+        Box::new(Elements::Verify)
+    }
+
+    fn clone_box(&self) -> Box<dyn JetHinter> {
+        Box::new(Self)
+    }
+}
+
 /// Scope for generating the abstract syntax tree.
 ///
 /// The scope is used for:
@@ -522,7 +589,6 @@ impl TreeLike for ExprTree<'_> {
 /// 2. Resolving type aliases
 /// 3. Assigning types to each witness expression
 /// 4. Resolving calls to custom functions
-#[derive(Clone, Debug, Eq, PartialEq)]
 struct Scope {
     file_id: usize,
     variables: Vec<HashMap<Identifier, ResolvedType>>,
@@ -534,6 +600,7 @@ struct Scope {
     functions_table: SymbolTable<FunctionName>,
     is_main: bool,
     call_tracker: CallTracker,
+    jet_hinter: Box<dyn JetHinter>,
 }
 
 impl Default for Scope {
@@ -541,6 +608,8 @@ impl Default for Scope {
         Self::new(
             SymbolTable::<AliasName>::default(),
             SymbolTable::<FunctionName>::default(),
+            // TODO: Should be passed in global configuration
+            Box::new(ElementsJetHinter),
         )
     }
 }
@@ -549,6 +618,7 @@ impl Scope {
     pub fn new(
         aliases_table: SymbolTable<AliasName>,
         functions_table: SymbolTable<FunctionName>,
+        jet_hinter: Box<dyn JetHinter>,
     ) -> Self {
         Self {
             file_id: MAIN_MODULE,
@@ -561,6 +631,7 @@ impl Scope {
             functions_table,
             is_main: false,
             call_tracker: CallTracker::default(),
+            jet_hinter,
         }
     }
 
@@ -847,9 +918,12 @@ trait AbstractSyntaxTree: Sized {
 }
 
 impl Program {
-    pub fn analyze(from: &driver::Program) -> Result<Self, RichError> {
+    pub fn analyze(
+        from: &driver::Program,
+        jet_hinter: Box<dyn JetHinter>,
+    ) -> Result<Self, RichError> {
         let unit = ResolvedType::unit();
-        let mut scope = Scope::new(from.aliases().clone(), from.functions().clone());
+        let mut scope = Scope::new(from.aliases().clone(), from.functions().clone(), jet_hinter);
 
         let items = from
             .items()
@@ -1442,8 +1516,8 @@ impl AbstractSyntaxTree for CallName {
         scope: &mut Scope,
     ) -> Result<Self, RichError> {
         match from.name() {
-            parse::CallName::Jet(name) => match Elements::from_str(name.as_inner()) {
-                Ok(jet) if !jet.is_disabled() => Ok(Self::Jet(jet)),
+            parse::CallName::Jet(name) => match scope.jet_hinter.parse_jet(name.as_inner()) {
+                Some(jet) if !jet.is_disabled() => Ok(Self::Jet(jet)),
                 _ => Err(Error::JetDoesNotExist(name.clone())).with_span(from),
             },
             parse::CallName::UnwrapLeft(right_ty) => scope
@@ -1653,7 +1727,7 @@ impl AsRef<Span> for ModuleAssignment {
 
 #[cfg(test)]
 mod alias_scope_regression_tests {
-    use super::Program;
+    use super::{ElementsJetHinter, Program};
     use crate::driver::tests::setup_graph;
     use crate::error::ErrorCollector;
 
@@ -1666,7 +1740,7 @@ mod alias_scope_regression_tests {
             .unwrap()
             .expect("driver build should succeed");
 
-        Program::analyze(&driver_program)
+        Program::analyze(&driver_program, Box::new(ElementsJetHinter))
             .map(|_| ())
             .map_err(|e| e.to_string())
     }

--- a/src/compile/mod.rs
+++ b/src/compile/mod.rs
@@ -5,19 +5,17 @@ mod builtins;
 use std::sync::Arc;
 
 use either::Either;
-use simplicity::jet::Elements;
 use simplicity::node::{CoreConstructible as _, JetConstructible as _};
 use simplicity::{types, Cmr, FailEntropy};
 
 use self::builtins::array_fold;
 use crate::array::{BTreeSlice, Partition};
 use crate::ast::{
-    Call, CallName, Expression, ExpressionInner, Match, Program, SingleExpression,
+    Call, CallName, Expression, ExpressionInner, JetHinter, Match, Program, SingleExpression,
     SingleExpressionInner, Statement,
 };
 use crate::debug::CallTracker;
 use crate::error::{Error, RichError, Span, WithSpan};
-use crate::jet::JetHL;
 use crate::named::{self, CoreExt, PairBuilder};
 use crate::num::{NonZeroPow2Usize, Pow2Usize};
 use crate::pattern::{BasePattern, Pattern};
@@ -39,7 +37,7 @@ type ProgNode<'brand> = Arc<named::ConstructNode<'brand>>;
 /// Each (nested) block expression introduces a new scope.
 /// Bindings from inner scopes overwrite bindings from outer scopes.
 /// Bindings live as long as their scope.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 struct Scope<'brand> {
     /// For each scope, the set of assigned variables.
     ///
@@ -73,6 +71,7 @@ struct Scope<'brand> {
     /// Values for parameters inside the SimplicityHL program.
     arguments: Arguments,
     include_debug_symbols: bool,
+    jet_hinter: Box<dyn JetHinter>,
 }
 
 impl<'brand> Scope<'brand> {
@@ -89,6 +88,7 @@ impl<'brand> Scope<'brand> {
         call_tracker: Arc<CallTracker>,
         arguments: Arguments,
         include_debug_symbols: bool,
+        jet_hinter: Box<dyn JetHinter>,
     ) -> Self {
         Self {
             variables: vec![vec![Pattern::Ignore]],
@@ -96,6 +96,7 @@ impl<'brand> Scope<'brand> {
             call_tracker,
             arguments,
             include_debug_symbols,
+            jet_hinter,
         }
     }
 
@@ -107,6 +108,7 @@ impl<'brand> Scope<'brand> {
             call_tracker: Arc::clone(&self.call_tracker),
             arguments: self.arguments.clone(),
             include_debug_symbols: self.include_debug_symbols,
+            jet_hinter: self.jet_hinter.clone_box(),
         }
     }
 
@@ -264,6 +266,7 @@ impl Program {
         &self,
         arguments: Arguments,
         include_debug_symbols: bool,
+        jet_hinter: Box<dyn JetHinter>,
     ) -> Result<Arc<named::CommitNode>, RichError> {
         types::Context::with_context(|ctx| {
             let mut scope = Scope::new(
@@ -271,6 +274,7 @@ impl Program {
                 Arc::clone(self.call_tracker()),
                 arguments,
                 include_debug_symbols,
+                jet_hinter,
             );
 
             let main = self.main();
@@ -380,7 +384,7 @@ impl Call {
 
         match self.name() {
             CallName::Jet(name) => {
-                let jet = ProgNode::jet(scope.ctx(), name);
+                let jet = ProgNode::jet(scope.ctx(), name.as_jet());
                 scope.with_debug_symbol(args, &jet, self)
             }
             CallName::UnwrapLeft(..) => {
@@ -411,7 +415,7 @@ impl Call {
                 args.comp(&body).with_span(self)
             }
             CallName::Assert => {
-                let jet = ProgNode::jet(scope.ctx(), &*Elements::verify());
+                let jet = ProgNode::jet(scope.ctx(), scope.jet_hinter.construct_verify().as_jet());
                 scope.with_debug_symbol(args, &jet, self)
             }
             CallName::Panic => {

--- a/src/jet.rs
+++ b/src/jet.rs
@@ -3,14 +3,36 @@ use crate::types::BuiltinAlias::*;
 use crate::types::UIntType::*;
 use crate::types::*;
 
+use simplicity::jet::DynJet;
 use simplicity::jet::Elements;
 use simplicity::jet::Jet;
 
-pub trait JetHL {
+pub trait JetHL: DynJet + Jet + std::fmt::Debug + Send + Sync + 'static {
     fn source_type(&self) -> Vec<AliasedType>;
     fn target_type(&self) -> AliasedType;
-    fn verify() -> Box<dyn Jet>;
     fn is_disabled(&self) -> bool;
+    fn clone_box(&self) -> Box<dyn JetHL>;
+    fn as_jet(&self) -> &dyn Jet;
+}
+
+impl Clone for Box<dyn JetHL> {
+    fn clone(&self) -> Self {
+        (**self).clone_box()
+    }
+}
+
+impl PartialEq for Box<dyn JetHL> {
+    fn eq(&self, other: &Self) -> bool {
+        (**self).dyn_eq(other.as_jet())
+    }
+}
+
+impl Eq for Box<dyn JetHL> {}
+
+impl std::hash::Hash for Box<dyn JetHL> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        (**self).dyn_hash(state)
+    }
 }
 
 impl JetHL for Elements {
@@ -22,12 +44,16 @@ impl JetHL for Elements {
         target_type(*self)
     }
 
-    fn verify() -> Box<dyn Jet> {
-        Box::new(Elements::Verify)
-    }
-
     fn is_disabled(&self) -> bool {
         matches!(self, Elements::CheckSigVerify | Elements::Verify)
+    }
+
+    fn clone_box(&self) -> Box<dyn JetHL> {
+        Box::new(*self)
+    }
+
+    fn as_jet(&self) -> &dyn Jet {
+        self
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,10 +51,11 @@ pub use crate::witness::{Arguments, Parameters, WitnessTypes, WitnessValues};
 /// The template of a SimplicityHL program.
 ///
 /// A template has parameterized values that need to be supplied with arguments.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Debug)]
 pub struct TemplateProgram {
     simfony: ast::Program,
     file: Arc<str>,
+    jet_hinter: Box<dyn ast::JetHinter>,
 }
 
 impl TemplateProgram {
@@ -66,6 +67,7 @@ impl TemplateProgram {
     pub fn new_with_dep(
         source: CanonSourceFile,
         dependency_map: &DependencyMap,
+        jet_hinter: Box<dyn ast::JetHinter>,
     ) -> Result<Self, String> {
         let mut error_handler = ErrorCollector::new();
 
@@ -88,10 +90,12 @@ impl TemplateProgram {
             .ok_or_else(|| error_handler.to_string())?;
 
         // 3. AST Analysis
-        let ast_program = ast::Program::analyze(&driver_program).with_source(source.clone())?;
+        let ast_program = ast::Program::analyze(&driver_program, jet_hinter.clone_box())
+            .with_source(source.clone())?;
         Ok(Self {
             simfony: ast_program,
             file: source.content(),
+            jet_hinter,
         })
     }
 
@@ -100,7 +104,10 @@ impl TemplateProgram {
     /// ## Errors
     ///
     /// The string is not a valid SimplicityHL program.
-    pub fn new<Str: Into<Arc<str>>>(s: Str) -> Result<Self, String> {
+    pub fn new<Str: Into<Arc<str>>>(
+        s: Str,
+        jet_hinter: Box<dyn ast::JetHinter>,
+    ) -> Result<Self, String> {
         let file = s.into();
         let source = SourceFile::anonymous(file.clone());
         let mut error_handler = ErrorCollector::new();
@@ -113,10 +120,12 @@ impl TemplateProgram {
         };
 
         if let Some(program) = driver_program {
-            let ast_program = ast::Program::analyze(&program).with_content(Arc::clone(&file))?;
+            let ast_program = ast::Program::analyze(&program, jet_hinter.clone_box())
+                .with_content(Arc::clone(&file))?;
             Ok(Self {
                 simfony: ast_program,
                 file,
+                jet_hinter,
             })
         } else {
             Err(ErrorCollector::to_string(&error_handler))?
@@ -150,7 +159,11 @@ impl TemplateProgram {
 
         let commit = self
             .simfony
-            .compile(arguments, include_debug_symbols)
+            .compile(
+                arguments,
+                include_debug_symbols,
+                self.jet_hinter.clone_box(),
+            )
             .with_content(Arc::clone(&self.file))?;
 
         Ok(CompiledProgram {
@@ -190,8 +203,9 @@ impl CompiledProgram {
         dependency_map: &DependencyMap,
         arguments: Arguments,
         include_debug_symbols: bool,
+        jet_hinter: Box<dyn ast::JetHinter>,
     ) -> Result<Self, String> {
-        TemplateProgram::new_with_dep(source, dependency_map)
+        TemplateProgram::new_with_dep(source, dependency_map, jet_hinter.clone_box())
             .and_then(|template| template.instantiate(arguments, include_debug_symbols))
     }
 
@@ -205,8 +219,9 @@ impl CompiledProgram {
         s: Str,
         arguments: Arguments,
         include_debug_symbols: bool,
+        jet_hinter: Box<dyn ast::JetHinter>,
     ) -> Result<Self, String> {
-        TemplateProgram::new(s)
+        TemplateProgram::new(s, jet_hinter.clone_box())
             .and_then(|template| template.instantiate(arguments, include_debug_symbols))
     }
 
@@ -290,8 +305,9 @@ impl SatisfiedProgram {
         arguments: Arguments,
         witness_values: WitnessValues,
         include_debug_symbols: bool,
+        jet_hinter: Box<dyn ast::JetHinter>,
     ) -> Result<Self, String> {
-        let compiled = CompiledProgram::new(s, arguments, include_debug_symbols)?;
+        let compiled = CompiledProgram::new(s, arguments, include_debug_symbols, jet_hinter)?;
         compiled.satisfy(witness_values)
     }
 
@@ -396,6 +412,7 @@ pub trait ArbitraryOfType: Sized {
 
 #[cfg(test)]
 pub(crate) mod tests {
+    use crate::ast::ElementsJetHinter;
     use crate::parse::ParseFromStr;
     use crate::resolution::tests::canon;
     use crate::resolution::DependencyMapBuilder;
@@ -429,7 +446,11 @@ pub(crate) mod tests {
                 Arc::from(program_text),
             );
 
-            let program = match TemplateProgram::new_with_dep(source, dependency_map) {
+            let program = match TemplateProgram::new_with_dep(
+                source,
+                dependency_map,
+                Box::new(ElementsJetHinter::new()),
+            ) {
                 Ok(x) => x,
                 Err(error) => panic!("{error}"),
             };
@@ -443,7 +464,10 @@ pub(crate) mod tests {
         }
 
         pub fn template_text(program_text: Cow<str>) -> Self {
-            let program = match TemplateProgram::new(program_text.as_ref()) {
+            let program = match TemplateProgram::new(
+                program_text.as_ref(),
+                Box::new(ElementsJetHinter::new()),
+            ) {
                 Ok(x) => x,
                 Err(error) => panic!("{error}"),
             };
@@ -743,7 +767,7 @@ pub(crate) mod tests {
     #[test]
     fn test_anonymous_source_compiles_without_dependencies() {
         let code = "fn main() { assert!(true); }";
-        let program = TemplateProgram::new(code);
+        let program = TemplateProgram::new(code, Box::new(ElementsJetHinter::new()));
         assert!(
             program.is_ok(),
             "TemplateProgram::new should successfully compile anonymous source files without requiring canonical paths"
@@ -949,6 +973,7 @@ fn main() {
             Arguments::default(),
             WitnessValues::default(),
             false,
+            Box::new(ElementsJetHinter::new()),
         ) {
             Ok(_) => panic!("Accepted faulty program"),
             Err(error) => {
@@ -1155,6 +1180,7 @@ mod error_tests {
 
     use super::*;
 
+    use crate::ast::ElementsJetHinter;
     use crate::resolution::tests::canon;
     use crate::resolution::DependencyMapBuilder;
     use crate::source::CanonPath;
@@ -1192,8 +1218,12 @@ mod error_tests {
 
         let dependencies = dependency_map(&root_dir, "lib", &lib_dir);
 
-        let err = TemplateProgram::new_with_dep(source_file(&main_path), &dependencies)
-            .expect_err("dependency body has a type error");
+        let err = TemplateProgram::new_with_dep(
+            source_file(&main_path),
+            &dependencies,
+            Box::new(ElementsJetHinter::new()),
+        )
+        .expect_err("dependency body has a type error");
         let dependency_source = canon(&bad_path).as_path().display().to_string();
 
         assert!(
@@ -1218,8 +1248,12 @@ mod error_tests {
         ws.create_file("workspace/lib/base.simf", "pub fn one() -> u32 { 1 }\n");
 
         let dependencies = dependency_map(&root_dir, "lib", &lib_dir);
-        let _err = TemplateProgram::new_with_dep(source_file(&main_path), &dependencies)
-            .expect_err("omitted-context dependencies");
+        let _err = TemplateProgram::new_with_dep(
+            source_file(&main_path),
+            &dependencies,
+            Box::new(ElementsJetHinter::new()),
+        )
+        .expect_err("omitted-context dependencies");
     }
 
     #[test]
@@ -1233,8 +1267,12 @@ mod error_tests {
         );
         let dependencies = dependency_map(&root_dir, "lib", &lib_dir);
 
-        let err = TemplateProgram::new_with_dep(source_file(&main_path), &dependencies)
-            .expect_err("missing imported module should fail");
+        let err = TemplateProgram::new_with_dep(
+            source_file(&main_path),
+            &dependencies,
+            Box::new(ElementsJetHinter::new()),
+        )
+        .expect_err("missing imported module should fail");
 
         assert!(
             err.contains("missing.simf"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use base64::display::Base64Display;
 use base64::engine::general_purpose::STANDARD;
 use clap::{Arg, ArgAction, Command};
 
+use simplicityhl::ast::ElementsJetHinter;
 use simplicityhl::{
     resolution::DependencyMapBuilder, source::CanonPath, source::CanonSourceFile, AbiMeta,
     CompiledProgram,
@@ -169,15 +170,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     let source = CanonSourceFile::new(main_path.clone(), std::sync::Arc::from(main_text));
-    let compiled =
-        match CompiledProgram::new_with_dep(source, &dependencies, args_opt, include_debug_symbols)
-        {
-            Ok(program) => program,
-            Err(e) => {
-                eprintln!("{}", e);
-                std::process::exit(1);
-            }
-        };
+    let compiled = match CompiledProgram::new_with_dep(
+        source,
+        &dependencies,
+        args_opt,
+        include_debug_symbols,
+        Box::new(ElementsJetHinter::new()),
+    ) {
+        Ok(program) => program,
+        Err(e) => {
+            eprintln!("{}", e);
+            std::process::exit(1);
+        }
+    };
 
     #[cfg(feature = "serde")]
     let witness_opt = matches

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -361,6 +361,7 @@ mod tests {
     use simplicity::jet::elements::{ElementsEnv, ElementsUtxo};
     use simplicity::Cmr;
 
+    use crate::ast::ElementsJetHinter;
     use crate::elements::confidential::Asset;
     use crate::elements::hashes::Hash;
     use crate::elements::pset::Input;
@@ -438,7 +439,8 @@ mod tests {
 
     #[test]
     fn test_debug_and_jet_tracing() {
-        let program = TemplateProgram::new(TEST_PROGRAM).unwrap();
+        let program =
+            TemplateProgram::new(TEST_PROGRAM, Box::new(ElementsJetHinter::new())).unwrap();
         let program = program.instantiate(Arguments::default(), true).unwrap();
         let satisfied = program.satisfy(WitnessValues::default()).unwrap();
 
@@ -507,7 +509,8 @@ mod tests {
     fn test_arith_jet_trace_regression() {
         let env = create_test_env();
 
-        let program = TemplateProgram::new(TEST_ARITHMETIC_JETS).unwrap();
+        let program =
+            TemplateProgram::new(TEST_ARITHMETIC_JETS, Box::new(ElementsJetHinter::new())).unwrap();
         let program = program.instantiate(Arguments::default(), true).unwrap();
         let satisfied = program.satisfy(WitnessValues::default()).unwrap();
 
@@ -561,7 +564,9 @@ mod tests {
 
         let env = create_test_env();
 
-        let program = TemplateProgram::new(TEST_FULL_MULTIPLY_JETS).unwrap();
+        let program =
+            TemplateProgram::new(TEST_FULL_MULTIPLY_JETS, Box::new(ElementsJetHinter::new()))
+                .unwrap();
         let program = program.instantiate(Arguments::default(), true).unwrap();
         let satisfied = program.satisfy(WitnessValues::default()).unwrap();
 

--- a/src/witness.rs
+++ b/src/witness.rs
@@ -213,6 +213,7 @@ impl crate::ArbitraryOfType for Arguments {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ast::ElementsJetHinter;
     use crate::error::ErrorCollector;
     use crate::parse::ParseFromStr;
     use crate::value::ValueConstructible;
@@ -232,7 +233,9 @@ mod tests {
             &mut error_collector,
         )
         .expect("driver works");
-        match ast::Program::analyze(&driver_program).map_err(Error::from) {
+        match ast::Program::analyze(&driver_program, Box::new(ElementsJetHinter::new()))
+            .map_err(Error::from)
+        {
             Ok(_) => panic!("Witness reuse was falsely accepted"),
             Err(Error::WitnessReused(..)) => {}
             Err(error) => panic!("Unexpected error: {error}"),
@@ -249,7 +252,13 @@ mod tests {
             WitnessName::from_str_unchecked("A"),
             Value::u16(42),
         )]));
-        match SatisfiedProgram::new(s, Arguments::default(), witness, false) {
+        match SatisfiedProgram::new(
+            s,
+            Arguments::default(),
+            witness,
+            false,
+            Box::new(ElementsJetHinter::new()),
+        ) {
             Ok(_) => panic!("Ill-typed witness assignment was falsely accepted"),
             Err(error) => assert_eq!(
                 "Witness `A` was declared with type `u32` but its assigned value is of type `u16`",
@@ -268,7 +277,12 @@ fn main() {
     assert!(jet::is_zero_32(f()));
 }"#;
 
-        match CompiledProgram::new(s, Arguments::default(), false) {
+        match CompiledProgram::new(
+            s,
+            Arguments::default(),
+            false,
+            Box::new(ElementsJetHinter::new()),
+        ) {
             Ok(_) => panic!("Witness outside main was falsely accepted"),
             Err(error) => {
                 assert!(error


### PR DESCRIPTION
This PR moves forward #224. It introduces `JetHinter`, which parses jet names and provides hints on which jet to use for assertions. It comes into play at the highest possible level — main.rs — and the downstream execution flow is fully derived from it.

As a follow-up, I plan to implement `JetHL` for `Core` with an appropriate `JetHinter` build function and add tests so we can see the effect even better.