### PR TITLE
just: add local check_all

### DIFF
--- a/bitcoind-tests/Cargo.lock
+++ b/bitcoind-tests/Cargo.lock
@@ -634,18 +634,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bc1d4caf89fac26a70747fe603c130093b53c773888797a6329091246d651a"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
 name = "regex-automata"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -681,15 +669,6 @@ name = "ryu"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
-
-[[package]]
-name = "santiago"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de36022292bc2086eb8f55bffa460fef3475e4459b478820711f4c421feb87ec"
-dependencies = [
- "regex",
-]
 
 [[package]]
 name = "secp256k1"
@@ -773,9 +752,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "simplicity-lang"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e57bd4d84853974a212eab24ed89da54f49fbccf5e33e93bcd29f0a6591cd5"
+checksum = "07f79806a665b34e4d8950edd053a991e57915e3924b8b21ac6f2bdd23d9e842"
 dependencies = [
  "bitcoin",
  "bitcoin_hashes",
@@ -785,15 +764,14 @@ dependencies = [
  "ghost-cell",
  "hex-conservative",
  "miniscript",
- "santiago",
  "simplicity-sys",
 ]
 
 [[package]]
 name = "simplicity-sys"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3401ee7331f183a5458c0f5a4b3d5d00bde0fd12e2e03728c537df34efae289"
+checksum = "96d1ec5477c7650b8ef511aa56dccb28f2e8cdb6e87f260ecffdaf0ebfef2d3b"
 dependencies = [
  "bitcoin_hashes",
  "cc",
@@ -801,7 +779,7 @@ dependencies = [
 
 [[package]]
 name = "simplicityhl"
-version = "0.5.0"
+version = "0.6.0-rc.0"
 dependencies = [
  "base64 0.21.2",
  "chumsky",

--- a/bitcoind-tests/tests/common/daemon.rs
+++ b/bitcoind-tests/tests/common/daemon.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 use elements::encode::{deserialize, serialize_hex};
 use elements::hex::FromHex;
-use elementsd::bitcoincore_rpc::jsonrpc::serde_json::{json, Value};
+use elementsd::bitcoincore_rpc::jsonrpc::serde_json::Value;
 use elementsd::bitcoind::bitcoincore_rpc::RpcApi;
 use elementsd::ElementsD;
 use simplicityhl::elements;
@@ -52,7 +52,6 @@ pub trait Call {
     fn get_new_address(&self) -> elements::Address;
     fn send_to_address(&self, addr: &elements::Address, amt: &str) -> elements::Txid;
     fn get_transaction(&self, txid: &elements::Txid) -> elements::Transaction;
-    fn test_mempool_accept(&self, hex: &elements::Transaction) -> bool;
     fn send_raw_transaction(&self, hex: &elements::Transaction) -> elements::Txid;
     fn generate(&self, blocks: u32);
 }
@@ -107,11 +106,5 @@ impl Call for ElementsD {
             "generatetoaddress",
             &[blocks.into(), address.to_string().into()],
         );
-    }
-
-    fn test_mempool_accept(&self, tx: &elements::Transaction) -> bool {
-        let result = self.call("testmempoolaccept", &[json!([serialize_hex(tx)])]);
-        let allowed = result.get(0).unwrap().get("allowed");
-        allowed.unwrap().as_bool().unwrap()
     }
 }

--- a/bitcoind-tests/tests/common/test.rs
+++ b/bitcoind-tests/tests/common/test.rs
@@ -6,13 +6,13 @@ use elements::{confidential, secp256k1_zkp as secp256k1};
 use elementsd::ElementsD;
 use secp256k1::XOnlyPublicKey;
 use simplicity::jet::elements::{ElementsEnv, ElementsUtxo};
+use simplicityhl::ast::ElementsJetHinter;
 use simplicityhl::{elements, simplicity};
 
 use crate::common::daemon::Call;
 
 type FnWitness = fn([u8; 32]) -> simplicityhl::WitnessValues;
 
-#[derive(Clone)]
 pub struct TestCase<'a> {
     pub name: &'static str,
     template: Option<simplicityhl::TemplateProgram>,
@@ -53,8 +53,13 @@ impl<'a> TestCase<'a> {
 
     pub fn program_path<P: AsRef<std::path::Path>>(mut self, path: P) -> Self {
         let text = std::fs::read_to_string(path).expect("path should be readable");
-        let compiled = simplicityhl::CompiledProgram::new(text.as_str(), simplicityhl::Arguments::default(), false)
-            .expect("program should compile");
+        let compiled = simplicityhl::CompiledProgram::new(
+            text.as_str(),
+            simplicityhl::Arguments::default(),
+            false,
+            Box::new(ElementsJetHinter::new()),
+        )
+        .expect("program should compile");
         self.compiled = Some(compiled);
         self
     }
@@ -62,7 +67,8 @@ impl<'a> TestCase<'a> {
     pub fn template_path<P: AsRef<std::path::Path>>(mut self, path: P) -> Self {
         let text = std::fs::read_to_string(path).expect("path should be readable");
         let template =
-            simplicityhl::TemplateProgram::new(text.as_str()).expect("program should compile");
+            simplicityhl::TemplateProgram::new(text.as_str(), Box::new(ElementsJetHinter::new()))
+                .expect("program should compile");
         self.template = Some(template);
         self
     }
@@ -205,7 +211,7 @@ impl<'a> TestCase<'a> {
         let satisfied_program = compiled
             .satisfy(witness_values)
             .expect("program should be satisfiable");
-        let (program_bytes, witness_bytes) = satisfied_program.redeem().encode_to_vec();
+        let (program_bytes, witness_bytes) = satisfied_program.redeem().to_vec_with_witness();
         psbt.inputs_mut()[0].final_script_witness = Some(vec![
             witness_bytes,
             program_bytes,

--- a/fuzz/fuzz_targets/parse_witness_json_rtt.rs
+++ b/fuzz/fuzz_targets/parse_witness_json_rtt.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(fuzzing, no_main)]
 
-#[cfg(any(fuzzing, test))]
+#[cfg(fuzzing)]
 fn do_test(witness_values: simplicityhl::WitnessValues) {
     let witness_text = serde_json::to_string(&witness_values)
         .expect("Witness map should be convertible into JSON");

--- a/justfile
+++ b/justfile
@@ -44,13 +44,43 @@ check_fuzz:
 build_fuzz:
     cargo-fuzz check
 
+# Check the standalone fuzz crate compiles
+check_fuzz_crate:
+    cargo rbmt --lock-file existing run --toolchain nightly -- check --manifest-path fuzz/Cargo.toml
+
+# Run fuzz target unit tests
+check_fuzz_bins:
+    cargo rbmt --lock-file existing run --toolchain nightly -- test --manifest-path fuzz/Cargo.toml --bins
+
+# Run CI-equivalent checks plus strict non-mutating RBMT checks
+check_all:
+    cargo rbmt toolchains
+    cargo rbmt --lock-file existing test --toolchain stable
+    cargo rbmt --lock-file existing test --toolchain nightly
+    cargo rbmt --lock-file existing test --toolchain msrv
+    cargo test
+    cargo rbmt --lock-file existing lint
+    cargo rbmt --lock-file existing docs
+    cargo rbmt --lock-file existing docsrs
+    cargo rbmt fmt --check
+    rustup target add wasm32-unknown-unknown
+    just build_wasm
+    cargo rbmt tools cargo-fuzz
+    just check_fuzz_crate
+    just check_fuzz_bins
+    cargo rbmt --lock-file existing integration
+    cargo rbmt --lock-file existing bench
+    cargo rbmt --lock-file existing api --baseline master
+    cargo rbmt --lock-file existing prerelease --baseline master
+    just build_integration
+
 # Build integration tests
 build_integration:
-    cargo test --no-run --manifest-path ./bitcoind-tests/Cargo.toml
+    cargo test --locked --no-run --manifest-path ./bitcoind-tests/Cargo.toml
 
 # Run integration tests (requires custom elementsd)
 check_integration:
-    cargo test --manifest-path ./bitcoind-tests/Cargo.toml
+    cargo test --locked --manifest-path ./bitcoind-tests/Cargo.toml
 
 # Build code for the WASM target
 build_wasm:


### PR DESCRIPTION
Added `check_fuzz_crate`, `check_fuzz_bins`, and `check_all` in [`justfile`](justfile), locked integration build/test recipes (kept the full `check_fuzz` fuzz-run out of `check_all`) updated the integration helper for the current `JetHinter` API in [`test.rs`](bitcoind-tests/tests/common/test.rs), refreshed [`Cargo.lock`](bitcoind-tests/Cargo.lock), and removed the unused `test_mempool_accept` helper from [`daemon.rs`](bitcoind-tests/tests/common/daemon.rs)