### PR TITLE
Add module parser

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -74,8 +74,10 @@ pub enum Item {
     TypeAlias,
     /// A function.
     Function(Function),
-    /// A module, which is ignored.
+    Use,
     Module,
+    /// A placeholder used for error recovery during parsing.
+    Ignored,
 }
 
 /// Definition of a function.
@@ -984,7 +986,11 @@ impl AbstractSyntaxTree for Item {
                 Error::UseKeywordIsNotSupported,
                 *use_decl.span(),
             )),
-            parse::Item::Module => Ok(Self::Module),
+            parse::Item::Module(module) => Err(RichError::new(
+                Error::ModuleKeywordIsNotSupported,
+                *module.span(),
+            )),
+            parse::Item::Ignored => Ok(Self::Ignored),
         };
 
         scope.file_id = previous_file_id;
@@ -1658,48 +1664,6 @@ impl AbstractSyntaxTree for Match {
                 pattern: from.right().pattern().clone(),
                 expression: ast_r,
             },
-            span: *from.as_ref(),
-        })
-    }
-}
-
-impl AbstractSyntaxTree for Module {
-    type From = parse::Module;
-
-    fn analyze(from: &Self::From, ty: &ResolvedType, scope: &mut Scope) -> Result<Self, RichError> {
-        assert!(ty.is_unit(), "Modules cannot return anything");
-        assert!(scope.is_topmost(), "Modules live in the topmost scope only");
-        let assignments = from
-            .assignments()
-            .iter()
-            .map(|s| ModuleAssignment::analyze(s, ty, scope))
-            .collect::<Result<Arc<[ModuleAssignment]>, RichError>>()?;
-        debug_assert!(scope.is_topmost());
-
-        Ok(Self {
-            name: from.name().shallow_clone(),
-            span: *from.as_ref(),
-            assignments,
-        })
-    }
-}
-
-impl AbstractSyntaxTree for ModuleAssignment {
-    type From = parse::ModuleAssignment;
-
-    fn analyze(from: &Self::From, ty: &ResolvedType, scope: &mut Scope) -> Result<Self, RichError> {
-        assert!(ty.is_unit(), "Assignments cannot return anything");
-        let ty_expr = scope.resolve(from.ty()).with_span(from)?;
-        let expression = Expression::analyze(from.expression(), &ty_expr, scope)?;
-        let value = Value::from_const_expr(&expression)
-            .ok_or(Error::ExpressionUnexpectedType {
-                ty: ty_expr.clone(),
-            })
-            .with_span(from.expression())?;
-
-        Ok(Self {
-            name: from.name().clone(),
-            value,
             span: *from.as_ref(),
         })
     }

--- a/src/driver/resolve_order.rs
+++ b/src/driver/resolve_order.rs
@@ -68,7 +68,8 @@ impl Program {
                 }
 
                 // Safe to skip: `Use` items are handled earlier in the loop, and `Module` currently has no functionality.
-                parse::Item::Module | parse::Item::Use(_) => continue,
+                // It will handle properly in the following commits.
+                parse::Item::Module(_) | parse::Item::Use(_) | parse::Item::Ignored => continue,
             }
             items.push(new_elem);
         }
@@ -238,7 +239,8 @@ impl DependencyGraph {
                     }
 
                     // Safe to skip: `Use` items are handled earlier in the loop, and `Module` currently has no functionality.
-                    parse::Item::Module | parse::Item::Use(_) => continue,
+                    // It will handle properly in the following commits.
+                    parse::Item::Module(_) | parse::Item::Use(_) | parse::Item::Ignored => continue,
                 }
                 items.push(new_elem);
             }

--- a/src/error.rs
+++ b/src/error.rs
@@ -633,7 +633,9 @@ pub enum Error {
         declared: ResolvedType,
         assigned: ResolvedType,
     },
+    // TODO: Remove these once `use` and `mod` are supported by the AST
     UseKeywordIsNotSupported,
+    ModuleKeywordIsNotSupported,
 }
 
 #[rustfmt::skip]
@@ -859,6 +861,10 @@ impl fmt::Display for Error {
             Error::UseKeywordIsNotSupported => write!(
                 f,
                 "The `use` keyword is not supported yet"
+            ),
+            Error::ModuleKeywordIsNotSupported => write!(
+                f,
+                "The `mod` keyword is not supported yet"
             ),
         }
     }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -49,7 +49,6 @@ impl_eq_hash!(Program; items);
 
 /// An item is a component of a program.
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum Item {
     /// A type alias.
     TypeAlias(TypeAlias),
@@ -58,8 +57,13 @@ pub enum Item {
     /// An import declaration (e.g., `use math::add`) that brings another
     /// [`Item`] into the current scope.
     Use(UseDecl),
-    /// A module, which is ignored.
-    Module,
+    /// A module containing a collection of nested [`Item`].
+    Module(Module),
+    /// A placeholder used exclusively for error recovery during parsing.
+    ///
+    /// When the parser encounters a syntax error, it skips the malformed tokens
+    /// until it reaches a valid top-level keyword and inserts `Ignored` into the AST.
+    Ignored,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Default)]
@@ -621,50 +625,31 @@ impl MatchPattern {
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct Module {
+    file_id: usize,
+    visibility: Visibility,
     name: ModuleName,
-    assignments: Arc<[ModuleAssignment]>,
+    items: Arc<[Item]>,
     span: Span,
 }
 
 impl Module {
+    pub fn visibility(&self) -> &Visibility {
+        &self.visibility
+    }
+
     /// Access the name of the module.
     pub fn name(&self) -> &ModuleName {
         &self.name
     }
 
     /// Access the assignments of the module.
-    pub fn assignments(&self) -> &[ModuleAssignment] {
-        &self.assignments
+    pub fn items(&self) -> &[Item] {
+        &self.items
     }
 
     /// Access the span of the module.
     pub fn span(&self) -> &Span {
         &self.span
-    }
-}
-
-#[derive(Clone, Debug, Eq, PartialEq, Hash)]
-pub struct ModuleAssignment {
-    name: WitnessName,
-    ty: AliasedType,
-    expression: Expression,
-    span: Span,
-}
-
-impl ModuleAssignment {
-    /// Access the assigned witness name.
-    pub fn name(&self) -> &WitnessName {
-        &self.name
-    }
-
-    /// Access the assigned witness type.
-    pub fn ty(&self) -> &AliasedType {
-        &self.ty
-    }
-
-    /// Access the assigned witness expression.
-    pub fn expression(&self) -> &Expression {
-        &self.expression
     }
 }
 
@@ -683,10 +668,8 @@ impl fmt::Display for Item {
             Self::TypeAlias(alias) => write!(f, "{alias}"),
             Self::Function(function) => write!(f, "{function}"),
             Self::Use(use_declaration) => write!(f, "{use_declaration}"),
-            // The parse tree contains no information about the contents of modules.
-            // We print a random empty module `mod witness {}` here
-            // so that `from_string(to_string(x)) = x` holds for all trees `x`.
-            Self::Module => write!(f, "mod witness {{}}"),
+            Self::Module(module) => write!(f, "{module}"),
+            Self::Ignored => Ok(()),
         }
     }
 }
@@ -726,6 +709,12 @@ impl fmt::Display for Function {
             write!(f, " -> {ty}")?;
         }
         write!(f, " {}", self.body())
+    }
+}
+
+impl fmt::Display for FunctionParam {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}: {}", self.identifier(), self.ty())
     }
 }
 
@@ -778,9 +767,19 @@ impl fmt::Display for UseItems {
     }
 }
 
-impl fmt::Display for FunctionParam {
+impl fmt::Display for Module {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}: {}", self.identifier(), self.ty())
+        writeln!(f, "{}mod {} {{", self.visibility(), self.name())?;
+
+        for item in self.items() {
+            let item_str = item.to_string();
+
+            for line in item_str.lines() {
+                writeln!(f, "    {line}")?;
+            }
+        }
+
+        write!(f, "}}")
     }
 }
 
@@ -847,6 +846,8 @@ impl TreeLike for ExprTree<'_> {
     }
 }
 
+// TODO: Fix indentation and formatting logic. The current flat iterator approach cannot
+// track AST depth, causing incorrect indentation for nested `Block` and `Match` nodes.
 impl fmt::Display for ExprTree<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use SingleExpressionInner as S;
@@ -1329,6 +1330,12 @@ impl ChumskyParse for AliasedType {
 }
 
 impl ChumskyParse for Program {
+    /// Parses a sequence of top-level [`Item`]s into a complete [`Program`].
+    ///
+    /// If an invalid item is encountered, it will safely skip the broken tokens
+    /// until it finds a synchronization point. This prevents the parser from
+    /// failing completely, allowing it to report multiple syntax errors across the file
+    /// while substituting the unparseable sections with [`Item::Ignored`].
     fn parser<'tokens, 'src: 'tokens, I>() -> impl Parser<'tokens, I, Self, ParseError<'src>> + Clone
     where
         I: ValueInput<'tokens, Token = Token<'src>, Span = Span>,
@@ -1344,8 +1351,7 @@ impl ChumskyParse for Program {
                     })
                     .repeated(),
             )
-            // map to empty module
-            .map_with(|_, _| Item::Module);
+            .map_with(|_, _| Item::Ignored);
 
         Item::parser()
             .recover_with(via_parser(skip_until_next_item))
@@ -1363,12 +1369,16 @@ impl ChumskyParse for Item {
     where
         I: ValueInput<'tokens, Token = Token<'src>, Span = Span>,
     {
-        let func_parser = Function::parser().map(Item::Function);
-        let type_parser = TypeAlias::parser().map(Item::TypeAlias);
-        let use_parser = UseDecl::parser().map(Item::Use);
-        let mod_parser = Module::parser().map(|_| Item::Module);
+        recursive(|item| {
+            let func_parser = Function::parser().map(Item::Function);
+            let type_parser = TypeAlias::parser().map(Item::TypeAlias);
+            let use_parser = UseDecl::parser().map(Item::Use);
 
-        choice((func_parser, use_parser, type_parser, mod_parser))
+            // Lazy item here
+            let mod_parser = Module::parser_with_items(item).map(Item::Module);
+
+            choice((func_parser, use_parser, type_parser, mod_parser))
+        })
     }
 }
 
@@ -1442,21 +1452,23 @@ impl ChumskyParse for UseDecl {
             .or_not()
             .map(Option::unwrap_or_default);
 
-        // Parse the base path prefix (e.g., `dependency_root_path::file::`, `dependency_root_path::dir::file::`, or `crate::dir::file::`).
-        // We require at least 2 segments here because a valid import needs a minimum
-        // of 3 items total: the dependency root path (or `crate`), the file, and the specific item/function.
         let first_segment = select! {
             Token::Ident(ident) => Identifier::from_str_unchecked(ident),
             Token::Crate => Identifier::from_str_unchecked(CRATE_STR),
         };
 
+        // Parse the base path prefix (e.g., `dependency_root_path::file::`, `dependency_root_path::dir::file::`,
+        // or `crate::dir::file::`). We require at least 2 segments here because a valid import needs a minimum
+        // of 3 items total: the dependency root path (or `crate`), the file, and the specific item.
+        //
+        // With the introduction of `mod` keyword and single-file flattening, 2 total segments are now
+        // valid: `crate::item`, where `crate` is the program root.
         let path = first_segment
             .then_ignore(just(Token::DoubleColon))
             .then(
                 Identifier::parser()
                     .then_ignore(just(Token::DoubleColon))
                     .repeated()
-                    .at_least(1)
                     .collect::<Vec<_>>(),
             )
             .map(|(first, mut rest)| {
@@ -2082,14 +2094,22 @@ impl Match {
     }
 }
 
-impl ChumskyParse for Module {
-    fn parser<'tokens, 'src: 'tokens, I>() -> impl Parser<'tokens, I, Self, ParseError<'src>> + Clone
+impl Module {
+    pub fn parser_with_items<'tokens, 'src: 'tokens, I>(
+        item_parser: impl Parser<'tokens, I, Item, ParseError<'src>> + Clone + 'tokens,
+    ) -> impl Parser<'tokens, I, Self, ParseError<'src>> + Clone
     where
         I: ValueInput<'tokens, Token = Token<'src>, Span = Span>,
     {
+        let file_id = MAIN_MODULE;
+        let visibility = just(Token::Pub)
+            .to(Visibility::Public)
+            .or_not()
+            .map(Option::unwrap_or_default);
+
         let name = ModuleName::parser().map_with(|name, e| (name, e.span()));
 
-        let assignments = ModuleAssignment::parser()
+        let items = item_parser
             .repeated()
             .collect::<Vec<_>>()
             .delimited_by(just(Token::LBrace), just(Token::RBrace))
@@ -2104,35 +2124,13 @@ impl ChumskyParse for Module {
             )))
             .map(Arc::from);
 
-        just(Token::Mod)
-            .ignore_then(name)
-            .then(assignments)
-            .map_with(|(name, assignments), e| Self {
+        visibility
+            .then(just(Token::Mod).ignore_then(name).then(items))
+            .map_with(move |(visibility, (name, items)), e| Self {
+                file_id,
+                visibility,
                 name: name.0,
-                assignments,
-                span: e.span(),
-            })
-    }
-}
-
-impl ChumskyParse for ModuleAssignment {
-    fn parser<'tokens, 'src: 'tokens, I>() -> impl Parser<'tokens, I, Self, ParseError<'src>> + Clone
-    where
-        I: ValueInput<'tokens, Token = Token<'src>, Span = Span>,
-    {
-        let name = WitnessName::parser();
-
-        just(Token::Const)
-            .ignore_then(name)
-            .then_ignore(just(Token::Colon))
-            .then(AliasedType::parser())
-            .then_ignore(just(Token::Eq))
-            .then(Expression::parser())
-            .then_ignore(just(Token::Semi))
-            .map_with(|((name, ty), expression), e| Self {
-                name,
-                ty,
-                expression,
+                items,
                 span: e.span(),
             })
     }
@@ -2192,26 +2190,37 @@ impl AsRef<Span> for Match {
     }
 }
 
+impl AsRef<Span> for UseDecl {
+    fn as_ref(&self) -> &Span {
+        &self.span
+    }
+}
+
 impl AsRef<Span> for Module {
     fn as_ref(&self) -> &Span {
         &self.span
     }
 }
 
-impl AsRef<Span> for ModuleAssignment {
-    fn as_ref(&self) -> &Span {
-        &self.span
+#[cfg(feature = "arbitrary")]
+pub(crate) fn generate_arbitrary_items<'a>(
+    u: &mut arbitrary::Unstructured<'a>,
+) -> arbitrary::Result<Vec<Item>> {
+    let mut items_vec = Vec::new();
+
+    let len = u.int_in_range(0..=2)?;
+    for _ in 0..len {
+        items_vec.push(<Item as arbitrary::Arbitrary>::arbitrary(u)?);
     }
+
+    Ok(items_vec)
 }
 
 #[cfg(feature = "arbitrary")]
 impl<'a> arbitrary::Arbitrary<'a> for Program {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        let mut items_vec: Vec<Item> = Vec::new();
-        let len = u.int_in_range(0..=2)?;
-        for _ in 0..len {
-            items_vec.push(Item::arbitrary(u)?);
-        }
+        let mut items_vec = generate_arbitrary_items(u)?;
+
         // Three equally-likely modes for how `fn main()` is injected:
         //   0 — no explicit main (arbitrary items only)
         //   1 — main with arbitrary params and return type
@@ -2237,6 +2246,19 @@ impl<'a> arbitrary::Arbitrary<'a> for Program {
             items,
             span: Span::DUMMY,
         })
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a> arbitrary::Arbitrary<'a> for Item {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        match u.int_in_range(0..=3)? {
+            0 => Ok(Item::TypeAlias(TypeAlias::arbitrary(u)?)),
+            1 => Ok(Item::Function(Function::arbitrary(u)?)),
+            2 => Ok(Item::Use(UseDecl::arbitrary(u)?)),
+            3 => Ok(Item::Module(Module::arbitrary(u)?)),
+            _ => unreachable!(),
+        }
     }
 }
 
@@ -2268,6 +2290,26 @@ impl crate::ArbitraryRec for Function {
             params,
             ret,
             body,
+            span: Span::DUMMY,
+        })
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a> arbitrary::Arbitrary<'a> for Module {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        // A small range allows us to test scenarios where two
+        // randomly generated modules end up in the same file.
+        let file_id = u.int_in_range(0..=3)?;
+        let visibility = Visibility::arbitrary(u)?;
+        let name = ModuleName::arbitrary(u)?;
+        let items_vec = generate_arbitrary_items(u)?;
+
+        Ok(Self {
+            file_id,
+            visibility,
+            name,
+            items: items_vec.into(),
             span: Span::DUMMY,
         })
     }

--- a/src/str.rs
+++ b/src/str.rs
@@ -96,30 +96,84 @@ impl From<SymbolName> for FunctionName {
     }
 }
 
+pub(crate) const FUNCTION_RESERVED: &[&str] = &[
+    "unwrap_left",
+    "unwrap_right",
+    "for_while",
+    "is_none",
+    "unwrap",
+    "assert",
+    "panic",
+    "match",
+    "into",
+    "fold",
+    "dbg",
+];
+
+pub(crate) const ALIAS_RESERVED: &[&str] = &[
+    "Either",
+    "Option",
+    "bool",
+    "List",
+    "u128",
+    "u256",
+    "u16",
+    "u32",
+    "u64",
+    "u1",
+    "u2",
+    "u4",
+    "u8",
+    "Ctx8",
+    "Pubkey",
+    "Message64",
+    "Message",
+    "Signature",
+    "Scalar",
+    "Fe",
+    "Gej",
+    "Ge",
+    "Point",
+    "Height",
+    "Time",
+    "Distance",
+    "Duration",
+    "Lock",
+    "Outpoint",
+    "Confidential1",
+    "ExplicitAsset",
+    "Asset1",
+    "ExplicitAmount",
+    "Amount1",
+    "ExplicitNonce",
+    "Nonce",
+    "TokenAmount1",
+];
+
+pub(crate) const MODULE_RESERVED: &[&str] = &["jet", "witness", "param"];
+
+pub fn is_reserved_function_name(name: &str) -> bool {
+    FUNCTION_RESERVED.contains(&name) || crate::lexer::is_keyword(name)
+}
+
+pub fn is_reserved_alias_name(name: &str) -> bool {
+    ALIAS_RESERVED.contains(&name) || crate::lexer::is_keyword(name)
+}
+
+pub fn is_reserved_module_name(name: &str) -> bool {
+    MODULE_RESERVED.contains(&name) || crate::lexer::is_keyword(name)
+}
+
 #[cfg(feature = "arbitrary")]
 impl<'a> arbitrary::Arbitrary<'a> for FunctionName {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        const RESERVED_NAMES: [&str; 11] = [
-            "unwrap_left",
-            "unwrap_right",
-            "for_while",
-            "is_none",
-            "unwrap",
-            "assert",
-            "panic",
-            "match",
-            "into",
-            "fold",
-            "dbg",
-        ];
-
         let len = u.int_in_range(1..=10)?;
         let mut string = String::with_capacity(len);
         for _ in 0..len {
             let offset = u.int_in_range(0..=25)?;
             string.push((b'a' + offset) as char)
         }
-        if RESERVED_NAMES.contains(&string.as_str()) || crate::lexer::is_keyword(string.as_str()) {
+        if is_reserved_function_name(string.as_str()) {
             string.push('_');
         }
 
@@ -184,53 +238,13 @@ impl From<SymbolName> for AliasName {
 #[cfg(feature = "arbitrary")]
 impl<'a> arbitrary::Arbitrary<'a> for AliasName {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        const RESERVED_NAMES: [&str; 37] = [
-            "Either",
-            "Option",
-            "bool",
-            "List",
-            "u128",
-            "u256",
-            "u16",
-            "u32",
-            "u64",
-            "u1",
-            "u2",
-            "u4",
-            "u8",
-            "Ctx8",
-            "Pubkey",
-            "Message64",
-            "Message",
-            "Signature",
-            "Scalar",
-            "Fe",
-            "Gej",
-            "Ge",
-            "Point",
-            "Height",
-            "Time",
-            "Distance",
-            "Duration",
-            "Lock",
-            "Outpoint",
-            "Confidential1",
-            "ExplicitAsset",
-            "Asset1",
-            "ExplicitAmount",
-            "Amount1",
-            "ExplicitNonce",
-            "Nonce",
-            "TokenAmount1",
-        ];
-
         let len = u.int_in_range(1..=10)?;
         let mut string = String::with_capacity(len);
         for _ in 0..len {
             let offset = u.int_in_range(0..=25)?;
             string.push((b'a' + offset) as char)
         }
-        if RESERVED_NAMES.contains(&string.as_str()) || crate::lexer::is_keyword(string.as_str()) {
+        if is_reserved_alias_name(string.as_str()) {
             string.push('_');
         }
 
@@ -305,15 +319,9 @@ impl<'a> arbitrary::Arbitrary<'a> for Hexadecimal {
 #[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub struct ModuleName(Arc<str>);
 
-impl ModuleName {
-    /// Return the name of the witness module.
-    pub fn witness() -> Self {
-        Self(Arc::from("witness"))
-    }
-
-    /// Return the name of the parameter module.
-    pub fn param() -> Self {
-        Self(Arc::from("param"))
+impl Default for ModuleName {
+    fn default() -> Self {
+        Self(Arc::from(""))
     }
 }
 
@@ -324,6 +332,23 @@ impl From<SymbolName> for ModuleName {
 }
 
 wrapped_string!(ModuleName, "module name");
+
+#[cfg(feature = "arbitrary")]
+impl<'a> arbitrary::Arbitrary<'a> for ModuleName {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let len = u.int_in_range(1..=10)?;
+        let mut string = String::with_capacity(len);
+        for _ in 0..len {
+            let offset = u.int_in_range(0..=25)?;
+            string.push((b'a' + offset) as char)
+        }
+        if is_reserved_module_name(string.as_str()) {
+            string.push('_');
+        }
+
+        Ok(Self::from_str_unchecked(string.as_str()))
+    }
+}
 
 /// An unresolved identifier parsed from the source code.
 ///


### PR DESCRIPTION
Implement a working `Module` struct and handle recursive parsing. In this series of PRs, we do not plan to support qualified calls via `::` (e.g., `unit_1::call_function`), as our existing alias system is sufficient.