### PR TITLE
just: use nightly cargo for fuzz tests

### DIFF
--- a/justfile
+++ b/justfile
@@ -29,7 +29,7 @@ check:
 
 # Run fuzz test for 30 seconds
 fuzz target:
-    cargo-fuzz run {{target}} -- -max_total_time=30 -max_len=50
+    cargo +nightly fuzz run {{target}} -- -max_total_time=30 -max_len=50
 
 # Check fuzz targets (CI; requires nightly)
 check_fuzz:
@@ -42,7 +42,7 @@ check_fuzz:
 
 # Build fuzz tests
 build_fuzz:
-    cargo-fuzz check
+    cargo +nightly fuzz check
 
 # Check the standalone fuzz crate compiles
 check_fuzz_crate:


### PR DESCRIPTION
Fixes:

```
inter simplicityhl (master) ✔ just build_fuzz       
cargo-fuzz check
error: failed to run `rustc` to learn about target-specific information

Caused by:
  process didn't exit successfully: `/Users/inter/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustc - --crate-name ___ --print=file-names -Cpasses=sancov-module -Cllvm-args=-sanitizer-coverage-level=4 -Cllvm-args=-sanitizer-coverage-inline-8bit-counters -Cllvm-args=-sanitizer-coverage-pc-table -Cllvm-args=-sanitizer-coverage-trace-compares --cfg fuzzing -Cllvm-args=-simplifycfg-branch-fold-threshold=0 -Zsanitizer=address -Cdebug-assertions -Ccodegen-units=1 --target aarch64-apple-darwin --crate-type bin --crate-type rlib --crate-type dylib --crate-type cdylib --crate-type staticlib --crate-type proc-macro --print=sysroot --print=split-debuginfo --print=crate-name --print=cfg -Wwarnings` (exit status: 1)
  --- stderr
  error: the option `Z` is only accepted on the nightly compiler

  help: consider switching to a nightly toolchain: `rustup default nightly`

  note: selecting a toolchain with `+toolchain` arguments require a rustup proxy; see <https://rust-lang.github.io/rustup/concepts/index.html>

  note: for more information about Rust's stability policy, see <https://doc.rust-lang.org/book/appendix-07-nightly-rust.html#unstable-features>

  error: 1 nightly option were parsed

Error: failed to build fuzz script: ASAN_OPTIONS="detect_odr_violation=0" RUSTFLAGS=" -Cpasses=sancov-module -Cllvm-args=-sanitizer-coverage-level=4 -Cllvm-args=-sanitizer-coverage-inline-8bit-counters -Cllvm-args=-sanitizer-coverage-pc-table -Cllvm-args=-sanitizer-coverage-trace-compares --cfg fuzzing -Cllvm-args=-simplifycfg-branch-fold-threshold=0 -Zsanitizer=address -Cdebug-assertions -Ccodegen-units=1" "cargo" "check" "--manifest-path" "/Volumes/Somebody/Desktop/Simp/simplicityhl/fuzz/Cargo.toml" "--target" "aarch64-apple-darwin" "--release" "--config" "profile.release.debug=\"line-tables-only\"" "--bins"
error: Recipe `build_fuzz` failed on line 45 with exit code 1
```