### PR TITLE
feat: unstable with traits

### DIFF
--- a/doc/unstable-features.md
+++ b/doc/unstable-features.md
@@ -1,0 +1,17 @@
+# Unstable features
+
+Unstable features are experimental compiler capabilities. They may change
+or be removed before stabilization.
+
+## Viewing available unstable features
+
+Run `simc --help`; the features are listed under the `-Z` flag.
+
+## Enabling an unstable feature
+
+Pass `-Z <feature-name>` to `simc`.
+
+## Adding or stabilizing a feature
+
+See the rustdoc on `UnstableFeature` in `src/unstable.rs`; the procedures
+live next to the code they mutate, so they cannot drift.

--- a/src/compile/mod.rs
+++ b/src/compile/mod.rs
@@ -63,7 +63,6 @@ struct Scope<'brand> {
     ///
     /// Inner scopes occur higher in the tree than outer scopes.
     /// Later assignments occur higher in the tree than earlier assignments.
-    /// ```
     variables: Vec<Vec<Pattern>>,
     ctx: simplicity::types::Context<'brand>,
     /// Tracker of function calls.

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -37,6 +37,7 @@ use crate::error::{Error, ErrorCollector, RichError, Span};
 use crate::parse::{self, ParseFromStrWithErrors};
 use crate::resolution::{DependencyMap, ResolvedUse};
 use crate::source::{CanonPath, CanonSourceFile};
+use crate::unstable::UnstableFeatures;
 
 /// The reserved identifier for the program's entry point.
 pub(crate) const MAIN_STR: &str = "main";
@@ -179,6 +180,7 @@ impl DependencyGraph {
         dependency_map: Arc<DependencyMap>,
         root_program: &parse::Program,
         handler: &mut ErrorCollector,
+        unstable_features: &UnstableFeatures,
     ) -> Result<Option<Self>, String> {
         let mut graph = Self {
             modules: vec![SourceModule {
@@ -227,6 +229,7 @@ impl DependencyGraph {
                 invalid_imports: &mut invalid_imports,
                 handler,
                 queue: &mut queue,
+                unstable_features,
             };
             graph.load_and_parse_dependencies(&current, valid_imports, &mut ctx);
         }
@@ -247,6 +250,7 @@ impl DependencyGraph {
         importer_source: &CanonSourceFile,
         span: Span,
         handler: &mut ErrorCollector,
+        unstable_features: &UnstableFeatures,
     ) -> Option<SourceModule> {
         let Ok(content) = std::fs::read_to_string(path.as_path()) else {
             let err = RichError::new(
@@ -264,7 +268,11 @@ impl DependencyGraph {
         let mut error_handler = ErrorCollector::new();
         let source = CanonSourceFile::new(path.clone(), Arc::from(content));
 
-        let ast = parse::Program::parse_from_str_with_errors(source.clone(), &mut error_handler);
+        let ast = parse::Program::parse_from_str_with_errors(
+            source.clone(),
+            unstable_features,
+            &mut error_handler,
+        );
 
         if error_handler.has_errors() {
             handler.extend_with_handler(source, &error_handler);
@@ -322,9 +330,13 @@ impl DependencyGraph {
                 continue;
             }
 
-            let Some(module) =
-                Self::parse_and_get_source_module(&path, &current.source, import_span, ctx.handler)
-            else {
+            let Some(module) = Self::parse_and_get_source_module(
+                &path,
+                &current.source,
+                import_span,
+                ctx.handler,
+                ctx.unstable_features,
+            ) else {
                 // Safe to ignore output: previous `.contains` check prevents collisions.
                 let _ = ctx.invalid_imports.insert(path);
                 continue;
@@ -422,6 +434,7 @@ struct LoadContext<'a> {
     invalid_imports: &'a mut HashSet<CanonPath>,
     handler: &'a mut ErrorCollector,
     queue: &'a mut VecDeque<usize>,
+    unstable_features: &'a UnstableFeatures,
 }
 
 /// The currently processed module and its source, used for error reporting
@@ -494,15 +507,24 @@ pub(crate) mod tests {
         let root_p = root_file_path.expect("main.simf must be defined in file list");
         let main_canon_source = CanonSourceFile::new(root_p, Arc::from(root_content));
 
-        let main_program_option =
-            parse::Program::parse_from_str_with_errors(main_canon_source.clone(), &mut handler);
+        let main_program_option = parse::Program::parse_from_str_with_errors(
+            main_canon_source.clone(),
+            &UnstableFeatures::all(),
+            &mut handler,
+        );
 
         let Some(main_program) = main_program_option else {
             return (None, HashMap::new(), ws, handler);
         };
 
-        let graph_option =
-            DependencyGraph::new(main_canon_source, map, &main_program, &mut handler).unwrap();
+        let graph_option = DependencyGraph::new(
+            main_canon_source,
+            map,
+            &main_program,
+            &mut handler,
+            &UnstableFeatures::all(),
+        )
+        .unwrap();
 
         let mut file_ids = HashMap::new();
 

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -1,3 +1,4 @@
+#![allow(rustdoc::private_intra_doc_links)]
 //! The `driver` module is responsible for module resolution and dependency management.
 //!
 //! Our compiler operates in a strict pipeline: `Lexer -> Parser -> Driver -> AST`.
@@ -346,7 +347,7 @@ impl DependencyGraph {
 }
 
 /// Groups all shared state for import resolution to avoid threading a lot of parameters
-/// through every recursive call. Lives only for the duration of [`resolve_imports`].
+/// through every recursive call. Lives only for the duration of [`DependencyGraph::resolve_imports`].
 struct ImportContext<'a> {
     current: CurrentModule,
     dependency_map: &'a DependencyMap,

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,6 +18,7 @@ use crate::parse::MatchPattern;
 use crate::source::SourceFile;
 use crate::str::{AliasName, FunctionName, Identifier, JetName, ModuleName, WitnessName};
 use crate::types::{ResolvedType, UIntType};
+use crate::unstable::UnstableFeature;
 
 /// Area that an object spans inside a file.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
@@ -478,6 +479,9 @@ impl fmt::Display for ErrorCollector {
 /// Records _what_ happened but not where.
 #[derive(Debug, Clone)]
 pub enum Error {
+    UnstableFeature {
+        feature: UnstableFeature,
+    },
     DependencyPathNotFound {
         path: PathBuf,
     },
@@ -643,15 +647,16 @@ pub enum Error {
         declared: ResolvedType,
         assigned: ResolvedType,
     },
-    // TODO: Remove these once `use` and `mod` are supported by the AST
-    UseKeywordIsNotSupported,
-    ModuleKeywordIsNotSupported,
 }
 
 #[rustfmt::skip]
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Error::UnstableFeature { feature } => write!(
+                f,
+                "The '{feature}' feature is not enabled.\nEnable it with: -Z {feature}"
+            ),
             Error::DependencyPathNotFound { path } => write!(
                 f,
                 "Path not found: {}", path.display()
@@ -879,14 +884,6 @@ impl fmt::Display for Error {
             Error::ArgumentTypeMismatch { name, declared, assigned } => write!(
                 f,
                 "Parameter `{name}` was declared with type `{declared}` but its assigned argument is of type `{assigned}`"
-            ),
-            Error::UseKeywordIsNotSupported => write!(
-                f,
-                "The `use` keyword is not supported yet"
-            ),
-            Error::ModuleKeywordIsNotSupported => write!(
-                f,
-                "The `mod` keyword is not supported yet"
             ),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub mod parse;
 pub mod pattern;
 pub mod resolution;
 pub mod source;
+pub mod unstable;
 
 #[cfg(feature = "serde")]
 mod serde;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@ use crate::resolution::DependencyMap;
 use crate::source::CanonSourceFile;
 use crate::source::SourceFile;
 pub use crate::types::ResolvedType;
+pub use crate::unstable::{UnstableFeature, UnstableFeatures};
 pub use crate::value::Value;
 pub use crate::witness::{Arguments, Parameters, WitnessTypes, WitnessValues};
 
@@ -71,10 +72,15 @@ impl TemplateProgram {
     pub fn flatten(
         source: CanonSourceFile,
         dependency_map: &DependencyMap,
+        unstable_features: &UnstableFeatures,
     ) -> Result<String, String> {
         let mut error_handler = ErrorCollector::new();
-        let (resolved_program, _) =
-            Self::dependency_helper(source, dependency_map, &mut error_handler)?;
+        let (resolved_program, _) = Self::dependency_helper(
+            source,
+            dependency_map,
+            unstable_features,
+            &mut error_handler,
+        )?;
 
         resolved_program
             .ok_or_else(|| error_handler.to_string())
@@ -89,14 +95,19 @@ impl TemplateProgram {
     pub fn new_with_dep(
         source: CanonSourceFile,
         dependency_map: &DependencyMap,
+        unstable_features: &UnstableFeatures,
         jet_hinter: Box<dyn ast::JetHinter>,
     ) -> Result<Self, ErrorCollector> {
         let mut error_handler = ErrorCollector::new();
 
         let build_program = || -> Result<Self, ()> {
-            let (resolved_program, source_map) =
-                Self::dependency_helper(source.clone(), dependency_map, &mut error_handler)
-                    .map_err(|_| ())?;
+            let (resolved_program, source_map) = Self::dependency_helper(
+                source.clone(),
+                dependency_map,
+                unstable_features,
+                &mut error_handler,
+            )
+            .map_err(|_| ())?;
 
             let resolved_program = resolved_program.ok_or(())?;
 
@@ -128,11 +139,25 @@ impl TemplateProgram {
         s: Str,
         jet_hinter: Box<dyn ast::JetHinter>,
     ) -> Result<Self, ErrorCollector> {
+        Self::new_with_unstable(s, &UnstableFeatures::none(), jet_hinter)
+    }
+
+    /// Like [`new`](Self::new), but rejects any unstable feature used by the
+    /// program that is not enabled in `unstable_features`.
+    pub fn new_with_unstable<Str: Into<Arc<str>>>(
+        s: Str,
+        unstable_features: &UnstableFeatures,
+        jet_hinter: Box<dyn ast::JetHinter>,
+    ) -> Result<Self, ErrorCollector> {
         let file = s.into();
         let source = SourceFile::anonymous(file.clone());
         let mut error_handler = ErrorCollector::new();
 
-        let parse_program = parse::Program::parse_from_str_with_errors(source, &mut error_handler);
+        let parse_program = parse::Program::parse_from_str_with_errors(
+            source,
+            unstable_features,
+            &mut error_handler,
+        );
 
         if let Some(program) = parse_program {
             let Ok(ast_program) = ast::Program::analyze(&program, jet_hinter.clone_box())
@@ -154,21 +179,53 @@ impl TemplateProgram {
         }
     }
 
+    /*
     fn dependency_helper(
         source: CanonSourceFile,
         dependency_map: &DependencyMap,
+        unstable_features: &UnstableFeatures,
         handler: &mut ErrorCollector,
     ) -> Result<(Option<parse::Program>, SourceMap), String> {
-        let program = parse::Program::parse_from_str_with_errors(source.clone(), handler)
-            .ok_or_else(|| handler.to_string())?;
-        // TODO: we should remove this errors push after refactoring errors
-        let graph =
-            DependencyGraph::new(source, Arc::from(dependency_map.clone()), &program, handler)
-                .map_err(|e| {
-                    handler.push(error::RichError::parsing_error(&e));
-                    handler.to_string()
-                })?
+        let program =
+            parse::Program::parse_from_str_with_errors(source.clone(), unstable_features, handler)
                 .ok_or_else(|| handler.to_string())?;
+        let graph = DependencyGraph::new(
+            source,
+            Arc::from(dependency_map.clone()),
+            &program,
+            handler,
+            unstable_features,
+        )?
+        .ok_or_else(|| handler.to_string())?;
+
+        let program = graph.linearize_and_build(handler);
+
+        program.map(|opt| (opt, graph.source_map().clone()))
+    }
+    */
+
+    fn dependency_helper(
+        source: CanonSourceFile,
+        dependency_map: &DependencyMap,
+        unstable_features: &UnstableFeatures,
+        handler: &mut ErrorCollector,
+    ) -> Result<(Option<parse::Program>, SourceMap), String> {
+        let program =
+            parse::Program::parse_from_str_with_errors(source.clone(), unstable_features, handler)
+                .ok_or_else(|| handler.to_string())?;
+        // TODO: we should remove this errors push after refactoring errors
+        let graph = DependencyGraph::new(
+            source,
+            Arc::from(dependency_map.clone()),
+            &program,
+            handler,
+            unstable_features,
+        )
+        .map_err(|e| {
+            handler.push(error::RichError::parsing_error(&e));
+            handler.to_string()
+        })?
+        .ok_or_else(|| handler.to_string())?;
 
         let program = graph.linearize_and_build(handler);
 
@@ -254,13 +311,19 @@ impl CompiledProgram {
     pub fn new_with_dep(
         source: CanonSourceFile,
         dependency_map: &DependencyMap,
+        unstable_features: &UnstableFeatures,
         arguments: Arguments,
         include_debug_symbols: bool,
         jet_hinter: Box<dyn ast::JetHinter>,
     ) -> Result<Self, String> {
-        TemplateProgram::new_with_dep(source, dependency_map, jet_hinter.clone_box())
-            .map_err(|e| e.to_string())
-            .and_then(|template| template.instantiate(arguments, include_debug_symbols))
+        TemplateProgram::new_with_dep(
+            source,
+            dependency_map,
+            unstable_features,
+            jet_hinter.clone_box(),
+        )
+        .map_err(|e| e.to_string())
+        .and_then(|template| template.instantiate(arguments, include_debug_symbols))
     }
 
     /// Parse and compile a SimplicityHL program from the given string.
@@ -275,7 +338,25 @@ impl CompiledProgram {
         include_debug_symbols: bool,
         jet_hinter: Box<dyn ast::JetHinter>,
     ) -> Result<Self, String> {
-        TemplateProgram::new(s, jet_hinter.clone_box())
+        Self::new_with_unstable(
+            s,
+            &UnstableFeatures::none(),
+            arguments,
+            include_debug_symbols,
+            jet_hinter,
+        )
+    }
+
+    /// Like [`new`](Self::new), but rejects any unstable feature used by the
+    /// program that is not enabled in `unstable_features`.
+    pub fn new_with_unstable<Str: Into<Arc<str>>>(
+        s: Str,
+        unstable_features: &UnstableFeatures,
+        arguments: Arguments,
+        include_debug_symbols: bool,
+        jet_hinter: Box<dyn ast::JetHinter>,
+    ) -> Result<Self, String> {
+        TemplateProgram::new_with_unstable(s, unstable_features, jet_hinter.clone_box())
             .map_err(|e| e.to_string())
             .and_then(|template| template.instantiate(arguments, include_debug_symbols))
     }
@@ -362,7 +443,33 @@ impl SatisfiedProgram {
         include_debug_symbols: bool,
         jet_hinter: Box<dyn ast::JetHinter>,
     ) -> Result<Self, String> {
-        let compiled = CompiledProgram::new(s, arguments, include_debug_symbols, jet_hinter)?;
+        Self::new_with_unstable(
+            s,
+            &UnstableFeatures::none(),
+            arguments,
+            witness_values,
+            include_debug_symbols,
+            jet_hinter,
+        )
+    }
+
+    /// Like [`new`](Self::new), but rejects any unstable feature used by the
+    /// program that is not enabled in `unstable_features`.
+    pub fn new_with_unstable<Str: Into<Arc<str>>>(
+        s: Str,
+        unstable_features: &UnstableFeatures,
+        arguments: Arguments,
+        witness_values: WitnessValues,
+        include_debug_symbols: bool,
+        jet_hinter: Box<dyn ast::JetHinter>,
+    ) -> Result<Self, String> {
+        let compiled = CompiledProgram::new_with_unstable(
+            s,
+            unstable_features,
+            arguments,
+            include_debug_symbols,
+            jet_hinter,
+        )?;
         compiled.satisfy(witness_values)
     }
 
@@ -494,7 +601,7 @@ pub(crate) mod tests {
             Arc::from(program_text),
         );
 
-        match TemplateProgram::flatten(source, dependency_map) {
+        match TemplateProgram::flatten(source, dependency_map, &UnstableFeatures::all()) {
             Ok(single_file) => single_file,
             Err(error) => panic!("{error}"),
         }
@@ -505,8 +612,12 @@ pub(crate) mod tests {
         let source = SourceFile::anonymous(file.clone());
 
         let mut error_handler = ErrorCollector::new();
-        let parse_program =
-            parse::Program::parse_from_str_with_errors(source, &mut error_handler).unwrap();
+        let parse_program = parse::Program::parse_from_str_with_errors(
+            source,
+            &UnstableFeatures::all(),
+            &mut error_handler,
+        )
+        .unwrap();
         parse_program.to_string()
     }
 
@@ -538,11 +649,22 @@ pub(crate) mod tests {
 
     impl TestCase<TemplateProgram> {
         pub fn template_file<P: AsRef<Path>>(program_file_path: P) -> Self {
-            let program_text = std::fs::read_to_string(program_file_path).unwrap();
-            Self::template_text(Cow::Owned(program_text))
+            Self::template_file_with_unstable(program_file_path, UnstableFeatures::none())
         }
 
-        pub fn template_deps(prog_path: &Path, dependency_map: &DependencyMap) -> Self {
+        pub fn template_file_with_unstable<P: AsRef<Path>>(
+            program_file_path: P,
+            unstable_features: UnstableFeatures,
+        ) -> Self {
+            let program_text = std::fs::read_to_string(program_file_path).unwrap();
+            Self::template_text_with_unstable(Cow::Owned(program_text), unstable_features)
+        }
+
+        pub fn template_deps_with_unstable(
+            prog_path: &Path,
+            dependency_map: &DependencyMap,
+            unstable_features: UnstableFeatures,
+        ) -> Self {
             let program_text = std::fs::read_to_string(prog_path).unwrap();
             let source = CanonSourceFile::new(
                 CanonPath::canonicalize(prog_path).unwrap(),
@@ -552,6 +674,7 @@ pub(crate) mod tests {
             let program = match TemplateProgram::new_with_dep(
                 source,
                 dependency_map,
+                &unstable_features,
                 Box::new(ElementsJetHinter::new()),
             ) {
                 Ok(x) => x,
@@ -567,8 +690,16 @@ pub(crate) mod tests {
         }
 
         pub fn template_text(program_text: Cow<str>) -> Self {
-            let program = match TemplateProgram::new(
+            Self::template_text_with_unstable(program_text, UnstableFeatures::none())
+        }
+
+        pub fn template_text_with_unstable(
+            program_text: Cow<str>,
+            unstable_features: UnstableFeatures,
+        ) -> Self {
+            let program = match TemplateProgram::new_with_unstable(
                 program_text.as_ref(),
+                &unstable_features,
                 Box::new(ElementsJetHinter::new()),
             ) {
                 Ok(x) => x,
@@ -615,17 +746,33 @@ pub(crate) mod tests {
                 .with_arguments(Arguments::default())
         }
 
+        pub fn program_file_with_unstable<P: AsRef<Path>>(
+            program_file_path: P,
+            unstable_features: UnstableFeatures,
+        ) -> Self {
+            TestCase::<TemplateProgram>::template_file_with_unstable(
+                program_file_path,
+                unstable_features,
+            )
+            .with_arguments(Arguments::default())
+        }
+
         pub fn program_text(program_text: Cow<str>) -> Self {
             TestCase::<TemplateProgram>::template_text(program_text)
                 .with_arguments(Arguments::default())
         }
 
-        pub fn program_file_with_deps(
+        pub fn program_file_with_deps_and_unstable(
             prog_path: impl AsRef<Path>,
             dependency_map: &DependencyMap,
+            unstable_features: UnstableFeatures,
         ) -> Self {
-            TestCase::<TemplateProgram>::template_deps(prog_path.as_ref(), dependency_map)
-                .with_arguments(Arguments::default())
+            TestCase::<TemplateProgram>::template_deps_with_unstable(
+                prog_path.as_ref(),
+                dependency_map,
+                unstable_features,
+            )
+            .with_arguments(Arguments::default())
         }
 
         #[cfg(feature = "serde")]
@@ -738,9 +885,13 @@ pub(crate) mod tests {
 
         let dependency_map = build_dependency_map(&main_path, [(&root_path, lib_alias, &lib_path)]);
 
-        TestCase::program_file_with_deps(&main_path, &dependency_map)
-            .with_witness_values(WitnessValues::default())
-            .assert_run_success();
+        TestCase::program_file_with_deps_and_unstable(
+            &main_path,
+            &dependency_map,
+            UnstableFeatures::all(),
+        )
+        .with_witness_values(WitnessValues::default())
+        .assert_run_success();
     }
 
     pub(crate) fn flatten_dependency_test(root_path: &str, lib_alias: &str) {
@@ -782,9 +933,13 @@ pub(crate) mod tests {
 
         let ref_deps = mapped_deps.iter().map(|(c, a, t)| (c, *a, t));
         let dependency_map = build_dependency_map(&main_path, ref_deps);
-        TestCase::program_file_with_deps(&main_path, &dependency_map)
-            .with_witness_values(WitnessValues::default())
-            .assert_run_success();
+        TestCase::program_file_with_deps_and_unstable(
+            &main_path,
+            &dependency_map,
+            UnstableFeatures::all(),
+        )
+        .with_witness_values(WitnessValues::default())
+        .assert_run_success();
     }
 
     /// THE ADVANCED HELPER
@@ -920,10 +1075,14 @@ pub(crate) mod tests {
 
         let dependency_map = build_map(&canon_root, &[]).unwrap();
 
-        TestCase::<TemplateProgram>::template_deps(&main_path, &dependency_map)
-            .with_arguments(Arguments::default())
-            .with_witness_values(WitnessValues::default())
-            .assert_run_success();
+        TestCase::<TemplateProgram>::template_deps_with_unstable(
+            &main_path,
+            &dependency_map,
+            UnstableFeatures::all(),
+        )
+        .with_arguments(Arguments::default())
+        .with_witness_values(WitnessValues::default())
+        .assert_run_success();
     }
 
     #[test]
@@ -945,7 +1104,7 @@ pub(crate) mod tests {
 
     #[test]
     fn modules() {
-        TestCase::program_file("./examples/modules.simf")
+        TestCase::program_file_with_unstable("./examples/modules.simf", UnstableFeatures::all())
             .with_witness_values(WitnessValues::default())
             .assert_run_success();
     }
@@ -1435,6 +1594,7 @@ mod error_tests {
         let err = TemplateProgram::new_with_dep(
             source_file(&main_path),
             &dependencies,
+            &UnstableFeatures::all(),
             Box::new(ElementsJetHinter::new()),
         )
         .expect_err("dependency body has a type error");
@@ -1465,6 +1625,7 @@ mod error_tests {
         let _err = TemplateProgram::new_with_dep(
             source_file(&main_path),
             &dependencies,
+            &UnstableFeatures::none(),
             Box::new(ElementsJetHinter::new()),
         )
         .expect_err("omitted-context dependencies");
@@ -1484,6 +1645,7 @@ mod error_tests {
         let err = TemplateProgram::new_with_dep(
             source_file(&main_path),
             &dependencies,
+            &UnstableFeatures::all(),
             Box::new(ElementsJetHinter::new()),
         )
         .expect_err("missing imported module should fail");
@@ -1689,6 +1851,7 @@ mod functional_tests {
         CompiledProgram::new_with_dep(
             source,
             dependency_map,
+            &crate::UnstableFeatures::all(),
             Arguments::default(),
             false,
             Box::new(ElementsJetHinter::new()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use simplicityhl::{
     resolution::DependencyMapBuilder, source::CanonPath, source::CanonSourceFile, AbiMeta,
     CompiledProgram,
 };
+use simplicityhl::{UnstableFeature, UnstableFeatures};
 use std::path::Path;
 use std::{env, fmt};
 
@@ -95,6 +96,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     .action(ArgAction::SetTrue)
                     .help("Additional ABI .simf contract types"),
             )
+            .arg(
+                Arg::new("unstable_features")
+                    .long("unstable-feature")
+                    .short('Z')
+                    .value_name("FEATURE")
+                    .action(ArgAction::Append)
+                    .value_parser(clap::value_parser!(UnstableFeature))
+                    .help(simplicityhl::UnstableFeature::help_message()),
+            )
     };
 
     let matches = command.get_matches();
@@ -105,6 +115,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let include_debug_symbols = matches.get_flag("debug");
     let output_json = matches.get_flag("json");
     let abi_param = matches.get_flag("abi");
+
+    let unstable_features = matches
+        .get_many::<UnstableFeature>("unstable_features")
+        .map_or_else(UnstableFeatures::none, |features| {
+            UnstableFeatures::new(features.copied())
+        });
 
     #[cfg(feature = "serde")]
     let args_opt: simplicityhl::Arguments = match matches.get_one::<String>("args_file") {
@@ -172,6 +188,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let compiled = match CompiledProgram::new_with_dep(
         source,
         &dependencies,
+        &unstable_features,
         args_opt,
         include_debug_symbols,
         Box::new(ElementsJetHinter::new()),

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -30,6 +30,7 @@ use crate::str::{
     SymbolName, WitnessName,
 };
 use crate::types::{AliasedType, BuiltinAlias, TypeConstructible, UIntType};
+use crate::unstable::{impl_require_feature, UnstableFeature, UnstableFeatures};
 
 /// A program is a sequence of items.
 #[derive(Clone, Debug)]
@@ -55,6 +56,8 @@ impl Program {
 
 impl_eq_hash!(Program; items);
 
+impl_require_feature!(Program { recurse: items; });
+
 /// An item is a component of a program.
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub enum Item {
@@ -73,6 +76,15 @@ pub enum Item {
     /// until it reaches a valid top-level keyword and inserts `Ignored` into the AST.
     Ignored,
 }
+
+impl_require_feature!(Item {
+    variants:
+        TypeAlias(alias),
+        Function(function),
+        Use(use_decl),
+        Module(module),
+        Ignored,
+});
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
@@ -109,6 +121,17 @@ pub struct UseDecl {
     items: UseItems,
     span: Span,
 }
+
+impl_require_feature!(UseDecl {
+    requires: UnstableFeature::Imports, span: span;
+    recurse: items;
+});
+
+impl_require_feature!(UseItems {
+    variants:
+        Single(_),
+        List(_),
+});
 
 impl UseDecl {
     /// The driver uses this to ensure imports conform to the flattened program structure.
@@ -269,6 +292,8 @@ impl Function {
 
 impl_eq_hash!(Function; visibility, name, params, ret, body);
 
+impl_require_feature!(Function { recurse: params, ret, body; });
+
 /// Parameter of a function.
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
@@ -289,6 +314,8 @@ impl FunctionParam {
     }
 }
 
+impl_require_feature!(FunctionParam { recurse: ty; });
+
 /// A statement is a component of a block expression.
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub enum Statement {
@@ -297,6 +324,12 @@ pub enum Statement {
     /// An expression that returns nothing (the unit value).
     Expression(Expression),
 }
+
+impl_require_feature!(Statement {
+    variants:
+        Assignment(assignment),
+        Expression(expr),
+});
 
 /// The output of an expression is assigned to a pattern.
 #[derive(Clone, Debug)]
@@ -331,6 +364,8 @@ impl Assignment {
 
 impl_eq_hash!(Assignment; pattern, ty, expression);
 
+impl_require_feature!(Assignment { recurse: pattern, ty, expression; });
+
 /// Call expression.
 #[derive(Clone, Debug)]
 pub struct Call {
@@ -357,6 +392,8 @@ impl Call {
 }
 
 impl_eq_hash!(Call; name, args);
+
+impl_require_feature!(Call {recurse: name, args; });
 
 /// Name of a call.
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
@@ -389,6 +426,23 @@ pub enum CallName {
     /// Loop over the given function a bounded number of times until it returns success.
     ForWhile(FunctionName),
 }
+
+impl_require_feature!(CallName {
+    variants:
+        Jet(_),
+        UnwrapLeft(ty),
+        UnwrapRight(ty),
+        Unwrap,
+        IsNone(ty),
+        Assert,
+        Panic,
+        Debug,
+        TypeCast(ty),
+        Custom(_),
+        Fold(_, _),
+        ArrayFold(_, _),
+        ForWhile(_),
+});
 
 /// A type alias.
 #[derive(Clone, Debug)]
@@ -435,6 +489,8 @@ impl TypeAlias {
 
 impl_eq_hash!(TypeAlias; name, ty);
 
+impl_require_feature!(TypeAlias { recurse: ty; });
+
 /// An expression is something that returns a value.
 #[derive(Clone, Debug)]
 pub struct Expression {
@@ -478,6 +534,8 @@ impl Expression {
 
 impl_eq_hash!(Expression; inner);
 
+impl_require_feature!(Expression { recurse: inner; });
+
 /// The kind of expression.
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub enum ExpressionInner {
@@ -488,6 +546,12 @@ pub enum ExpressionInner {
     /// The block returns nothing (unit) if there is no final expression.
     Block(Arc<[Statement]>, Option<Arc<Expression>>),
 }
+
+impl_require_feature!(ExpressionInner {
+    variants:
+        Single(single),
+        Block(statements, maybe_expr),
+});
 
 /// A single expression directly returns a value.
 #[derive(Clone, Debug)]
@@ -509,6 +573,8 @@ impl SingleExpression {
 }
 
 impl_eq_hash!(SingleExpression; inner);
+
+impl_require_feature!(SingleExpression {recurse: inner; });
 
 /// The kind of single expression.
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
@@ -546,6 +612,25 @@ pub enum SingleExpressionInner {
     /// The exclusive upper bound on the list size is not known at this point
     List(Arc<[Expression]>),
 }
+
+impl_require_feature!(SingleExpressionInner {
+    variants:
+        Either(either),
+        Option(maybe_expr),
+        Boolean(_),
+        Decimal(_),
+        Binary(_),
+        Hexadecimal(_),
+        Witness(_),
+        Parameter(_),
+        Variable(_),
+        Call(call),
+        Expression(expr),
+        Match(match_),
+        Tuple(exprs),
+        Array(exprs),
+        List(exprs),
+});
 
 /// Match expression.
 #[derive(Clone, Debug)]
@@ -592,6 +677,8 @@ impl Match {
 
 impl_eq_hash!(Match; scrutinee, left, right);
 
+impl_require_feature!(Match {recurse: scrutinee, left, right; });
+
 /// Arm of a match expression.
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct MatchArm {
@@ -611,6 +698,8 @@ impl MatchArm {
     }
 }
 
+impl_require_feature!(MatchArm {recurse: pattern, expression; });
+
 /// Pattern of a match arm.
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
@@ -628,6 +717,16 @@ pub enum MatchPattern {
     /// Match true value (no binding).
     True,
 }
+
+impl_require_feature!(MatchPattern {
+    variants:
+        Left(pattern, ty),
+        Right(pattern, ty),
+        None,
+        Some(pattern, ty),
+        False,
+        True,
+});
 
 impl MatchPattern {
     /// Access the pattern of a match pattern that binds a variables.
@@ -659,6 +758,11 @@ pub struct Module {
     items: Arc<[Item]>,
     span: Span,
 }
+
+impl_require_feature!(Module {
+    requires: UnstableFeature::Imports, span: span;
+    recurse: items;
+});
 
 impl Module {
     /// Needed by the driver to wrap a single file into a module.
@@ -1111,8 +1215,12 @@ pub trait ParseFromStr: Sized {
 /// Trait for parsing with collection of errors.
 pub trait ParseFromStrWithErrors: Sized {
     /// Parse a value from the string `s` with Errors.
+    ///
+    /// Feature-gated syntax in the parsed AST is checked against
+    /// `unstable_features`; uses of disabled features are pushed to `handler`.
     fn parse_from_str_with_errors(
         source: impl Into<SourceFile>,
+        unstable_features: &UnstableFeatures,
         handler: &mut ErrorCollector,
     ) -> Option<Self>;
 }
@@ -1157,28 +1265,32 @@ impl<A: ChumskyParse + std::fmt::Debug> ParseFromStr for A {
     }
 }
 
-impl<A: ChumskyParse + std::fmt::Debug> ParseFromStrWithErrors for A {
+impl<A: ChumskyParse + crate::unstable::RequireFeature + std::fmt::Debug> ParseFromStrWithErrors
+    for A
+{
     fn parse_from_str_with_errors(
         source: impl Into<SourceFile>,
+        unstable_features: &UnstableFeatures,
         handler: &mut ErrorCollector,
     ) -> Option<Self> {
         let source: SourceFile = source.into();
-        let s = &source.content().to_string();
-        let (tokens, lex_errs) = crate::lexer::lex(s);
+        let src = source.content().to_string();
 
+        let (tokens, lex_errs) = crate::lexer::lex(&src);
+        let lex_ok = lex_errs.is_empty();
         handler.extend(source.clone(), lex_errs);
         let tokens = tokens?;
 
+        let eoi = (src.len()..src.len()).into();
         let (ast, parse_errs) = A::parser()
-            .map_with(|parsed, _| parsed)
-            .parse(
-                tokens
-                    .as_slice()
-                    .map((s.len()..s.len()).into(), |(t, s)| (t, s)),
-            )
+            .parse(tokens.as_slice().map(eoi, |(t, s)| (t, s)))
             .into_output_errors();
-
+        let parse_ok = parse_errs.is_empty();
         handler.extend(source.clone(), parse_errs);
+
+        if let (Some(ast), true) = (&ast, lex_ok && parse_ok) {
+            unstable_features.check_program(ast, &source, handler);
+        }
 
         // TODO: We should return parsed result if we found errors, but because analyzing in `ast` module
         // is not handling poisoned tree right now, we don't return parsed result
@@ -2588,7 +2700,11 @@ mod test {
         let input = "fn main() { let ab: u8 = <(u4, u4)> : :into((0b1011, 0b1101)); }";
         let source = SourceFile::anonymous(Arc::from(input));
         let mut error_handler = ErrorCollector::new();
-        let parse_program = Program::parse_from_str_with_errors(source, &mut error_handler);
+        let parse_program = Program::parse_from_str_with_errors(
+            source,
+            &UnstableFeatures::all(),
+            &mut error_handler,
+        );
 
         assert!(parse_program.is_none());
         assert!(ErrorCollector::to_string(&error_handler).contains("Expected '::', found ':'"));
@@ -2599,10 +2715,102 @@ mod test {
         let input = "fn main() { let pk: Pubkey = witnes::::PK; }";
         let source = SourceFile::anonymous(Arc::from(input));
         let mut error_handler = ErrorCollector::new();
-        let parse_program = Program::parse_from_str_with_errors(source, &mut error_handler);
+        let parse_program = Program::parse_from_str_with_errors(
+            source,
+            &UnstableFeatures::all(),
+            &mut error_handler,
+        );
 
         assert!(parse_program.is_none());
         assert!(ErrorCollector::to_string(&error_handler).contains("Expected ';', found '::'"));
+    }
+
+    /// Parse `input` and return whether it was rejected and the collected error text.
+    fn parse_with(input: &str, features: &UnstableFeatures) -> (bool, String) {
+        let source = SourceFile::anonymous(Arc::from(input));
+        let mut handler = ErrorCollector::new();
+        let program = Program::parse_from_str_with_errors(source, features, &mut handler);
+        (program.is_none(), ErrorCollector::to_string(&handler))
+    }
+
+    #[test]
+    fn test_gated_syntax_is_rejected_without_features() {
+        // Real `use`/`mod` syntax: rejected under none() (naming the feature + a
+        // -Z hint), accepted under all(). Delete when `imports` stabilizes.
+        for input in [
+            "use crate::foo::bar;\nfn main() { }",
+            "mod inner { }\nfn main() { }",
+        ] {
+            let (rejected, error) = parse_with(input, &UnstableFeatures::none());
+            assert!(
+                rejected,
+                "gated syntax must be rejected without features (if this feature was \
+                 just stabilized, delete this test):\n{input}"
+            );
+            assert!(
+                error.contains("imports") && error.contains("-Z"),
+                "rejection should name the feature and suggest -Z, got:\n{error}"
+            );
+
+            let (rejected, error) = parse_with(input, &UnstableFeatures::all());
+            assert!(
+                !rejected,
+                "the same syntax must parse with all features enabled:\n{error}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_type_heavy_program_needs_no_features() {
+        // Types are traversed by `RequireFeature` but not gated, so a type-heavy,
+        // import-free program must parse with no features (no false-positive gates).
+        let input = r#"type Alias = u32;
+fn pick(e: Either<u32, u32>) -> u32 {
+    match e {
+        Left(a: u32) => a,
+        Right(b: u32) => b,
+    }
+}
+fn main() {
+    let casted: u32 = <(u16, u16)>::into((0xbeef, 0xbabe));
+    let chosen: Alias = pick(Left(casted));
+    assert!(jet::eq_32(chosen, chosen));
+}
+"#;
+        // `parse_from_str_with_errors` returns `Some` only when no errors were
+        // collected, so a non-rejection already proves there were no gate errors.
+        let (rejected, error) = parse_with(input, &UnstableFeatures::none());
+        assert!(
+            !rejected,
+            "type-heavy but import-free program should parse with no features:\n{error}"
+        );
+    }
+
+    #[test]
+    fn test_syntax_error_does_not_produce_spurious_feature_gate_error() {
+        // The gate check skips error-recovered ASTs, so a program with
+        // both a syntax error and gated syntax reports only the syntax error.
+        let input = "use crate::foo;\nfn main( {";
+        let (rejected, error) = parse_with(input, &UnstableFeatures::none());
+        assert!(rejected, "broken program must be rejected");
+        assert!(
+            !error.contains("-Z"),
+            "syntax error should not produce a spurious feature-gate hint, got:\n{error}"
+        );
+    }
+
+    #[test]
+    fn test_lexer_error_does_not_produce_spurious_feature_gate_error() {
+        // Lexer-side companion to the case above: the stray `@` lexes with an
+        // error but recovers a cleanly-parsing `use` AST, and a program that
+        // didn't lex cleanly skips the gate check — so no spurious `-Z` hint.
+        let input = "use crate@::foo;\nfn main() { }";
+        let (rejected, error) = parse_with(input, &UnstableFeatures::none());
+        assert!(rejected, "program with a lexer error must be rejected");
+        assert!(
+            !error.contains("-Z"),
+            "lexer error should not produce a spurious feature-gate hint, got:\n{error}"
+        );
     }
 
     #[test]

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -10,6 +10,7 @@ use crate::error::Error;
 use crate::named::{CoreExt, PairBuilder, SelectorBuilder};
 use crate::str::Identifier;
 use crate::types::{ResolvedType, TypeInner};
+use crate::unstable::impl_require_feature;
 
 /// Pattern for binding values to variables.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
@@ -74,6 +75,14 @@ impl Pattern {
         Ok(output)
     }
 }
+
+impl_require_feature!(Pattern {
+    variants:
+        Identifier(_),
+        Ignore,
+        Tuple(elements),
+        Array(elements),
+});
 
 impl TreeLike for &Pattern {
     fn as_node(&self) -> Tree<Self> {

--- a/src/types.rs
+++ b/src/types.rs
@@ -8,6 +8,7 @@ use simplicity::types::{CompleteBound, Final};
 use crate::array::{BTreeSlice, Partition};
 use crate::num::{NonZeroPow2Usize, Pow2Usize};
 use crate::str::AliasName;
+use crate::unstable::impl_require_feature;
 
 /// Primitives of the SimplicityHL type system, excluding type aliases.
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
@@ -632,6 +633,28 @@ impl AliasedType {
         self.resolve(|name: &AliasName| Err(name.clone()))
     }
 }
+
+impl_require_feature!(AliasedType {
+    recurse: 0;
+});
+
+impl_require_feature!(AliasedInner {
+    variants:
+        Alias(_),
+        Builtin(_),
+        Inner(inner),
+});
+
+impl_require_feature!(TypeInner<Arc<AliasedType>> {
+    variants:
+        Either(left, right),
+        Option(element),
+        Boolean,
+        UInt(_),
+        Tuple(elements),
+        Array(element, _),
+        List(element, _),
+});
 
 impl TypeConstructible for AliasedType {
     fn either(left: Self, right: Self) -> Self {

--- a/src/unstable.rs
+++ b/src/unstable.rs
@@ -1,0 +1,406 @@
+use std::fmt;
+use std::fmt::Write;
+use std::str::FromStr;
+
+use crate::error::{Error, ErrorCollector, RichError, Span};
+use crate::source::SourceFile;
+
+#[allow(rustdoc::private_intra_doc_links)]
+/// The set of unstable compiler features, enabled per-feature with
+/// `simc -Z <name>`.
+///
+/// # Adding a new feature
+///
+/// 1. Add a variant to this enum.
+/// 2. The compiler will then flag missing arms in `fmt::Display` and
+///    [`Self::description`]; fix each one.
+/// 3. Two hand updates remain the compiler is quiet:
+///    - extend the slice in [`Self::ALL`];
+///    - add a parse arm to `FromStr`.
+/// 4. Gate the syntax itself by pushing a [`FeatureRequirement`] from the
+///    relevant AST node's [`RequireFeature`] impl.
+///
+/// # Stabilizing a feature
+///
+/// Delete the variant. The compiler will then flag every arm in
+/// `fmt::Display`, `FromStr`, [`Self::description`], every entry in
+/// [`Self::ALL`], and every [`FeatureRequirement::new`] call that
+/// referenced the variant; follow the errors to clean up.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum UnstableFeature {
+    /// Import-system syntax: `use` imports, `mod` modules, `as` import
+    /// aliases, and `crate::` paths. Enable with `simc -Z imports`.
+    Imports,
+}
+
+impl UnstableFeature {
+    #[allow(rustdoc::private_intra_doc_links)]
+    /// Every defined feature, used by [`Self::help_message`] for `--help`
+    /// rendering and by [`UnstableFeatures::all`] for "enable everything"
+    /// in tests.
+    ///
+    /// # Third step when adding a feature
+    ///
+    /// Append the new variant here, bump the count in
+    /// `all_contains_every_variant` ( in the `tests` module below), then
+    /// gate the syntax via [`RequireFeature`].
+    pub const ALL: &'static [Self] = &[Self::Imports];
+
+    /// Human-readable description shown next to the feature's name under
+    /// `simc --help`.
+    pub fn description(&self) -> &'static str {
+        match self {
+            Self::Imports => {
+                "Module system syntax: 'use' imports, 'mod' modules, 'as' aliases, 'crate::' paths"
+            }
+        }
+    }
+
+    /// Renders the multi-line block that appears under `-Z,
+    /// --unstable-feature <FEATURE>` in `simc --help`.
+    pub fn help_message() -> String {
+        let max_len = Self::ALL
+            .iter()
+            .map(|feature| feature.to_string().len())
+            .max()
+            .unwrap_or(0);
+
+        let mut out = String::from("Enable unstable features. Available features:");
+
+        for feature in Self::ALL {
+            let _ = write!(
+                out,
+                "\n  {name:<width$}  {desc}",
+                name = feature.to_string(),
+                width = max_len,
+                desc = feature.description(),
+            );
+        }
+
+        out
+    }
+}
+
+/// The set of unstable features that the user has enabled on the command line.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnstableFeatures {
+    enabled_features: Vec<UnstableFeature>,
+}
+
+impl UnstableFeatures {
+    pub fn none() -> Self {
+        Self {
+            enabled_features: Vec::new(),
+        }
+    }
+
+    pub fn all() -> Self {
+        Self::new(UnstableFeature::ALL.iter().copied())
+    }
+
+    pub fn new(features: impl IntoIterator<Item = UnstableFeature>) -> Self {
+        let mut enabled_features: Vec<_> = features.into_iter().collect();
+
+        // `Vec::dedup` removes only consecutive duplicates, so we sort first.
+        enabled_features.sort_unstable();
+        enabled_features.dedup();
+
+        Self { enabled_features }
+    }
+
+    fn is_enabled(&self, feature: UnstableFeature) -> bool {
+        self.enabled_features.contains(&feature) // linear scan; n is always tiny
+    }
+
+    /// Walk a program and push one [`RichError`] per use of a feature
+    /// that this set does not enable.
+    pub(crate) fn check_program(
+        &self,
+        program: &impl RequireFeature,
+        source: &SourceFile,
+        handler: &mut ErrorCollector,
+    ) {
+        let mut uses = Vec::new();
+        program.feature_requirements(&mut uses);
+        for FeatureRequirement { feature, span } in uses {
+            if self.is_enabled(feature) {
+                continue;
+            }
+            let error = Error::UnstableFeature { feature };
+            handler.push(RichError::new(error, span).with_source(source.clone()));
+        }
+    }
+}
+
+/// One recorded use of gated syntax: a feature name and the source span
+/// where it appeared. AST nodes only *record* requirements via
+/// [`RequireFeature::feature_requirements`]; deciding whether to emit an
+/// error happens later in [`UnstableFeatures::check_program`].
+pub(crate) struct FeatureRequirement {
+    feature: UnstableFeature,
+    span: Span,
+}
+
+impl FeatureRequirement {
+    pub(crate) fn new(feature: UnstableFeature, span: Span) -> Self {
+        Self { feature, span }
+    }
+}
+
+/// Implemented by parsed syntax nodes that can require unstable compiler
+/// features.
+///
+/// Each node pushes every feature-gated construct it owns (and
+/// recursively its children's) into `out`. The caller then checks those
+/// uses against the enabled feature set via
+/// [`UnstableFeatures::check_program`].
+///
+/// Implementations must be exhaustive so that new syntax cannot silently
+/// bypass the check: enum impls match on `self` without a wildcard arm
+/// (adding a variant is a compile error until its arm is written), and
+/// struct impls destructure every field (adding a field is a compile
+/// error until the pattern is updated). Prefer [`impl_require_feature`]
+/// for the boilerplate.
+///
+/// # Fourth step when adding a feature
+///
+/// Identify where the new syntax lives:
+///
+/// - **New AST node** (a new `Item`, expression, statement…): write its
+///   `RequireFeature` impl. Push
+///   `FeatureRequirement::new(YourFeature, span)`, then recurse into
+///   children. The parent enum's exhaustive `match self` will fail to
+///   compile until you add a delegate arm there too.
+/// - **New syntax inside an existing node**: extend that node's existing
+///   impl. For types specifically, the new `AliasedType` / `TypeInner`
+///   variant in `src/types.rs` will refuse to compile until classified.
+pub(crate) trait RequireFeature {
+    fn feature_requirements(&self, out: &mut Vec<FeatureRequirement>);
+}
+
+impl<T: RequireFeature + ?Sized> RequireFeature for std::sync::Arc<T> {
+    fn feature_requirements(&self, out: &mut Vec<FeatureRequirement>) {
+        self.as_ref().feature_requirements(out);
+    }
+}
+
+impl<T: RequireFeature> RequireFeature for [T] {
+    fn feature_requirements(&self, out: &mut Vec<FeatureRequirement>) {
+        for item in self {
+            item.feature_requirements(out);
+        }
+    }
+}
+
+impl<T: RequireFeature> RequireFeature for Option<T> {
+    fn feature_requirements(&self, out: &mut Vec<FeatureRequirement>) {
+        if let Some(inner) = self {
+            inner.feature_requirements(out);
+        }
+    }
+}
+
+impl<L: RequireFeature, R: RequireFeature> RequireFeature for either::Either<L, R> {
+    fn feature_requirements(&self, out: &mut Vec<FeatureRequirement>) {
+        match self {
+            either::Either::Left(inner) => inner.feature_requirements(out),
+            either::Either::Right(inner) => inner.feature_requirements(out),
+        }
+    }
+}
+
+/// The canonical CLI name of a feature, used both by `simc -Z <name>` and
+/// by error messages.
+impl fmt::Display for UnstableFeature {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Imports => write!(f, "imports"),
+        }
+    }
+}
+
+/// Parses the name written after `simc -Z` into an [`UnstableFeature`].
+/// Arms must agree with `fmt::Display`
+impl FromStr for UnstableFeature {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "imports" => Ok(UnstableFeature::Imports),
+            _ => Err(format!("Unknown unstable feature: '{s}'")),
+        }
+    }
+}
+
+/// Generate a [`RequireFeature`] impl by listing the fields or variant
+/// payloads to recurse into, and (optionally, for the struct arm) a
+/// feature this whole node requires.
+///
+/// # Examples
+///
+/// ```ignore
+/// // Enum: list every variant. Each tuple slot is either an identifier
+/// // to recurse into, or `_` to skip.
+/// impl_require_feature! {
+///     Item {
+///         variants:
+///             Use(use_decl),
+///             Module(module),
+///             Function(function),
+///             Ignored,
+///     }
+/// }
+///
+/// // Struct: just recurse into the fields that can carry gated syntax.
+/// impl_require_feature! {
+///     Module {
+///         recurse: items;
+///     }
+/// }
+///
+/// // Struct that itself gates a feature. `span: <field>` names the
+/// // struct field that holds the source span attached to the
+/// // requirement.
+/// impl_require_feature! {
+///     UseDecl {
+///         requires: UnstableFeature::Imports, span: span;
+///         recurse: items;
+///     }
+/// }
+/// ```
+macro_rules! impl_require_feature {
+    (@recurse $out:ident; _) => {};
+    (@recurse $out:ident; $field:ident) => {
+        $crate::unstable::RequireFeature::feature_requirements($field, $out);
+    };
+    (
+        $ty:ty {
+            variants:
+                $($variant:ident $(($($field:tt),* $(,)?))?),* $(,)?
+        }
+    ) => {
+        impl $crate::unstable::RequireFeature for $ty {
+            fn feature_requirements(
+                &self,
+                out: &mut Vec<$crate::unstable::FeatureRequirement>,
+            ) {
+                let _ = out;
+
+                match self {
+                    $(
+                        Self::$variant $(($($field),*))? => {
+                            $($(impl_require_feature!(@recurse out; $field);)*)?
+                        },
+                    )*
+                }
+            }
+        }
+    };
+    (
+        $ty:ty {
+            $(requires: $feature:expr, span: $span:ident;)?
+            recurse: $($recurse:tt),* $(,)?;
+        }
+    ) => {
+        impl $crate::unstable::RequireFeature for $ty {
+            fn feature_requirements(
+                &self,
+                out: &mut Vec<$crate::unstable::FeatureRequirement>,
+            ) {
+                let _ = out;
+
+                $(
+                    out.push($crate::unstable::FeatureRequirement::new(
+                        $feature,
+                        self.$span,
+                    ));
+                )?
+                $(
+                    $crate::unstable::RequireFeature::feature_requirements(
+                        &self.$recurse,
+                        out,
+                    );
+                )*
+            }
+        }
+    };
+}
+pub(crate) use impl_require_feature;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+    use std::sync::Arc;
+
+    use crate::source::SourceFile;
+
+    // Just dev sanity check
+    #[test]
+    fn all_contains_every_variant() {
+        let all_features = UnstableFeature::ALL;
+
+        // When you add a variant to `UnstableFeature`, bump this count and add
+        // the variant to `ALL`. Pins that `ALL` stays complete.
+        assert_eq!(
+            all_features.len(),
+            1,
+            "update this count when adding a feature"
+        );
+
+        let mut unique = HashSet::new();
+        for feature in all_features {
+            assert!(unique.insert(*feature), "Features in ALL should be unique");
+        }
+    }
+
+    /// A synthetic node that requires exactly one feature, for testing the
+    /// check mechanism independently of any concrete syntax.
+    struct Requires(UnstableFeature);
+
+    impl RequireFeature for Requires {
+        fn feature_requirements(&self, out: &mut Vec<FeatureRequirement>) {
+            out.push(FeatureRequirement::new(self.0, Span::new(0, 3)));
+        }
+    }
+
+    /// A node requiring a feature is rejected  when no features are enabled,
+    /// and the error names the feature and poitns at the `-Z` flag.
+    #[test]
+    fn test_check_program_rejects_a_disabled_feature() {
+        // `check_program` does not branch on the variant; one feature
+        // witnesses the property for all of them. So, we can check only one instead of each.
+        let Some(&feature) = UnstableFeature::ALL.first() else {
+            return;
+        };
+
+        let mut handler = ErrorCollector::new();
+        let source = SourceFile::anonymous(Arc::from("x"));
+        UnstableFeatures::none().check_program(&Requires(feature), &source, &mut handler);
+
+        let error = handler.to_string();
+        assert!(
+            error.contains(&feature.to_string()),
+            "error should name the feature `{feature}`: {error}"
+        );
+        assert!(error.contains("not enabled"), "{error}");
+        assert!(error.contains("-Z"), "{error}");
+    }
+
+    #[test]
+    fn test_check_program_accepts_each_enabled_feature() {
+        let Some(&feature) = UnstableFeature::ALL.first() else {
+            return;
+        };
+
+        let mut handler = ErrorCollector::new();
+        let source = SourceFile::anonymous(Arc::from("x"));
+        UnstableFeatures::new([feature]).check_program(&Requires(feature), &source, &mut handler);
+
+        assert!(
+            !handler.has_errors(),
+            "enabling `{feature}` should accept a node that requires it: {}",
+            handler
+        );
+    }
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -14,6 +14,8 @@ fn cli_dependency_can_use_crate_root() {
 
     let output = Command::new(env!("CARGO_BIN_EXE_simc"))
         .arg(main)
+        .arg("-Z")
+        .arg("imports")
         .arg("--dep")
         .arg(dep_arg)
         .output()
@@ -25,6 +27,35 @@ fn cli_dependency_can_use_crate_root() {
         output.status.code(),
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+#[test]
+fn cli_import_program_rejected_without_unstable_flag() {
+    let root = repo_path("functional-tests/valid-test-cases/external-library-uses-crate");
+    let main = root.join("main.simf");
+    let ext_lib = root.join("ext_lib");
+    let dep_arg = format!("{}:ext_lib={}", root.display(), ext_lib.display());
+
+    // Same invocation as `cli_dependency_can_use_crate_root`, but without `-Z imports`:
+    // the import syntax must be gated, so the binary exits non-zero and points at
+    // the missing feature flag.
+    let output = Command::new(env!("CARGO_BIN_EXE_simc"))
+        .arg(main)
+        .arg("--dep")
+        .arg(dep_arg)
+        .output()
+        .expect("failed to run simc");
+
+    assert!(
+        !output.status.success(),
+        "simc must reject an import program without -Z imports"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("imports") && stderr.contains("-Z"),
+        "error should name the feature and the flag, got:\n{stderr}"
     );
 }
 


### PR DESCRIPTION
Closes #317

Replaces #329

Added `UnstableFeature` enum to track available unstable features
Added `UnstableFeatures` to check whether a feature is enabled

Added `RequireFeature` trait, implemented for every AST node. Each node reports which unstable features it requires. Struct impls use full field destructuring and enum impls use exhaustive matches, so new nodes or fields cause a compile error until the impl is updated.

The check runs at parse time: once a program parses without errors, any use of a disabled feature is reported with an error naming the feature and the `-Z` flag that enables it.

Added a `-Z <feature>` flag to the CLI. Multiple features can be passed with repeated flags. Available features are listed in the help output.

`simc program.simf -Z imports`

Added `doc/unstable-features.md` with user and developer guides.
