### PR TITLE
Refactor: replace `Result<_, String>` with `ErrorCollector`

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1848,10 +1848,9 @@ mod scope_resolution_tests {
         let (graph, _ids, _dir) = setup_graph(files);
 
         let mut error_handler = ErrorCollector::new();
-        let driver_program = graph
-            .linearize_and_build(&mut error_handler)
-            .unwrap()
-            .expect("driver build should succeed");
+        let Some(driver_program) = graph.linearize_and_build(&mut error_handler) else {
+            panic!("{}", &error_handler.to_string());
+        };
 
         Program::analyze(&driver_program, Box::new(ElementsJetHinter))
             .map(|_| ())

--- a/src/driver/linearization.rs
+++ b/src/driver/linearization.rs
@@ -7,14 +7,14 @@
 //! DFS is a better option.
 
 use std::collections::HashSet;
-use std::fmt;
 
 use crate::driver::DependencyGraph;
+use crate::error::{Error, RichError, Span};
 
 /// This is a core component of the [`DependencyGraph`].
 impl DependencyGraph {
     /// Returns the deterministic, BOTTOM-UP load order of dependencies.
-    pub(super) fn linearize(&self) -> Result<Vec<usize>, LinearizationError> {
+    pub(super) fn linearize(&self) -> Result<Vec<usize>, RichError> {
         let mut visited = HashSet::new();
         let mut visiting = Vec::new();
         let mut order = Vec::new();
@@ -35,18 +35,21 @@ impl DependencyGraph {
         visited: &mut HashSet<usize>,
         visiting: &mut Vec<usize>,
         order: &mut Vec<usize>,
-    ) -> Result<(), LinearizationError> {
+    ) -> Result<(), RichError> {
         // If we have already fully processed this module, skip it (Diamond Deduplication)
         if visited.contains(&module) {
             return Ok(());
         }
 
         if let Some(cycle_start) = visiting.iter().position(|&m| m == module) {
-            return Err(LinearizationError::CycleDetected(
-                visiting[cycle_start..]
-                    .iter()
-                    .map(|&id| self.modules[id].source.str_name())
-                    .collect(),
+            return Err(RichError::new(
+                Error::LinearizationCycleDetected {
+                    deps: visiting[cycle_start..]
+                        .iter()
+                        .map(|&id| self.modules[id].source.str_name())
+                        .collect(),
+                },
+                Span::DUMMY,
             ));
         }
 
@@ -71,22 +74,6 @@ impl DependencyGraph {
         order.push(module);
 
         Ok(())
-    }
-}
-
-#[derive(Debug)]
-pub enum LinearizationError {
-    /// Raised when a circular dependency (e.g., A -> B -> A) is detected.
-    CycleDetected(Vec<String>),
-}
-
-impl fmt::Display for LinearizationError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            LinearizationError::CycleDetected(cycle) => {
-                write!(f, "Circular dependency detected: {:?}", cycle.join(" -> "))
-            }
-        }
     }
 }
 
@@ -149,10 +136,11 @@ mod tests {
         ]);
 
         let order = graph.linearize();
-        assert!(matches!(
-            order,
-            Err(LinearizationError::CycleDetected { .. })
-        ));
+        let err = order
+            .expect_err("expected linearizatoin to fail")
+            .error()
+            .clone();
+        assert!(matches!(err, Error::LinearizationCycleDetected { .. }));
     }
 
     #[test]

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -200,7 +200,7 @@ impl DependencyGraph {
         root_program: &parse::Program,
         handler: &mut ErrorCollector,
         unstable_features: &UnstableFeatures,
-    ) -> Result<Option<Self>, String> {
+    ) -> Option<Self> {
         let mut graph = Self {
             modules: vec![SourceModule {
                 source: root_source.clone(),
@@ -223,10 +223,11 @@ impl DependencyGraph {
 
         while let Some(curr_id) = queue.pop_front() {
             let Some(current_source_module) = graph.modules.get(curr_id) else {
-                return Err(format!(
+                handler.push(RichError::new(Error::Internal { msg: format!(
                     "Internal Driver Error: Module ID {} is in the queue but missing from the graph.modules.",
                     curr_id
-                ));
+                ) }, Span::DUMMY));
+                return None;
             };
 
             // We need this to report errors inside THIS file.
@@ -255,9 +256,7 @@ impl DependencyGraph {
 
         graph.use_cache = use_cache;
 
-        // TODO: Consider getting rid of the 'String' error here and changing it to a more appropriate error
-        // (e.g. 'Result<Self, ErrorCollector>') after resolving https://github.com/BlockstreamResearch/SimplicityHL/issues/270.
-        Ok((!handler.has_errors()).then_some(graph))
+        (!handler.has_errors()).then_some(graph)
     }
 
     pub fn source_map(&self) -> &SourceMap {
@@ -537,8 +536,7 @@ pub(crate) mod tests {
             &main_program,
             &mut handler,
             &UnstableFeatures::all(),
-        )
-        .unwrap();
+        );
 
         let mut file_ids = HashMap::new();
 

--- a/src/driver/resolve_order.rs
+++ b/src/driver/resolve_order.rs
@@ -6,13 +6,13 @@ use crate::str::{Identifier, ModuleName};
 /// This is a core component of the [`DependencyGraph`].
 impl DependencyGraph {
     /// Resolves the dependency graph and constructs the final AST program.
-    pub fn linearize_and_build(
-        &self,
-        handler: &mut ErrorCollector,
-    ) -> Result<Option<parse::Program>, String> {
+    pub fn linearize_and_build(&self, handler: &mut ErrorCollector) -> Option<parse::Program> {
         match self.linearize() {
-            Ok(order) => Ok(self.build_program(&order, handler)),
-            Err(err) => Err(err.to_string()),
+            Ok(order) => self.build_program(&order, handler),
+            Err(err) => {
+                handler.push(err);
+                None
+            }
         }
     }
 
@@ -130,10 +130,9 @@ mod flattening_tests {
         let (graph, ids, _dir) = setup_graph(files);
         let mut error_handler = ErrorCollector::new();
 
-        let program = graph
-            .linearize_and_build(&mut error_handler)
-            .expect("Linearize should not fail in this test")
-            .expect("Build should succeed and return Some(Program)");
+        let Some(program) = graph.linearize_and_build(&mut error_handler) else {
+            panic!("{}", &error_handler.to_string());
+        };
 
         (program, ids)
     }
@@ -243,8 +242,8 @@ mod flattening_tests {
         let driver_program = graph.linearize_and_build(&mut error_handler);
 
         assert!(
-            matches!(driver_program, Ok(None)),
-            "Expected the build to fail and return Ok(None), but got: {:?}",
+            driver_program.is_none(),
+            "Expected the build to fail and return None, but got: {:?}",
             driver_program
         );
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -507,6 +507,9 @@ pub enum Error {
         alias: String,
         context: String,
     },
+    LinearizationCycleDetected {
+        deps: Vec<String>,
+    },
     InvalidDependencyIdentifier {
         alias: String,
     },
@@ -699,6 +702,10 @@ impl fmt::Display for Error {
             Error::DuplicateDependencyAlias { alias, context } => write!(
                 f,
                 "Duplicate dependency mapping: alias '{alias}' is defined multiple times for context '{context}'"
+            ),
+            Error::LinearizationCycleDetected { deps } => write!(
+                f,
+                "Circular dependency detected: {:?}", deps.join(" -> ")
             ),
             Error::InvalidDependencyIdentifier { alias } => write!(
                 f,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,18 +74,18 @@ impl TemplateProgram {
         source: CanonSourceFile,
         dependency_map: &DependencyMap,
         unstable_features: &UnstableFeatures,
-    ) -> Result<String, String> {
+    ) -> Result<String, ErrorCollector> {
         let mut error_handler = ErrorCollector::new();
-        let (resolved_program, _) = Self::dependency_helper(
+        let Some((resolved_program, _)) = Self::dependency_helper(
             source,
             dependency_map,
             unstable_features,
             &mut error_handler,
-        )?;
+        ) else {
+            return Err(error_handler);
+        };
 
-        resolved_program
-            .ok_or_else(|| error_handler.to_string())
-            .map(|p| p.to_string())
+        Ok(resolved_program.to_string())
     }
 
     /// Parse the template of a SimplicityHL program.
@@ -102,15 +102,14 @@ impl TemplateProgram {
         let mut error_handler = ErrorCollector::new();
 
         let build_program = || -> Result<Self, ()> {
-            let (resolved_program, source_map) = Self::dependency_helper(
+            let Some((resolved_program, source_map)) = Self::dependency_helper(
                 source.clone(),
                 dependency_map,
                 unstable_features,
                 &mut error_handler,
-            )
-            .map_err(|_| ())?;
-
-            let resolved_program = resolved_program.ok_or(())?;
+            ) else {
+                return Err(());
+            };
 
             let ast_program = ast::Program::analyze(&resolved_program, jet_hinter.clone_box())
                 .with_source(source.clone())
@@ -186,34 +185,25 @@ impl TemplateProgram {
         dependency_map: &DependencyMap,
         unstable_features: &UnstableFeatures,
         handler: &mut ErrorCollector,
-    ) -> Result<(Option<parse::Program>, SourceMap), String> {
+    ) -> Option<(parse::Program, SourceMap)> {
         let program = parse::Program::parse_from_str_with_errors(
             MAIN_MODULE,
             source.clone(),
             unstable_features,
             handler,
-        )
-        .ok_or_else(|| handler.to_string())?;
+        )?;
 
-        // TODO: we should remove this errors push after refactoring errors
         let graph = DependencyGraph::new(
             source,
             Arc::from(dependency_map.clone()),
             &program,
             handler,
             unstable_features,
-        )
-        .map_err(|e| {
-            handler.push(error::RichError::parsing_error(&e));
-            handler.to_string()
-        })?
-        .ok_or_else(|| handler.to_string())?;
+        )?;
 
         let program = graph.linearize_and_build(handler);
 
-        program
-            .map(|opt| (opt, graph.source_map().clone()))
-            .inspect_err(|e| handler.push(error::RichError::parsing_error(e)))
+        program.map(|opt| (opt, graph.source_map().clone()))
     }
 
     /// Access the parameters of the program.


### PR DESCRIPTION
Consolidates all error types into `error.rs` as prep for migrating `ErrorCollector` to diagnostic structs