### PR TITLE
Store file content inside the `SourceMap` struct

### DIFF
--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -72,36 +72,48 @@ pub struct SourceMap {
     /// This serves as the exact inverse of the `lookup` map.
     ///
     /// This is highly useful for error reporting and diagnostics.
-    paths: Vec<CanonPath>,
+    entries: Vec<CanonSourceFile>,
 }
 
 impl SourceMap {
     fn new(root_source: CanonSourceFile) -> Self {
         let mut ids = HashMap::new();
+
         ids.insert(root_source.name().clone(), MAIN_MODULE);
+
         Self {
             ids,
-            paths: vec![root_source.name().clone()],
+            entries: vec![root_source],
         }
     }
 
-    fn insert(&mut self, path: CanonPath) {
-        let id = self.paths.len();
-        self.ids.insert(path.clone(), id);
-        self.paths.push(path);
-        debug_assert_eq!(self.ids.len(), self.paths.len());
+    fn insert(&mut self, entry: CanonSourceFile) {
+        let id = self.entries.len();
+
+        self.ids.insert(entry.name().clone(), id);
+        self.entries.push(entry);
+
+        debug_assert_eq!(self.ids.len(), self.entries.len());
     }
 
     fn len(&self) -> usize {
-        self.paths.len()
+        self.entries.len()
     }
 
-    pub fn get_id(&self, path: &CanonPath) -> Option<usize> {
+    pub fn id(&self, path: &CanonPath) -> Option<usize> {
         self.ids.get(path).copied()
     }
 
-    pub fn get_path(&self, id: usize) -> Option<&CanonPath> {
-        self.paths.get(id)
+    pub fn entry(&self, id: usize) -> Option<&CanonSourceFile> {
+        self.entries.get(id)
+    }
+
+    pub fn content(&self, id: usize) -> Option<Arc<str>> {
+        self.entries.get(id).map(|e| e.content().clone())
+    }
+
+    pub fn path(&self, id: usize) -> Option<&CanonPath> {
+        self.entries.get(id).map(|e| e.name())
     }
 
     pub fn iter(&self) -> impl Iterator<Item = (&CanonPath, &usize)> {
@@ -289,7 +301,7 @@ impl DependencyGraph {
                 continue;
             }
 
-            if let Some(existing_id) = self.source_map.get_id(&path) {
+            if let Some(existing_id) = self.source_map.id(&path) {
                 let deps = self.dependencies.entry(current.id).or_default();
                 if !deps.contains(&existing_id) {
                     deps.push(existing_id);
@@ -299,11 +311,27 @@ impl DependencyGraph {
 
             let new_id = self.source_map.len();
 
+            let Ok(content) = std::fs::read_to_string(path.as_path()) else {
+                let err = RichError::new(
+                    Error::FileNotFound {
+                        filename: PathBuf::from(path.as_path()),
+                    },
+                    import_span,
+                )
+                .with_source(current.source.clone());
+
+                ctx.handler.push(err);
+
+                // Safe to ignore output: previous `.contains` check prevents collisions.
+                let _ = ctx.invalid_imports.insert(path);
+                continue;
+            };
+
+            let source = CanonSourceFile::new(path.clone(), Arc::from(content));
+
             let Some(module) = Self::parse_and_get_source_module(
                 new_id,
-                &path,
-                &current.source,
-                import_span,
+                source.clone(),
                 ctx.handler,
                 ctx.unstable_features,
             ) else {
@@ -312,7 +340,7 @@ impl DependencyGraph {
                 continue;
             };
 
-            self.source_map.insert(path.clone());
+            self.source_map.insert(source);
             self.modules.push(module);
 
             self.dependencies
@@ -323,33 +351,17 @@ impl DependencyGraph {
         }
     }
 
-    /// This helper cleanly encapsulates the process of loading source text, parsing it
-    /// into an `parse::Program`, and combining them so the compiler can easily work with the file.
-    /// If the file is missing or contains syntax errors, it logs the diagnostic to the
+    /// This helper cleanly encapsulates the process of parsing source text into an
+    /// `parse::Program`, and combining them so the compiler can easily work with the file.
+    /// If the file is contains syntax errors, it logs the diagnostic to the
     /// `ErrorCollector` and safely returns `None`.
     fn parse_and_get_source_module(
         new_id: usize,
-        path: &CanonPath,
-        importer_source: &CanonSourceFile,
-        span: Span,
+        source: CanonSourceFile,
         handler: &mut ErrorCollector,
         unstable_features: &UnstableFeatures,
     ) -> Option<SourceModule> {
-        let Ok(content) = std::fs::read_to_string(path.as_path()) else {
-            let err = RichError::new(
-                Error::FileNotFound {
-                    filename: PathBuf::from(path.as_path()),
-                },
-                span,
-            )
-            .with_source(importer_source.clone());
-
-            handler.push(err);
-            return None;
-        };
-
         let mut error_handler = ErrorCollector::new();
-        let source = CanonSourceFile::new(path.clone(), Arc::from(content));
         let ast = parse::Program::parse_from_str_with_errors(
             new_id,
             source.clone(),
@@ -715,7 +727,7 @@ pub(crate) mod tests {
 
         // Assert: Size checks
         assert_eq!(graph.modules.len(), 3);
-        assert_eq!(graph.source_map.paths.len(), 3);
+        assert_eq!(graph.source_map.entries.len(), 3);
 
         // Assert: Ensure BFS assigned the IDs in the exact correct order
         let main_id = ids["main"];

--- a/src/driver/resolve_order.rs
+++ b/src/driver/resolve_order.rs
@@ -86,17 +86,17 @@ impl DependencyGraph {
     ///
     /// The resolved path becomes `crate::<module>::<mod_path...>`, where
     /// `<module>` is `file_N` for dependency files and is omitted when the
-    /// target is `MAIN_MODULE` (via `get_module_name`).
+    /// target is [`MAIN_MODULE`] (via [`DependencyGraph::get_module_name`]).
     ///
     /// ## Examples
     ///
     /// - `use base_math::simple_op::hash` → `use crate::file_2::hash`
-    /// - `use some_dep::item` (target = `MAIN_MODULE`) → `use crate::item`
+    /// - `use some_dep::item` (target = [`MAIN_MODULE`]) → `use crate::item`
     fn rewrite_use(&self, use_decl: &parse::UseDecl) -> parse::Item {
         let resolved = &self.use_cache[use_decl.span()];
         let target_id = self
             .source_map
-            .get_id(&resolved.path)
+            .id(&resolved.path)
             .expect("resolved path must be registered");
 
         let mut new_path = Vec::with_capacity(resolved.mod_path.len() + 2);


### PR DESCRIPTION

Follow the same approach as Rust's `SourceMap` ([source code](https://github.com/rust-lang/rust/blob/c397dae808f70caebab1fc4e11b3edf7e59f58c7/compiler/rustc_span/src/source_map.rs#L1-L10)): the map should own the source bytes of every file it tracks, not just their paths.

Storing content indexed by `file_id` lets a future Diagnostic retrieve the specific lines where errors occurred using `ariadne` render