### PR TITLE
Optimize `DependencyMapBuilder` for multiple entry roots

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1059,7 +1059,6 @@ impl Program {
         })
     }
 
-    // Put this helper function inside your impl block or just above your logic
     fn extract_single_main(items: &[Item]) -> Result<Option<Expression>, Error> {
         let mut main_expr = None;
 

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -397,8 +397,7 @@ struct CurrentModule {
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
-    use crate::resolution::tests::canon;
-    use crate::resolution::DependencyMapBuilder;
+    use crate::resolution::tests::{build_map, canon};
     use crate::test_utils::TempWorkspace;
 
     /// Initializes a raw graph environment for testing, explicitly allowing for and capturing failure states.
@@ -437,11 +436,8 @@ pub(crate) mod tests {
         let lib_dir = canon(&ws.create_dir("workspace/libs/lib"));
 
         // Set up the dependency map for imports (e.g. `use lib::...`)
-        let map = DependencyMapBuilder::new(workspace_dir.clone())
-            .add_dependency(workspace_dir.clone(), "lib".to_string(), lib_dir.clone())
-            .build()
-            .expect("Failed to create dependency map");
-        let map = Arc::new(map);
+        let map =
+            Arc::new(build_map(&workspace_dir, &[(&workspace_dir, "lib", &lib_dir)]).unwrap());
 
         let mut root_file_path = None;
         let mut root_content = String::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -422,7 +422,7 @@ pub trait ArbitraryOfType: Sized {
 pub(crate) mod tests {
     use crate::ast::ElementsJetHinter;
     use crate::parse::ParseFromStr;
-    use crate::resolution::tests::canon;
+    use crate::resolution::tests::{build_map, canon};
     use crate::resolution::DependencyMapBuilder;
     use crate::source::CanonPath;
     use crate::test_utils::TempWorkspace;
@@ -471,15 +471,15 @@ pub(crate) mod tests {
     {
         let parent = prog_path.as_ref().parent().unwrap();
         let canon_root = canon(parent);
-        let mut builder = DependencyMapBuilder::new(canon_root);
+        let mut builder = DependencyMapBuilder::new();
 
         for (context, alias, target) in dependencies {
             let context = canon(context.as_ref());
             let target = canon(target.as_ref());
 
-            builder = builder.add_dependency(context, alias.into(), target);
+            builder.add_dependency(context, alias.into(), target);
         }
-        builder.build().unwrap()
+        builder.build(canon_root).unwrap()
     }
 
     pub(crate) struct TestCase<T> {
@@ -871,7 +871,7 @@ pub(crate) mod tests {
         let main_path = root.join(MAIN);
         let canon_root = CanonPath::canonicalize(&root).unwrap();
 
-        let dependency_map = DependencyMapBuilder::new(canon_root).build().unwrap();
+        let dependency_map = build_map(&canon_root, &[]).unwrap();
 
         TestCase::<TemplateProgram>::template_deps(&main_path, &dependency_map)
             .with_arguments(Arguments::default())
@@ -1304,8 +1304,7 @@ mod error_tests {
     use super::*;
 
     use crate::ast::ElementsJetHinter;
-    use crate::resolution::tests::canon;
-    use crate::resolution::DependencyMapBuilder;
+    use crate::resolution::tests::{build_map, canon};
     use crate::source::CanonPath;
     use crate::test_utils::TempWorkspace;
 
@@ -1313,10 +1312,7 @@ mod error_tests {
         let context = CanonPath::canonicalize(root_dir).unwrap();
         let target = CanonPath::canonicalize(lib_dir).unwrap();
 
-        DependencyMapBuilder::new(context.clone())
-            .add_dependency(context, drp.into(), target)
-            .build()
-            .unwrap()
+        build_map(&context, &[(&context, drp, &target)]).unwrap()
     }
 
     fn source_file(path: &Path) -> CanonSourceFile {
@@ -1407,7 +1403,8 @@ mod error_tests {
 #[cfg(test)]
 mod functional_tests {
     use crate::ast::ElementsJetHinter;
-    use crate::resolution::{DependencyMap, DependencyMapBuilder};
+    use crate::resolution::tests::build_map;
+    use crate::resolution::DependencyMap;
     use crate::source::{CanonPath, CanonSourceFile};
     use crate::tests::{flatten_multidep_test, run_dependency_test, run_multidep_test};
     use crate::{Arguments, CompiledProgram};
@@ -1616,12 +1613,9 @@ mod functional_tests {
         let lib_canon = CanonPath::canonicalize(&lib_dir).unwrap();
 
         // 3. Set up the dependency maps
-        let dependency_map = DependencyMapBuilder::new(root_canon.clone())
-            .add_dependency(root_canon.clone(), "lib".to_string(), lib_canon)
-            .build()
-            .unwrap();
+        let dependency_map = build_map(&root_canon, &[(&root_canon, "lib", &lib_canon)]).unwrap();
 
-        let no_dependency_map = DependencyMapBuilder::new(root_canon).build().unwrap();
+        let no_dependency_map = build_map(&root_canon, &[]).unwrap();
 
         // Compile both programs reading directly from the file system
         let poisoned = compile_with_deps(&poisoned_main, &dependency_map);

--- a/src/main.rs
+++ b/src/main.rs
@@ -135,7 +135,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .and_then(|p| CanonPath::canonicalize(p).ok())
         .ok_or("Failed to determine project root directory from entry file")?;
 
-    let mut builder = DependencyMapBuilder::new(canon_root.clone());
+    let mut builder = DependencyMapBuilder::new();
 
     for arg in dep_args {
         let (left_side, path_str) = arg.split_once('=').unwrap_or_else(|| {
@@ -157,11 +157,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         };
 
         let target_path = CanonPath::canonicalize(Path::new(path_str))?;
-
-        builder = builder.add_dependency(context_path, alias.to_string(), target_path);
+        builder.add_dependency(context_path, alias.to_string(), target_path);
     }
 
-    let dependencies = match builder.build() {
+    let dependencies = match builder.build(canon_root.clone()) {
         Ok(map) => map,
         Err(e) => {
             eprintln!("Error: {e}");

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::driver::CRATE_STR;
 use crate::error::{Error, RichError, WithSpan as _};
 use crate::parse::UseDecl;
@@ -42,7 +44,7 @@ fn is_valid_dependency_identifier(s: &str) -> bool {
 #[derive(Debug, Clone)]
 pub struct DependencyMap {
     /// External dependency remappings (e.g., `use math::...`)
-    remappings: Vec<Remapping>,
+    remappings: Arc<Vec<Remapping>>,
     /// Package roots for resolving local workspace paths (`crate::...`).
     ///
     /// In a multi-file workspace with nested dependencies,
@@ -54,21 +56,130 @@ pub struct DependencyMap {
     package_roots: Vec<CanonPath>,
 }
 
+/// Pre-validated, frozen dependency graph without an entry root.
+///
+/// Built once from [`DependencyMapBuilder::validate_deps`] — all filesystem checks,
+/// identifier validation, and sorting are done at this stage.
 #[derive(Debug, Clone)]
+pub struct ValidatedDeps {
+    /// Already validated and sorted by longest context prefix.
+    ///
+    /// Wrapped in `Arc` so multiple [`DependencyMap`]'s produced by `with_root`
+    /// share the same `Vec` instead of deep-cloning every `Remapping` per call.
+    remappings: Arc<Vec<Remapping>>,
+    /// Package roots contributed by deps only; entry root is excluded here
+    /// because it changes per call. Already deduped and sorted.
+    dep_roots: Arc<[CanonPath]>,
+}
+
+impl ValidatedDeps {
+    /// Attaches a new entry root and produces a [`DependencyMap`].
+    ///
+    /// Only validates the root directory — all dependency checks were done once
+    /// in [`DependencyMapBuilder::validate_deps`] and are not repeated here.
+    /// Cost: one `validate_dir` call + one sort of `package_roots`.
+    pub fn with_root(&self, entry_root: CanonPath) -> Result<DependencyMap, Error> {
+        DependencyMapBuilder::validate_dir(&entry_root)?;
+
+        // Build the full set of package roots: entry root + pre-validated dep roots.
+        // No `HashSet` here because for the small `N` we expect (~200 max), allocating a `HashSet`
+        // and re-collecting into a `Vec` costs more than sorting then deduplicating in place.
+        let mut package_roots: Vec<CanonPath> = std::iter::once(entry_root)
+            .chain(self.dep_roots.iter().cloned())
+            .collect();
+
+        package_roots.sort_by(Self::cmp_by_path_len_desc);
+        package_roots.dedup();
+
+        Ok(DependencyMap {
+            // Remappings are already sorted
+            remappings: self.remappings.clone(),
+            package_roots,
+        })
+    }
+
+    /// Comparator for sorting paths by descending length, then alphabetically.
+    /// Ensures longest-prefix-match works correctly on the resulting vector.
+    fn cmp_by_path_len_desc(a: &CanonPath, b: &CanonPath) -> std::cmp::Ordering {
+        b.as_path()
+            .as_os_str()
+            .len()
+            .cmp(&a.as_path().as_os_str().len())
+            .then_with(|| a.cmp(b))
+    }
+}
+
+/// Builder for [`DependencyMap`].
+///
+/// Supports two usage patterns:
+///
+/// - **Single entry root**: call [`build`](Self::build) directly.
+/// - **Multiple entry roots with shared deps**: call [`validate_deps`](Self::validate_deps)
+///   once, then call [`with_root`](ValidatedDeps::with_root) for each entry point.
+#[derive(Debug, Clone, Default)]
 pub struct DependencyMapBuilder {
-    entry_root: CanonPath,
     deps: Vec<Remapping>,
 }
 
 impl DependencyMapBuilder {
-    pub fn new(entry_root: CanonPath) -> Self {
-        Self {
-            entry_root,
-            deps: Vec::new(),
-        }
+    pub fn new() -> Self {
+        Self::default()
     }
 
-    pub fn add_dependency(mut self, context: CanonPath, alias: String, target: CanonPath) -> Self {
+    /// Convenience method for single-root use cases
+    pub fn build(self, entry_root: CanonPath) -> Result<DependencyMap, Error> {
+        self.validate_deps()?.with_root(entry_root)
+    }
+
+    /// validates and freezes all dependencies into a reusable [`ValidatedDeps`].
+    ///
+    /// Performs all filesystem checks and sorting exactly once — O(n log n).
+    /// The result can then be combined with any number of entry roots via
+    /// [`ValidatedDeps::with_root`] without repeating this work.
+    pub fn validate_deps(self) -> Result<ValidatedDeps, Error> {
+        let mut seen =
+            std::collections::HashSet::<(CanonPath, String)>::with_capacity(self.deps.len());
+        let mut dep_roots = Vec::<CanonPath>::with_capacity(self.deps.len());
+        let mut remappings = Vec::<Remapping>::with_capacity(self.deps.len());
+
+        for dep in self.deps {
+            Self::validate_dir(&dep.context_prefix)?;
+            Self::validate_dir(&dep.target)?;
+            Self::validate_dependency_identifier(&dep.drp_name)?;
+
+            if !seen.insert((dep.context_prefix.clone(), dep.drp_name.clone())) {
+                return Err(Error::DuplicateDependencyAlias {
+                    alias: dep.drp_name,
+                    context: dep.context_prefix.as_path().display().to_string(),
+                });
+            }
+
+            dep_roots.push(dep.target.clone());
+            remappings.push(dep);
+        }
+
+        // Re-sort the vector in descending order so the longest context paths are always at the front.
+        // This mathematically guarantees that the first match we find is the most specific.
+        remappings.sort_by(|a, b| {
+            ValidatedDeps::cmp_by_path_len_desc(&a.context_prefix, &b.context_prefix)
+                .then_with(|| a.drp_name.cmp(&b.drp_name))
+        });
+
+        dep_roots.sort_by(ValidatedDeps::cmp_by_path_len_desc);
+        dep_roots.dedup();
+
+        Ok(ValidatedDeps {
+            remappings: Arc::new(remappings),
+            dep_roots: dep_roots.into(),
+        })
+    }
+
+    pub fn add_dependency(
+        &mut self,
+        context: CanonPath,
+        alias: String,
+        target: CanonPath,
+    ) -> &mut Self {
         self.deps.push(Remapping {
             context_prefix: context,
             drp_name: alias,
@@ -77,87 +188,33 @@ impl DependencyMapBuilder {
         self
     }
 
-    pub fn build(self) -> Result<DependencyMap, Error> {
-        let mut remappings = Vec::new();
-        let mut crate_roots = Vec::new();
-
-        // This guarantees that `crate_roots` is never empty, so `get_package_root()`
-        // will always return `Some()` for files under the entry root.
-        let root = self.entry_root;
-        if !root.as_path().exists() {
+    fn validate_dir(path: &CanonPath) -> Result<(), Error> {
+        if !path.as_path().exists() {
             return Err(Error::DependencyPathNotFound {
-                path: root.as_path().into(),
+                path: path.as_path().into(),
             });
         }
-        if !root.as_path().is_dir() {
+        if !path.as_path().is_dir() {
             return Err(Error::DependencyNotADirectory {
-                path: root.as_path().into(),
+                path: path.as_path().into(),
             });
         }
-        crate_roots.push(root);
+        Ok(())
+    }
 
-        for dep in self.deps {
-            if !dep.context_prefix.as_path().exists() {
-                return Err(Error::DependencyPathNotFound {
-                    path: dep.context_prefix.as_path().into(),
-                });
-            }
-            if !dep.context_prefix.as_path().is_dir() {
-                return Err(Error::DependencyNotADirectory {
-                    path: dep.context_prefix.as_path().into(),
-                });
-            }
-            if !dep.target.as_path().exists() {
-                return Err(Error::DependencyPathNotFound {
-                    path: dep.target.as_path().into(),
-                });
-            }
-            if !dep.target.as_path().is_dir() {
-                return Err(Error::DependencyNotADirectory {
-                    path: dep.target.as_path().into(),
-                });
-            }
-
-            if !is_valid_dependency_identifier(&dep.drp_name) {
-                if dep.drp_name == CRATE_STR {
-                    return Err(Error::ReservedDependencyKeyword {
-                        keyword: dep.drp_name,
-                    });
-                }
-                return Err(Error::InvalidDependencyIdentifier {
-                    alias: dep.drp_name,
-                });
-            }
-
-            // Reject duplicates: same context and same alias
-            if remappings.iter().any(|r: &Remapping| {
-                r.context_prefix == dep.context_prefix && r.drp_name == dep.drp_name
-            }) {
-                return Err(Error::DuplicateDependencyAlias {
-                    alias: dep.drp_name.clone(),
-                    context: dep.context_prefix.as_path().display().to_string(),
-                });
-            }
-
-            crate_roots.push(dep.target.clone());
-            remappings.push(dep);
+    fn validate_dependency_identifier(alias: &str) -> Result<(), Error> {
+        if is_valid_dependency_identifier(alias) {
+            return Ok(());
         }
-
-        // Sort package roots by length descending (for longest prefix match),
-        // and then alphabetically to group duplicates together for deduplication.
-        crate_roots.sort_by(|a, b| {
-            let len_a = a.as_path().as_os_str().len();
-            let len_b = b.as_path().as_os_str().len();
-            len_b.cmp(&len_a).then_with(|| a.cmp(b))
-        });
-        crate_roots.dedup();
-
-        let mut map = DependencyMap {
-            remappings,
-            package_roots: crate_roots,
-        };
-        map.sort_mappings();
-        Ok(map)
+        if alias == CRATE_STR {
+            Err(Error::ReservedDependencyKeyword {
+                keyword: alias.to_string(),
+            })
+        } else {
+            Err(Error::InvalidDependencyIdentifier {
+                alias: alias.to_string(),
+            })
+        }
     }
 }
 
@@ -184,19 +241,6 @@ pub(crate) struct ResolvedUse {
 }
 
 impl DependencyMap {
-    /// Re-sort the vector in descending order so the longest context paths are always at the front.
-    /// This mathematically guarantees that the first match we find is the most specific.
-    fn sort_mappings(&mut self) {
-        self.remappings.sort_by(|a, b| {
-            let len_a = a.context_prefix.as_path().as_os_str().len();
-            let len_b = b.context_prefix.as_path().as_os_str().len();
-            len_b
-                .cmp(&len_a)
-                .then_with(|| a.context_prefix.cmp(&b.context_prefix))
-                .then_with(|| a.drp_name.cmp(&b.drp_name))
-        });
-    }
-
     /// Returns the package root for the given file, which corresponds to the
     /// target directory of the most specific dependency or the entry root.
     pub fn get_package_root(&self, current_file: &CanonPath) -> Option<&CanonPath> {
@@ -393,19 +437,35 @@ pub(crate) mod tests {
         UseDecl::dummy_path(path)
     }
 
+    /// Creates directories under `ws` and returns their canonical paths.
+    fn dirs<const N: usize>(ws: &TempWorkspace, paths: [&str; N]) -> [CanonPath; N] {
+        paths.map(|p| canon(&ws.create_dir(p)))
+    }
+
+    /// Creates empty files under `ws` and returns their canonical paths.
+    fn files<const N: usize>(ws: &TempWorkspace, paths: [&str; N]) -> [CanonPath; N] {
+        paths.map(|p| canon(&ws.create_file(p, "")))
+    }
+
+    /// Builds a `DependencyMap`, hiding the `.clone()` and `.to_string()` noise of `add_dependency`.
+    pub(crate) fn build_map(
+        root: &CanonPath,
+        deps: &[(&CanonPath, &str, &CanonPath)],
+    ) -> Result<DependencyMap, Error> {
+        let mut builder = DependencyMapBuilder::new();
+        for (ctx, alias, target) in deps {
+            builder.add_dependency((*ctx).clone(), alias.to_string(), (*target).clone());
+        }
+        builder.build(root.clone())
+    }
+
     /// Attempting to manually map the `crate` keyword using `insert()` must result in an error.
     #[test]
     fn test_insert_crate_fails() {
         let ws = TempWorkspace::new("insert_crate_fail");
-        let project_dir = canon(&ws.create_dir("workspace"));
+        let [project_dir] = dirs(&ws, ["workspace"]);
 
-        let result = DependencyMapBuilder::new(project_dir.clone())
-            .add_dependency(
-                project_dir.clone(),
-                CRATE_STR.to_string(),
-                project_dir.clone(),
-            )
-            .build();
+        let result = build_map(&project_dir, &[(&project_dir, CRATE_STR, &project_dir)]);
 
         assert!(matches!(
             result.unwrap_err(),
@@ -419,20 +479,27 @@ pub(crate) mod tests {
     fn test_sorting_longest_prefix() {
         let ws = TempWorkspace::new("sorting");
 
-        let workspace_dir = canon(&ws.create_dir("workspace"));
-        let nested_dir = canon(&ws.create_dir("workspace/project_a/nested"));
-        let project_a_dir = canon(&ws.create_dir("workspace/project_a"));
+        let [workspace_dir, project_a_dir, nested_dir, target_v1, target_v2, target_v3] = dirs(
+            &ws,
+            [
+                "workspace",
+                "workspace/project_a",
+                "workspace/project_a/nested",
+                "lib/math_v1",
+                "lib/math_v2",
+                "lib/math_v3",
+            ],
+        );
 
-        let target_v1 = canon(&ws.create_dir("lib/math_v1"));
-        let target_v3 = canon(&ws.create_dir("lib/math_v3"));
-        let target_v2 = canon(&ws.create_dir("lib/math_v2"));
-
-        let map = DependencyMapBuilder::new(workspace_dir.clone())
-            .add_dependency(workspace_dir.clone(), "math".to_string(), target_v1)
-            .add_dependency(nested_dir.clone(), "math".to_string(), target_v3)
-            .add_dependency(project_a_dir.clone(), "math".to_string(), target_v2)
-            .build()
-            .unwrap();
+        let map = build_map(
+            &workspace_dir,
+            &[
+                (&workspace_dir, "math", &target_v1),
+                (&nested_dir, "math", &target_v3),
+                (&project_a_dir, "math", &target_v2),
+            ],
+        )
+        .unwrap();
 
         // The longest prefixes should bubble to the top
         assert_eq!(map.remappings[0].context_prefix, nested_dir);
@@ -446,14 +513,10 @@ pub(crate) mod tests {
     fn test_context_isolation() {
         let ws = TempWorkspace::new("isolation");
 
-        let project_a = canon(&ws.create_dir("project_a"));
-        let target_utils = canon(&ws.create_dir("libs/utils_a"));
-        let current_file = canon(&ws.create_file("project_b/main.simf", ""));
+        let [project_a, target_utils] = dirs(&ws, ["project_a", "libs/utils_a"]);
+        let [current_file] = files(&ws, ["project_b/main.simf"]);
 
-        let map = DependencyMapBuilder::new(project_a.clone())
-            .add_dependency(project_a, "utils".to_string(), target_utils)
-            .build()
-            .unwrap();
+        let map = build_map(&project_a, &[(&project_a, "utils", &target_utils)]).unwrap();
 
         let use_decl = create_dummy_use_decl(&["utils"]);
         let result = map.resolve_path(&current_file, &use_decl);
@@ -471,29 +534,45 @@ pub(crate) mod tests {
     fn test_resolve_longest_prefix_match() {
         let ws = TempWorkspace::new("resolve_prefix");
 
-        let global_context = canon(&ws.create_dir("workspace"));
-        let global_target = canon(&ws.create_dir("libs/global_math"));
-        let global_expected = canon(&ws.create_file("libs/global_math/vector.simf", ""));
+        let [global_context, global_target, frontend_context, frontend_target] = dirs(
+            &ws,
+            [
+                "workspace",
+                "libs/global_math",
+                "workspace/frontend",
+                "libs/frontend_math",
+            ],
+        );
 
-        let frontend_context = canon(&ws.create_dir("workspace/frontend"));
-        let frontend_target = canon(&ws.create_dir("libs/frontend_math"));
-        let frontend_expected = canon(&ws.create_file("libs/frontend_math/vector.simf", ""));
+        let [global_expected, frontend_expected, frontend_file, backend_file] = files(
+            &ws,
+            [
+                "libs/global_math/vector.simf",
+                "libs/frontend_math/vector.simf",
+                "workspace/frontend/src/main.simf",
+                "workspace/backend/src/main.simf",
+            ],
+        );
 
-        let map = DependencyMapBuilder::new(global_context.clone())
-            .add_dependency(global_context, "math".to_string(), global_target)
-            .add_dependency(frontend_context, "math".to_string(), frontend_target)
-            .build()
-            .unwrap();
+        let map = build_map(
+            &global_context,
+            &[
+                (&global_context, "math", &global_target),
+                (&frontend_context, "math", &frontend_target),
+            ],
+        )
+        .unwrap();
 
         let use_decl = create_dummy_use_decl(&["math", "vector"]);
 
-        let frontend_file = canon(&ws.create_file("workspace/frontend/src/main.simf", ""));
-        let resolved_frontend = map.resolve_path(&frontend_file, &use_decl).unwrap();
-        assert_eq!(resolved_frontend, frontend_expected);
-
-        let backend_file = canon(&ws.create_file("workspace/backend/src/main.simf", ""));
-        let resolved_backend = map.resolve_path(&backend_file, &use_decl).unwrap();
-        assert_eq!(resolved_backend, global_expected);
+        assert_eq!(
+            map.resolve_path(&frontend_file, &use_decl).unwrap(),
+            frontend_expected
+        );
+        assert_eq!(
+            map.resolve_path(&backend_file, &use_decl).unwrap(),
+            global_expected
+        );
     }
 
     /// It proves that a file inside the local project cannot be imported via an external dependency alias.
@@ -501,18 +580,11 @@ pub(crate) mod tests {
     fn test_local_file_imported_as_external() {
         let ws = TempWorkspace::new("local_as_ext");
 
-        let project_dir = canon(&ws.create_dir("workspace"));
-        ws.create_file("workspace/utils.simf", "");
-        let current_file = canon(&ws.create_file("workspace/main.simf", ""));
+        let [project_dir] = dirs(&ws, ["workspace"]);
+        let [_utils_file, current_file] =
+            files(&ws, ["workspace/utils.simf", "workspace/main.simf"]);
 
-        let map = DependencyMapBuilder::new(project_dir.clone())
-            .add_dependency(
-                project_dir.clone(),
-                "utils_lib".to_string(),
-                project_dir.clone(),
-            )
-            .build()
-            .unwrap();
+        let map = build_map(&project_dir, &[(&project_dir, "utils_lib", &project_dir)]).unwrap();
 
         let use_decl = create_dummy_use_decl(&["utils_lib", "utils"]);
         let result = map.resolve_path(&current_file, &use_decl);
@@ -529,13 +601,10 @@ pub(crate) mod tests {
     fn test_crate_resolution() {
         let ws = TempWorkspace::new("crate_res");
 
-        let project_dir = canon(&ws.create_dir("workspace"));
-        let expected = canon(&ws.create_file("workspace/utils.simf", ""));
-        let current_file = canon(&ws.create_file("workspace/main.simf", ""));
+        let [project_dir] = dirs(&ws, ["workspace"]);
+        let [expected, current_file] = files(&ws, ["workspace/utils.simf", "workspace/main.simf"]);
 
-        let map = DependencyMapBuilder::new(project_dir.clone())
-            .build()
-            .unwrap();
+        let map = build_map(&project_dir, &[]).unwrap();
 
         let use_decl = create_dummy_use_decl(&[CRATE_STR, "utils"]);
         let result = map.resolve_path(&current_file, &use_decl).unwrap();
@@ -549,10 +618,11 @@ pub(crate) mod tests {
     #[test]
     fn test_crate_unconfigured_error() {
         let ws = TempWorkspace::new("crate_unconf");
-        let current_file = canon(&ws.create_file("workspace/main.simf", ""));
 
-        let other_dir = canon(&ws.create_dir("other_dir"));
-        let map = DependencyMapBuilder::new(other_dir).build().unwrap();
+        let [other_dir] = dirs(&ws, ["other_dir"]);
+        let [current_file] = files(&ws, ["workspace/main.simf"]);
+
+        let map = build_map(&other_dir, &[]).unwrap();
 
         let use_decl = create_dummy_use_decl(&[CRATE_STR, "utils"]);
         let result = map.resolve_path(&current_file, &use_decl);
@@ -570,16 +640,16 @@ pub(crate) mod tests {
     fn test_resolve_relative_current_file_against_canonical_context() {
         let ws = TempWorkspace::new("relative_current");
 
-        let context = canon(&ws.create_dir("workspace/frontend"));
-        let target = canon(&ws.create_dir("libs/frontend_math"));
-        let expected = canon(&ws.create_file("libs/frontend_math/vector.simf", ""));
+        let [context, target] = dirs(&ws, ["workspace/frontend", "libs/frontend_math"]);
+        let [expected, current_file] = files(
+            &ws,
+            [
+                "libs/frontend_math/vector.simf",
+                "workspace/frontend/src/main.simf",
+            ],
+        );
 
-        let current_file = canon(&ws.create_file("workspace/frontend/src/main.simf", ""));
-
-        let map = DependencyMapBuilder::new(context.clone())
-            .add_dependency(context, "math".to_string(), target)
-            .build()
-            .unwrap();
+        let map = build_map(&context, &[(&context, "math", &target)]).unwrap();
 
         let use_decl = create_dummy_use_decl(&["math", "vector"]);
         let result = map.resolve_path(&current_file, &use_decl).unwrap();
@@ -590,26 +660,23 @@ pub(crate) mod tests {
     #[test]
     fn test_builder_rejects_file_as_directory() {
         let ws = TempWorkspace::new("file_as_dir");
-        let file_path = canon(&ws.create_file("workspace/not_a_dir.simf", ""));
-        let valid_dir = canon(&ws.create_dir("workspace/valid_dir"));
 
-        let res1 = DependencyMapBuilder::new(file_path.clone()).build();
+        let [valid_dir] = dirs(&ws, ["workspace/valid_dir"]);
+        let [file_path] = files(&ws, ["workspace/not_a_dir.simf"]);
+
+        let res1 = build_map(&file_path, &[]);
         assert!(matches!(
             res1.unwrap_err(),
             Error::DependencyNotADirectory { .. }
         ));
 
-        let res2 = DependencyMapBuilder::new(valid_dir.clone())
-            .add_dependency(file_path.clone(), "alias".to_string(), valid_dir.clone())
-            .build();
+        let res2 = build_map(&valid_dir, &[(&file_path, "alias", &valid_dir)]);
         assert!(matches!(
             res2.unwrap_err(),
             Error::DependencyNotADirectory { .. }
         ));
 
-        let res3 = DependencyMapBuilder::new(valid_dir.clone())
-            .add_dependency(valid_dir.clone(), "alias".to_string(), file_path)
-            .build();
+        let res3 = build_map(&valid_dir, &[(&valid_dir, "alias", &file_path)]);
         assert!(matches!(
             res3.unwrap_err(),
             Error::DependencyNotADirectory { .. }
@@ -619,12 +686,11 @@ pub(crate) mod tests {
     #[test]
     fn test_builder_rejects_non_existent_paths() {
         let ws = TempWorkspace::new("non_existent");
-        let valid_dir = canon(&ws.create_dir("workspace/valid_dir"));
+
+        let [valid_dir] = dirs(&ws, ["workspace/valid_dir"]);
         let fake_path = CanonPath::dummy_for_test(Path::new("/does/not/exist/in/this/universe"));
 
-        let res = DependencyMapBuilder::new(valid_dir.clone())
-            .add_dependency(valid_dir.clone(), "alias".to_string(), fake_path)
-            .build();
+        let res = build_map(&valid_dir, &[(&valid_dir, "alias", &fake_path)]);
         assert!(matches!(
             res.unwrap_err(),
             Error::DependencyPathNotFound { .. }
@@ -634,14 +700,12 @@ pub(crate) mod tests {
     #[test]
     fn test_builder_rejects_invalid_identifiers() {
         let ws = TempWorkspace::new("invalid_idents");
-        let valid_dir = canon(&ws.create_dir("workspace/valid_dir"));
+        let [valid_dir] = dirs(&ws, ["workspace/valid_dir"]);
 
         let bad_aliases = vec!["", "123lib", "my-lib", "lib!", " space "];
 
         for bad_alias in bad_aliases {
-            let res = DependencyMapBuilder::new(valid_dir.clone())
-                .add_dependency(valid_dir.clone(), bad_alias.to_string(), valid_dir.clone())
-                .build();
+            let res = build_map(&valid_dir, &[(&valid_dir, bad_alias, &valid_dir)]);
             assert!(
                 matches!(res.unwrap_err(), Error::InvalidDependencyIdentifier { .. }),
                 "Builder should reject alias: '{}'",
@@ -653,15 +717,12 @@ pub(crate) mod tests {
     #[test]
     fn test_builder_rejects_reserved_keywords() {
         let ws = TempWorkspace::new("reserved_keywords");
-        let valid_dir = canon(&ws.create_dir("workspace/valid_dir"));
+        let [valid_dir] = dirs(&ws, ["workspace/valid_dir"]);
 
-        let keywords = crate::lexer::KEYWORDS.to_vec();
-
-        for kw in keywords {
-            let res = DependencyMapBuilder::new(valid_dir.clone())
-                .add_dependency(valid_dir.clone(), kw.to_string(), valid_dir.clone())
-                .build();
+        for kw in crate::lexer::KEYWORDS.to_vec() {
+            let res = build_map(&valid_dir, &[(&valid_dir, kw, &valid_dir)]);
             let err = res.unwrap_err();
+
             if kw == CRATE_STR {
                 assert!(matches!(err, Error::ReservedDependencyKeyword { .. }));
             } else {
@@ -673,14 +734,23 @@ pub(crate) mod tests {
     #[test]
     fn test_builder_rejects_duplicates() {
         let ws = TempWorkspace::new("duplicates");
-        let valid_dir = canon(&ws.create_dir("workspace/valid_dir"));
-        let target1 = canon(&ws.create_dir("workspace/target1"));
-        let target2 = canon(&ws.create_dir("workspace/target2"));
 
-        let res = DependencyMapBuilder::new(valid_dir.clone())
-            .add_dependency(valid_dir.clone(), "alias".to_string(), target1)
-            .add_dependency(valid_dir.clone(), "alias".to_string(), target2)
-            .build();
+        let [valid_dir, target1, target2] = dirs(
+            &ws,
+            [
+                "workspace/valid_dir",
+                "workspace/target1",
+                "workspace/target2",
+            ],
+        );
+
+        let res = build_map(
+            &valid_dir,
+            &[
+                (&valid_dir, "alias", &target1),
+                (&valid_dir, "alias", &target2),
+            ],
+        );
 
         assert!(matches!(
             res.unwrap_err(),
@@ -691,16 +761,12 @@ pub(crate) mod tests {
     #[test]
     fn test_resolve_rejects_escaping_package_root() {
         let ws = TempWorkspace::new("escaping_root");
-        let context = canon(&ws.create_dir("workspace"));
-        let target = canon(&ws.create_dir("libs/target"));
-        let current_file = canon(&ws.create_file("workspace/main.simf", ""));
 
-        let _outside_file = canon(&ws.create_file("libs/escaped.simf", ""));
+        let [context, target] = dirs(&ws, ["workspace", "libs/target"]);
+        let [current_file, _outside_file] =
+            files(&ws, ["workspace/main.simf", "libs/escaped.simf"]);
 
-        let map = DependencyMapBuilder::new(context.clone())
-            .add_dependency(context, "alias".to_string(), target.clone())
-            .build()
-            .unwrap();
+        let map = build_map(&context, &[(&context, "alias", &target)]).unwrap();
 
         let use_decl = create_dummy_use_decl(&["alias", "..", "escaped"]);
         let result = map.resolve_path(&current_file, &use_decl);
@@ -716,18 +782,16 @@ pub(crate) mod tests {
     fn test_dependency_symlink_escape_rejected() {
         let ws = TempWorkspace::new("dependency_symlink_escape");
 
-        let workspace_dir = canon(&ws.create_dir("workspace"));
+        let [workspace_dir] = dirs(&ws, ["workspace"]);
+
         let dependency_dir_path = ws.create_dir("deps/package");
         let escaped_file = ws.create_file("outside/foo.simf", "");
         std::os::unix::fs::symlink(&escaped_file, dependency_dir_path.join("foo.simf")).unwrap();
 
         let dependency_dir = canon(&dependency_dir_path);
-        let current_file = canon(&ws.create_file("workspace/main.simf", ""));
+        let [current_file] = files(&ws, ["workspace/main.simf"]);
 
-        let map = DependencyMapBuilder::new(workspace_dir.clone())
-            .add_dependency(workspace_dir, "dep".to_string(), dependency_dir)
-            .build()
-            .unwrap();
+        let map = build_map(&workspace_dir, &[(&workspace_dir, "dep", &dependency_dir)]).unwrap();
 
         let use_decl = create_dummy_use_decl(&["dep", "foo"]);
         map.resolve_path(&current_file, &use_decl)
@@ -740,16 +804,18 @@ pub(crate) mod tests {
     fn test_package_roots_deduplication() {
         let ws = TempWorkspace::new("dedup_roots");
 
-        let workspace_dir = canon(&ws.create_dir("workspace"));
-        let lib_a = canon(&ws.create_dir("workspace/libs/A"));
-        let lib_b = canon(&ws.create_dir("workspace/libs/B"));
+        let [workspace_dir, lib_a, lib_b] =
+            dirs(&ws, ["workspace", "workspace/libs/A", "workspace/libs/B"]);
 
-        let map = DependencyMapBuilder::new(workspace_dir.clone())
-            .add_dependency(workspace_dir.clone(), "lib_a".to_string(), lib_a.clone())
-            .add_dependency(workspace_dir.clone(), "lib_b".to_string(), lib_b.clone())
-            .add_dependency(lib_b.clone(), "lib_a".to_string(), lib_a.clone())
-            .build()
-            .unwrap();
+        let map = build_map(
+            &workspace_dir,
+            &[
+                (&workspace_dir, "lib_a", &lib_a),
+                (&workspace_dir, "lib_b", &lib_b),
+                (&lib_b, "lib_a", &lib_a),
+            ],
+        )
+        .unwrap();
 
         // The package roots should only contain workspace_dir, lib_a, and lib_b (exactly 3 unique roots).
         assert_eq!(
@@ -765,15 +831,12 @@ pub(crate) mod tests {
     #[test]
     fn test_crate_resolves_to_closest_package_root() {
         let ws = TempWorkspace::new("closest_root");
-        let workspace_dir = canon(&ws.create_dir("workspace"));
-        let lib_dir = canon(&ws.create_dir("workspace/libs/math"));
 
-        let map = DependencyMapBuilder::new(workspace_dir.clone())
-            .add_dependency(workspace_dir.clone(), "math".to_string(), lib_dir.clone())
-            .build()
-            .unwrap();
+        let [workspace_dir, lib_dir] = dirs(&ws, ["workspace", "workspace/libs/math"]);
+        let [lib_file] = files(&ws, ["workspace/libs/math/vector.simf"]);
 
-        let lib_file = canon(&ws.create_file("workspace/libs/math/vector.simf", ""));
+        let map = build_map(&workspace_dir, &[(&workspace_dir, "math", &lib_dir)]).unwrap();
+
         let lib_crate = map.get_package_root(&lib_file).unwrap();
         assert_eq!(
             lib_crate, &lib_dir,


### PR DESCRIPTION
Introduce a new `ValidatedDeps` structure and remove `entry_root` from `DependencyMapBuilder`. This also optimizes the build algorithm complexity from `O(n²)` to `O(n log n)`.

Finally, this refactors the tests to accommodate the new functionality and adds helper macros to make testing more convenient.