### PR TITLE
feat: SourceMap

### DIFF
--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -56,6 +56,53 @@ struct SourceModule {
     program: parse::Program,
 }
 
+/// Record of all modules that was discovered.
+#[derive(Debug, Clone, Default)]
+pub struct SourceMap {
+    /// Fast lookup: `CanonPath` -> Module ID.
+    /// A reverse index mapping absolute file paths to their internal IDs.
+    /// This solves the duplication problem, ensuring each file is only parsed once.
+    ids: HashMap<CanonPath, usize>,
+
+    /// Fast lookup: Module ID -> `CanonPath`.
+    ///
+    /// A direct index mapping internal IDs back to their absolute file paths.
+    /// This serves as the exact inverse of the `lookup` map.
+    ///
+    /// This is highly useful for error reporting and diagnostics.
+    paths: Vec<CanonPath>,
+}
+
+impl SourceMap {
+    fn new(root_source: CanonSourceFile) -> Self {
+        let mut ids = HashMap::new();
+        ids.insert(root_source.name().clone(), MAIN_MODULE);
+        Self {
+            ids,
+            paths: vec![root_source.name().clone()],
+        }
+    }
+
+    fn insert(&mut self, path: CanonPath) -> usize {
+        let id = self.paths.len();
+        self.ids.insert(path.clone(), id);
+        self.paths.push(path);
+        id
+    }
+
+    pub fn get_id(&self, path: &CanonPath) -> Option<usize> {
+        self.ids.get(path).copied()
+    }
+
+    pub fn get_path(&self, id: usize) -> Option<&CanonPath> {
+        self.paths.get(id)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&CanonPath, &usize)> {
+        self.ids.iter()
+    }
+}
+
 /// An Intermediate Representation that helps transform isolated files into a global program.
 ///
 /// While an AST only understands a single file, the `DependencyGraph` links multiple
@@ -85,18 +132,8 @@ pub(crate) struct DependencyGraph {
     /// Used to resolve external library dependencies and invoke their associated functions.
     dependency_map: Arc<DependencyMap>,
 
-    /// Fast lookup: `CanonPath` -> Module ID.
-    /// A reverse index mapping absolute file paths to their internal IDs.
-    /// This solves the duplication problem, ensuring each file is only parsed once.
-    lookup: HashMap<CanonPath, usize>,
-
-    /// Fast lookup: Module ID -> `CanonPath`.
-    ///
-    /// A direct index mapping internal IDs back to their absolute file paths.
-    /// This serves as the exact inverse of the `lookup` map.
-    ///
-    /// This is highly useful for error reporting and diagnostics.
-    paths: Vec<CanonPath>,
+    /// Fast bidirectional lookup between `CanonPath` and Module IDs.
+    source_map: SourceMap,
 
     /// Memoized results of [`crate::resolution::DependencyMap::resolve_path`] to avoid
     /// resolving the same [`parse::UseDecl`] twice — once during the driver phase
@@ -148,13 +185,11 @@ impl DependencyGraph {
                 program: root_program.clone(),
             }],
             dependency_map,
-            lookup: HashMap::new(),
-            paths: vec![root_source.name().clone()],
+            source_map: SourceMap::new(root_source),
             use_cache: HashMap::new(),
             dependencies: HashMap::new(),
         };
 
-        graph.lookup.insert(root_source.name().clone(), MAIN_MODULE);
         graph.dependencies.insert(MAIN_MODULE, Vec::new());
 
         let mut use_cache = HashMap::new();
@@ -278,7 +313,7 @@ impl DependencyGraph {
                 continue;
             }
 
-            if let Some(&existing_id) = self.lookup.get(&path) {
+            if let Some(existing_id) = self.source_map.get_id(&path) {
                 let deps = self.dependencies.entry(current.id).or_default();
                 if !deps.contains(&existing_id) {
                     deps.push(existing_id);
@@ -294,17 +329,19 @@ impl DependencyGraph {
                 continue;
             };
 
-            let last_ind = self.modules.len();
+            let new_id = self.source_map.insert(path.clone());
             self.modules.push(module);
 
-            self.lookup.insert(path.clone(), last_ind);
-            self.paths.push(path.clone());
             self.dependencies
                 .entry(current.id)
                 .or_default()
-                .push(last_ind);
-            ctx.queue.push_back(last_ind);
+                .push(new_id);
+            ctx.queue.push_back(new_id);
         }
+    }
+
+    pub fn source_map(&self) -> &SourceMap {
+        &self.source_map
     }
 }
 
@@ -469,7 +506,7 @@ pub(crate) mod tests {
         let mut file_ids = HashMap::new();
 
         if let Some(ref graph) = graph_option {
-            for (path, id) in &graph.lookup {
+            for (path, id) in graph.source_map.iter() {
                 let file_stem = path
                     .as_path()
                     .file_stem()
@@ -656,7 +693,7 @@ pub(crate) mod tests {
 
         // Assert: Size checks
         assert_eq!(graph.modules.len(), 3);
-        assert_eq!(graph.paths.len(), 3);
+        assert_eq!(graph.source_map.paths.len(), 3);
 
         // Assert: Ensure BFS assigned the IDs in the exact correct order
         let main_id = ids["main"];

--- a/src/driver/resolve_order.rs
+++ b/src/driver/resolve_order.rs
@@ -107,7 +107,10 @@ impl DependencyGraph {
         let mut use_decl = use_decl.clone();
         use_decl.set_file_id(source_id);
         let resolved = &self.use_cache[&use_decl];
-        let target_id = self.lookup[&resolved.path];
+        let target_id = self
+            .source_map
+            .get_id(&resolved.path)
+            .expect("resolved path must be registered");
 
         let mut new_path = Vec::with_capacity(resolved.mod_path.len() + 2);
         new_path.push(Identifier::from_str_unchecked(CRATE_STR));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,7 @@ pub struct TemplateProgram {
     file: Arc<str>,
     jet_hinter: Box<dyn ast::JetHinter>,
     source_map: SourceMap,
+    resolved_program: parse::Program,
 }
 
 impl TemplateProgram {
@@ -71,8 +72,10 @@ impl TemplateProgram {
         dependency_map: &DependencyMap,
     ) -> Result<String, String> {
         let mut error_handler = ErrorCollector::new();
-        Self::dependency_helper(source, dependency_map, &mut error_handler)?
-            .0
+        let (resolved_program, _) =
+            Self::dependency_helper(source, dependency_map, &mut error_handler)?;
+
+        resolved_program
             .ok_or_else(|| error_handler.to_string())
             .map(|p| p.to_string())
     }
@@ -89,17 +92,18 @@ impl TemplateProgram {
     ) -> Result<Self, String> {
         let mut error_handler = ErrorCollector::new();
 
-        let (driver_program, source_map) =
+        let (resolved_program, source_map) =
             Self::dependency_helper(source.clone(), dependency_map, &mut error_handler)?;
-        let driver_program = driver_program.ok_or_else(|| error_handler.to_string())?;
+        let resolved_program = resolved_program.ok_or_else(|| error_handler.to_string())?;
 
-        let ast_program = ast::Program::analyze(&driver_program, jet_hinter.clone_box())
+        let ast_program = ast::Program::analyze(&resolved_program, jet_hinter.clone_box())
             .with_source(source.clone())?;
         Ok(Self {
             simfony: ast_program,
             file: source.content(),
             jet_hinter,
             source_map,
+            resolved_program,
         })
     }
 
@@ -125,6 +129,7 @@ impl TemplateProgram {
                 file,
                 jet_hinter,
                 source_map: SourceMap::default(),
+                resolved_program: program,
             })
         } else {
             Err(error_handler.to_string())?
@@ -198,6 +203,10 @@ impl TemplateProgram {
 
     pub fn source_map(&self) -> &SourceMap {
         &self.source_map
+    }
+
+    pub fn resolved_program(&self) -> &parse::Program {
+        &self.resolved_program
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ pub extern crate simplicity;
 pub use simplicity::elements;
 
 use crate::debug::DebugSymbols;
-use crate::driver::DependencyGraph;
+use crate::driver::{DependencyGraph, SourceMap};
 use crate::error::{ErrorCollector, WithContent, WithSource as _};
 use crate::parse::ParseFromStrWithErrors;
 use crate::resolution::DependencyMap;
@@ -56,6 +56,7 @@ pub struct TemplateProgram {
     simfony: ast::Program,
     file: Arc<str>,
     jet_hinter: Box<dyn ast::JetHinter>,
+    source_map: SourceMap,
 }
 
 impl TemplateProgram {
@@ -71,6 +72,7 @@ impl TemplateProgram {
     ) -> Result<String, String> {
         let mut error_handler = ErrorCollector::new();
         Self::dependency_helper(source, dependency_map, &mut error_handler)?
+            .0
             .ok_or_else(|| error_handler.to_string())
             .map(|p| p.to_string())
     }
@@ -87,9 +89,9 @@ impl TemplateProgram {
     ) -> Result<Self, String> {
         let mut error_handler = ErrorCollector::new();
 
-        let driver_program =
-            Self::dependency_helper(source.clone(), dependency_map, &mut error_handler)?
-                .ok_or_else(|| error_handler.to_string())?;
+        let (driver_program, source_map) =
+            Self::dependency_helper(source.clone(), dependency_map, &mut error_handler)?;
+        let driver_program = driver_program.ok_or_else(|| error_handler.to_string())?;
 
         let ast_program = ast::Program::analyze(&driver_program, jet_hinter.clone_box())
             .with_source(source.clone())?;
@@ -97,6 +99,7 @@ impl TemplateProgram {
             simfony: ast_program,
             file: source.content(),
             jet_hinter,
+            source_map,
         })
     }
 
@@ -121,6 +124,7 @@ impl TemplateProgram {
                 simfony: ast_program,
                 file,
                 jet_hinter,
+                source_map: SourceMap::default(),
             })
         } else {
             Err(error_handler.to_string())?
@@ -131,13 +135,16 @@ impl TemplateProgram {
         source: CanonSourceFile,
         dependency_map: &DependencyMap,
         handler: &mut ErrorCollector,
-    ) -> Result<Option<parse::Program>, String> {
+    ) -> Result<(Option<parse::Program>, SourceMap), String> {
         let program = parse::Program::parse_from_str_with_errors(source.clone(), handler)
             .ok_or_else(|| handler.to_string())?;
         let graph =
             DependencyGraph::new(source, Arc::from(dependency_map.clone()), &program, handler)?
                 .ok_or_else(|| handler.to_string())?;
-        graph.linearize_and_build(handler)
+
+        let program = graph.linearize_and_build(handler);
+
+        program.map(|opt| (opt, graph.source_map().clone()))
     }
 
     /// Access the parameters of the program.
@@ -187,6 +194,10 @@ impl TemplateProgram {
             witness_types: self.simfony.witness_types().shallow_clone(),
             param_types: self.parameters().shallow_clone(),
         })
+    }
+
+    pub fn source_map(&self) -> &SourceMap {
+        &self.source_map
     }
 }
 


### PR DESCRIPTION
This adds `SourceMap`, which is actually a wrapper around `ids` and `paths` inside the driver (see https://github.com/BlockstreamResearch/SimplicityHL/issues/327#issuecomment-4508425248).
It also stores and exposes `SourceMap` and the built program in `TemplateProgram`. 

Motivation: It mainly exposes things for the LSP to access the parser program and the needed indexes to resolve `file_id` for functions.