### PR TITLE
tracker: use generic JetHL instead of hardcoding Elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * Remove ModuleProgram and the parsing of Arguments and Witnesses from the core compiler [#323](https://github.com/BlockstreamResearch/SimplicityHL/pull/323)
+* Deprecate the `DefaultTracker::new` [#355](https://github.com/BlockstreamResearch/SimplicityHL/pull/355)
 
 # 0.6.0-rc.0 - 2026-04-24
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -504,6 +504,8 @@ pub trait JetHinter: std::fmt::Debug + Send + Sync {
     fn parse_jet(&self, name: &str) -> Option<Box<dyn JetHL>>;
     /// Constructs an instance of the `verify` jet.
     fn construct_verify(&self) -> Box<dyn JetHL>;
+    /// Converts a runtime Simplicity jet back into this hinter's high-level jet.
+    fn conjure(&self, jet: &dyn Jet) -> Option<Box<dyn JetHL>>;
 
     /// Clones the `JetHinter` into a boxed trait object.
     fn clone_box(&self) -> Box<dyn JetHinter>;
@@ -529,6 +531,12 @@ macro_rules! impl_jet_hinter {
 
             fn construct_verify(&self) -> Box<dyn JetHL> {
                 Box::new($jet_type::Verify)
+            }
+
+            fn conjure(&self, jet: &dyn Jet) -> Option<Box<dyn JetHL>> {
+                jet.as_any()
+                    .downcast_ref::<$jet_type>()
+                    .map(|jet| Box::new(*jet) as Box<dyn JetHL>)
             }
 
             fn clone_box(&self) -> Box<dyn JetHinter> {

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -1,12 +1,12 @@
 use simplicity::bit_machine::{ExecTracker, FrameIter, NodeOutput, PruneTracker, SetTracker};
-use simplicity::jet::{Elements, Jet};
 use simplicity::node::Inner;
 use simplicity::{Ihr, RedeemNode, Value as SimValue};
 
 use crate::array::Unfolder;
+use crate::ast::{ElementsJetHinter, JetHinter};
 use crate::debug::{DebugSymbols, TrackedCallName};
 use crate::either::Either;
-use crate::jet::{source_type, target_type};
+use crate::jet::{source_type, target_type, JetHL};
 use crate::str::AliasName;
 use crate::types::AliasedType;
 use crate::value::StructuralValue;
@@ -22,7 +22,7 @@ type DebugSink<'a> = Box<dyn FnMut(&str, &Value) + 'a>;
 ///
 /// Arguments are: the jet that was executed, its input arguments (if successfully parsed),
 /// and the result (`None` if the jet failed).
-type JetTraceSink<'a> = Box<dyn FnMut(Elements, Option<&[Value]>, Option<Value>) + 'a>;
+type JetTraceSink<'a> = Box<dyn FnMut(&dyn JetHL, Option<&[Value]>, Option<Value>) + 'a>;
 
 /// Callback signature for receiving warnings during execution.
 type WarningSink<'a> = Box<dyn Fn(&str) + 'a>;
@@ -43,7 +43,7 @@ fn default_debug_sink(label: &str, value: &Value) {
 }
 
 /// Default jet trace sink that prints jet calls to stderr.
-fn default_jet_trace_sink(jet: Elements, args: Option<&[Value]>, result: Option<Value>) {
+fn default_jet_trace_sink(jet: &dyn JetHL, args: Option<&[Value]>, result: Option<Value>) {
     print!("{jet:?}(");
     if let Some(args) = args {
         for (i, arg) in args.iter().enumerate() {
@@ -85,6 +85,7 @@ fn default_warning_sink(message: &str) {
 /// ```
 pub struct DefaultTracker<'a> {
     debug_symbols: &'a DebugSymbols,
+    jet_hinter: Box<dyn JetHinter>,
     debug_sink: Option<DebugSink<'a>>,
     jet_trace_sink: Option<JetTraceSink<'a>>,
     warning_sink: Option<WarningSink<'a>>,
@@ -93,9 +94,20 @@ pub struct DefaultTracker<'a> {
 
 impl<'a> DefaultTracker<'a> {
     /// Creates a new tracker bound to the given debug symbol table.
+    ///
+    /// This constructor is deprecated in favor of more flexible tracker setup.
+    /// The deprecation is necessary to show the direction in which the SimplicityHL is moving
+    /// (i.e. different targets and support for possible custom Jets)  
+    #[deprecated(since = "0.6.0", note = "Please use `build` instead")]
     pub fn new(debug_symbols: &'a DebugSymbols) -> Self {
+        Self::build(debug_symbols, Box::new(ElementsJetHinter::new()))
+    }
+
+    /// Creates a new tracker bound to a custom jet family.
+    pub fn build(debug_symbols: &'a DebugSymbols, jet_hinter: Box<dyn JetHinter>) -> Self {
         Self {
             debug_symbols,
+            jet_hinter,
             debug_sink: None,
             jet_trace_sink: None,
             warning_sink: None,
@@ -120,7 +132,7 @@ impl<'a> DefaultTracker<'a> {
     /// Enables forwarding of jet call traces to the provided sink.
     pub fn with_jet_trace_sink<F>(mut self, sink: F) -> Self
     where
-        F: FnMut(Elements, Option<&[Value]>, Option<Value>) + 'a,
+        F: FnMut(&dyn JetHL, Option<&[Value]>, Option<Value>) + 'a,
     {
         self.jet_trace_sink = Some(Box::new(sink));
         self
@@ -175,7 +187,7 @@ impl<'a> DefaultTracker<'a> {
     fn handle_jet(
         &mut self,
         node: &RedeemNode,
-        jet: Elements,
+        jet: &dyn JetHL,
         input: &FrameIter,
         output: &NodeOutput,
     ) {
@@ -208,11 +220,11 @@ impl<'a> DefaultTracker<'a> {
     }
 
     /// Parses the result of a jet execution from the output frame.
-    fn parse_jet_result(node: &RedeemNode, jet: Elements, output: &NodeOutput) -> Option<Value> {
+    fn parse_jet_result(node: &RedeemNode, jet: &dyn JetHL, output: &NodeOutput) -> Option<Value> {
         match output.clone() {
             NodeOutput::Success(mut output_frame) => {
                 let target_ty = &node.arrow().target;
-                let jet_target_ty = resolve_jet_type(&target_type(&jet));
+                let jet_target_ty = resolve_jet_type(&target_type(jet));
 
                 let output_value = SimValue::from_padded_bits(&mut output_frame, target_ty)
                     .expect("output from bit machine is always well-formed");
@@ -303,10 +315,10 @@ impl ExecTracker for DefaultTracker<'_> {
     fn visit_node(&mut self, node: &RedeemNode, input: FrameIter, output: NodeOutput) {
         match node.inner() {
             Inner::Jet(jet) => {
-                if let Some(&elements_jet) = jet.as_any().downcast_ref::<Elements>() {
-                    self.handle_jet(node, elements_jet, &input, &output);
+                if let Some(jet) = self.jet_hinter.conjure(jet.as_ref()) {
+                    self.handle_jet(node, jet.as_ref(), &input, &output);
                 } else {
-                    panic!("Expected an Elements jet, found a different type of jet: {jet:?}");
+                    self.warn(&format!("Unexpected jet type for tracker: {jet:?}"));
                 }
             }
             Inner::AssertL(_, cmr) => self.handle_debug(node, &input, cmr),
@@ -318,8 +330,8 @@ impl ExecTracker for DefaultTracker<'_> {
 }
 
 /// Parses jet input arguments from the bit machine's read frame.
-fn parse_jet_arguments(jet: Elements, input_frame: &mut FrameIter) -> Result<Vec<Value>, String> {
-    let source_types = source_type(&jet);
+fn parse_jet_arguments(jet: &dyn JetHL, input_frame: &mut FrameIter) -> Result<Vec<Value>, String> {
+    let source_types = source_type(jet);
     if source_types.is_empty() {
         return Ok(vec![]);
     }
@@ -389,7 +401,7 @@ mod tests {
     type DebugStore = Rc<RefCell<HashMap<String, String>>>;
     type JetStore = Rc<RefCell<HashMap<String, (Option<Vec<String>>, Option<String>)>>>;
 
-    fn create_test_tracker(
+    fn create_test_elements_tracker(
         debug_symbols: &DebugSymbols,
     ) -> (DefaultTracker<'_>, DebugStore, JetStore) {
         let debug_store: DebugStore = Rc::default();
@@ -398,7 +410,7 @@ mod tests {
         let debug_clone = debug_store.clone();
         let jet_clone = jet_store.clone();
 
-        let tracker = DefaultTracker::new(debug_symbols)
+        let tracker = DefaultTracker::build(debug_symbols, Box::new(ElementsJetHinter::new()))
             .with_debug_sink(move |label, value| {
                 debug_clone
                     .borrow_mut()
@@ -444,7 +456,8 @@ mod tests {
         let program = program.instantiate(Arguments::default(), true).unwrap();
         let satisfied = program.satisfy(WitnessValues::default()).unwrap();
 
-        let (mut tracker, debug_store, jet_store) = create_test_tracker(&satisfied.debug_symbols);
+        let (mut tracker, debug_store, jet_store) =
+            create_test_elements_tracker(&satisfied.debug_symbols);
         let env = create_test_env();
 
         let _ = satisfied
@@ -514,7 +527,7 @@ mod tests {
         let program = program.instantiate(Arguments::default(), true).unwrap();
         let satisfied = program.satisfy(WitnessValues::default()).unwrap();
 
-        let (mut tracker, _, jet_store) = create_test_tracker(&satisfied.debug_symbols);
+        let (mut tracker, _, jet_store) = create_test_elements_tracker(&satisfied.debug_symbols);
 
         let _ = satisfied.redeem().prune_with_tracker(&env, &mut tracker);
 
@@ -570,7 +583,7 @@ mod tests {
         let program = program.instantiate(Arguments::default(), true).unwrap();
         let satisfied = program.satisfy(WitnessValues::default()).unwrap();
 
-        let (mut tracker, _, jet_store) = create_test_tracker(&satisfied.debug_symbols);
+        let (mut tracker, _, jet_store) = create_test_elements_tracker(&satisfied.debug_symbols);
 
         let _ = satisfied.redeem().prune_with_tracker(&env, &mut tracker);
 

--- a/tests/core_tracker.rs
+++ b/tests/core_tracker.rs
@@ -1,0 +1,61 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use simplicityhl::ast::CoreJetHinter;
+use simplicityhl::simplicity::jet::CoreEnv;
+use simplicityhl::tracker::DefaultTracker;
+use simplicityhl::{Arguments, TemplateProgram, WitnessValues};
+
+const CORE_PROGRAM: &str = r#"fn main() {
+    let (_, sum): (bool, u32) = jet::add_32(10, 20);
+    assert!(jet::eq_32(sum, 30));
+}"#;
+
+fn satisfied_core_program() -> simplicityhl::SatisfiedProgram {
+    TemplateProgram::new(CORE_PROGRAM, Box::new(CoreJetHinter::new()))
+        .unwrap()
+        .instantiate(Arguments::default(), true)
+        .unwrap()
+        .satisfy(WitnessValues::default())
+        .unwrap()
+}
+
+#[test]
+fn core_program_prunes_without_tracker() {
+    let satisfied = satisfied_core_program();
+    satisfied.redeem().prune(&CoreEnv::new()).unwrap();
+}
+
+#[test]
+fn core_program_should_not_panic_with_core_tracker() {
+    let satisfied = satisfied_core_program();
+    let mut tracker =
+        DefaultTracker::build(satisfied.debug_symbols(), Box::new(CoreJetHinter::new()));
+
+    satisfied
+        .redeem()
+        .prune_with_tracker(&CoreEnv::new(), &mut tracker)
+        .unwrap();
+}
+
+#[test]
+fn core_program_traces_core_jets() {
+    let satisfied = satisfied_core_program();
+    let traced_jets = Rc::new(RefCell::new(Vec::new()));
+    let traced_jets_clone = traced_jets.clone();
+    let mut tracker =
+        DefaultTracker::build(satisfied.debug_symbols(), Box::new(CoreJetHinter::new()))
+            .with_jet_trace_sink(move |jet, _args, _result| {
+                traced_jets_clone.borrow_mut().push(jet.to_string());
+            });
+
+    satisfied
+        .redeem()
+        .prune_with_tracker(&CoreEnv::new(), &mut tracker)
+        .unwrap();
+
+    assert!(
+        traced_jets.borrow().iter().any(|jet| jet == "add_32"),
+        "expected add_32 to be traced as a Core jet"
+    );
+}


### PR DESCRIPTION
Refactor tracker to support changes in #334

Now, when `CoreJetHinter` is passed to `prune_with_tracker`, the function will not panic with the message that `Elements Jet` was expected.

If an unexpected Jet is encountered, it will be piped to the warning sink