### PR TITLE
Migrate error rendering to `ariadne`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ariadne"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31beedec3ce83ae6da3a79592b3d8d7afd146a5b15bb9bb940279aced60faa89"
+dependencies = [
+ "unicode-width",
+ "yansi",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -654,6 +664,7 @@ name = "simplicityhl"
 version = "0.6.0"
 dependencies = [
  "arbitrary",
+ "ariadne",
  "base64 0.21.3",
  "chumsky",
  "clap",
@@ -731,6 +742,12 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "utf8parse"
@@ -870,3 +887,9 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ arbitrary = { version = "1", optional = true, features = ["derive"] }
 clap = "4.5.37"
 chumsky = "0.11.2"
 semver = "1.0.28"
+ariadne = "=0.5.0"
 
 [target.wasm32-unknown-unknown.dependencies]
 getrandom = { version = "0.2", features = ["js"] }

--- a/fuzz/fuzz_targets/compile_parse_tree.rs
+++ b/fuzz/fuzz_targets/compile_parse_tree.rs
@@ -5,7 +5,6 @@ fn do_test(data: &[u8]) {
     use arbitrary::Arbitrary;
     use simplicityhl::ast::ElementsJetHinter;
 
-    use simplicityhl::error::WithContent;
     use simplicityhl::{ast, named, parse, ArbitraryOfType, Arguments};
 
     let mut u = arbitrary::Unstructured::new(data);
@@ -24,7 +23,6 @@ fn do_test(data: &[u8]) {
     };
     let simplicity_named_construct = ast_program
         .compile(arguments, false, Box::new(ElementsJetHinter::new()))
-        .with_content("")
         .expect("AST should compile with given arguments");
     let _simplicity_commit = named::forget_names(&simplicity_named_construct);
 }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -9,7 +9,7 @@ use simplicity::jet::{Core, Elements, Jet};
 
 use crate::debug::{CallTracker, DebugSymbols, TrackedCallName};
 use crate::driver::{CRATE_STR, MAIN_STR};
-use crate::error::{Error, RichError, Span, WithSpan};
+use crate::error::{Diagnostic, Error, Span, WithSpan};
 use crate::jet::{source_type, target_type, JetHL};
 use crate::num::{NonZeroPow2Usize, Pow2Usize};
 use crate::parse::{MatchPattern, UseDecl, Visibility};
@@ -1037,14 +1037,15 @@ trait AbstractSyntaxTree: Sized {
     ///
     /// Check if the analyzed expression is of the expected type.
     /// Statements return no values so their expected type is always unit.
-    fn analyze(from: &Self::From, ty: &ResolvedType, scope: &mut Scope) -> Result<Self, RichError>;
+    fn analyze(from: &Self::From, ty: &ResolvedType, scope: &mut Scope)
+        -> Result<Self, Diagnostic>;
 }
 
 impl Program {
     pub fn analyze(
         from: &parse::Program,
         jet_hinter: Box<dyn JetHinter>,
-    ) -> Result<Self, RichError> {
+    ) -> Result<Self, Diagnostic> {
         let unit = ResolvedType::unit();
         let mut scope = Scope::new(jet_hinter);
 
@@ -1052,7 +1053,7 @@ impl Program {
             .items()
             .iter()
             .map(|s| Item::analyze(s, &unit, &mut scope))
-            .collect::<Result<Vec<Item>, RichError>>()?;
+            .collect::<Result<Vec<Item>, Diagnostic>>()?;
         debug_assert!(scope.is_outside_function());
         debug_assert!(
             scope.module_path.is_empty(),
@@ -1102,7 +1103,11 @@ impl Program {
 impl AbstractSyntaxTree for Item {
     type From = parse::Item;
 
-    fn analyze(from: &Self::From, ty: &ResolvedType, scope: &mut Scope) -> Result<Self, RichError> {
+    fn analyze(
+        from: &Self::From,
+        ty: &ResolvedType,
+        scope: &mut Scope,
+    ) -> Result<Self, Diagnostic> {
         assert!(ty.is_unit(), "Items cannot return anything");
         assert!(
             scope.is_outside_function(),
@@ -1141,7 +1146,11 @@ impl AbstractSyntaxTree for Item {
 impl AbstractSyntaxTree for Function {
     type From = parse::Function;
 
-    fn analyze(from: &Self::From, ty: &ResolvedType, scope: &mut Scope) -> Result<Self, RichError> {
+    fn analyze(
+        from: &Self::From,
+        ty: &ResolvedType,
+        scope: &mut Scope,
+    ) -> Result<Self, Diagnostic> {
         assert!(ty.is_unit(), "Function definitions cannot return anything");
         assert!(
             scope.is_outside_function(),
@@ -1206,7 +1215,11 @@ impl AbstractSyntaxTree for Function {
 impl AbstractSyntaxTree for Statement {
     type From = parse::Statement;
 
-    fn analyze(from: &Self::From, ty: &ResolvedType, scope: &mut Scope) -> Result<Self, RichError> {
+    fn analyze(
+        from: &Self::From,
+        ty: &ResolvedType,
+        scope: &mut Scope,
+    ) -> Result<Self, Diagnostic> {
         assert!(ty.is_unit(), "Statements cannot return anything");
         match from {
             parse::Statement::Assignment(assignment) => {
@@ -1222,7 +1235,11 @@ impl AbstractSyntaxTree for Statement {
 impl AbstractSyntaxTree for Assignment {
     type From = parse::Assignment;
 
-    fn analyze(from: &Self::From, ty: &ResolvedType, scope: &mut Scope) -> Result<Self, RichError> {
+    fn analyze(
+        from: &Self::From,
+        ty: &ResolvedType,
+        scope: &mut Scope,
+    ) -> Result<Self, Diagnostic> {
         assert!(ty.is_unit(), "Assignments cannot return anything");
         // The assignment is a statement that returns nothing.
         //
@@ -1252,7 +1269,7 @@ impl Expression {
     ///
     /// The returned expression might not be evaluable at compile time.
     /// The details depend on the current state of the SimplicityHL compiler.
-    pub fn analyze_const(from: &parse::Expression, ty: &ResolvedType) -> Result<Self, RichError> {
+    pub fn analyze_const(from: &parse::Expression, ty: &ResolvedType) -> Result<Self, Diagnostic> {
         let mut empty_scope = Scope::default();
         Self::analyze(from, ty, &mut empty_scope)
     }
@@ -1261,7 +1278,11 @@ impl Expression {
 impl AbstractSyntaxTree for Expression {
     type From = parse::Expression;
 
-    fn analyze(from: &Self::From, ty: &ResolvedType, scope: &mut Scope) -> Result<Self, RichError> {
+    fn analyze(
+        from: &Self::From,
+        ty: &ResolvedType,
+        scope: &mut Scope,
+    ) -> Result<Self, Diagnostic> {
         match from.inner() {
             parse::ExpressionInner::Single(single) => {
                 let ast_single = SingleExpression::analyze(single, ty, scope)?;
@@ -1276,7 +1297,7 @@ impl AbstractSyntaxTree for Expression {
                 let ast_statements = statements
                     .iter()
                     .map(|s| Statement::analyze(s, &ResolvedType::unit(), scope))
-                    .collect::<Result<Arc<[Statement]>, RichError>>()?;
+                    .collect::<Result<Arc<[Statement]>, Diagnostic>>()?;
                 let ast_expression = match expression {
                     Some(expression) => Expression::analyze(expression, ty, scope)
                         .map(Arc::new)
@@ -1303,7 +1324,11 @@ impl AbstractSyntaxTree for Expression {
 impl AbstractSyntaxTree for SingleExpression {
     type From = parse::SingleExpression;
 
-    fn analyze(from: &Self::From, ty: &ResolvedType, scope: &mut Scope) -> Result<Self, RichError> {
+    fn analyze(
+        from: &Self::From,
+        ty: &ResolvedType,
+        scope: &mut Scope,
+    ) -> Result<Self, Diagnostic> {
         let inner = match from.inner() {
             parse::SingleExpressionInner::Boolean(bit) => {
                 if !ty.is_boolean() {
@@ -1383,7 +1408,7 @@ impl AbstractSyntaxTree for SingleExpression {
                     .iter()
                     .zip(types.iter())
                     .map(|(el_parse, el_ty)| Expression::analyze(el_parse, el_ty, scope))
-                    .collect::<Result<Arc<[Expression]>, RichError>>()
+                    .collect::<Result<Arc<[Expression]>, Diagnostic>>()
                     .map(SingleExpressionInner::Tuple)?
             }
             parse::SingleExpressionInner::Array(array) => {
@@ -1397,7 +1422,7 @@ impl AbstractSyntaxTree for SingleExpression {
                 array
                     .iter()
                     .map(|el_parse| Expression::analyze(el_parse, el_ty, scope))
-                    .collect::<Result<Arc<[Expression]>, RichError>>()
+                    .collect::<Result<Arc<[Expression]>, Diagnostic>>()
                     .map(SingleExpressionInner::Array)?
             }
             parse::SingleExpressionInner::List(list) => {
@@ -1410,7 +1435,7 @@ impl AbstractSyntaxTree for SingleExpression {
                 }
                 list.iter()
                     .map(|e| Expression::analyze(e, el_ty, scope))
-                    .collect::<Result<Arc<[Expression]>, RichError>>()
+                    .collect::<Result<Arc<[Expression]>, Diagnostic>>()
                     .map(SingleExpressionInner::List)?
             }
             parse::SingleExpressionInner::Either(either) => {
@@ -1460,7 +1485,11 @@ impl AbstractSyntaxTree for SingleExpression {
 impl AbstractSyntaxTree for Call {
     type From = parse::Call;
 
-    fn analyze(from: &Self::From, ty: &ResolvedType, scope: &mut Scope) -> Result<Self, RichError> {
+    fn analyze(
+        from: &Self::From,
+        ty: &ResolvedType,
+        scope: &mut Scope,
+    ) -> Result<Self, Diagnostic> {
         fn check_argument_types(
             parse_args: &[parse::Expression],
             expected_tys: &[ResolvedType],
@@ -1493,12 +1522,12 @@ impl AbstractSyntaxTree for Call {
             parse_args: &[parse::Expression],
             args_tys: &[ResolvedType],
             scope: &mut Scope,
-        ) -> Result<Arc<[Expression]>, RichError> {
+        ) -> Result<Arc<[Expression]>, Diagnostic> {
             let args = parse_args
                 .iter()
                 .zip(args_tys.iter())
                 .map(|(arg_parse, arg_ty)| Expression::analyze(arg_parse, arg_ty, scope))
-                .collect::<Result<Arc<[Expression]>, RichError>>()?;
+                .collect::<Result<Arc<[Expression]>, Diagnostic>>()?;
             Ok(args)
         }
 
@@ -1680,7 +1709,7 @@ impl AbstractSyntaxTree for CallName {
         from: &Self::From,
         _ty: &ResolvedType,
         scope: &mut Scope,
-    ) -> Result<Self, RichError> {
+    ) -> Result<Self, Diagnostic> {
         match from.name() {
             parse::CallName::Jet(name) => match scope.jet_hinter.parse_jet(name.as_inner()) {
                 Some(jet) if !jet.is_disabled() => Ok(Self::Jet(jet)),
@@ -1766,7 +1795,11 @@ impl AbstractSyntaxTree for CallName {
 impl AbstractSyntaxTree for Match {
     type From = parse::Match;
 
-    fn analyze(from: &Self::From, ty: &ResolvedType, scope: &mut Scope) -> Result<Self, RichError> {
+    fn analyze(
+        from: &Self::From,
+        ty: &ResolvedType,
+        scope: &mut Scope,
+    ) -> Result<Self, Diagnostic> {
         let scrutinee_ty = from.scrutinee_type();
         let scrutinee_ty = scope.resolve(&scrutinee_ty).with_span(from)?;
         let scrutinee =
@@ -1842,14 +1875,12 @@ impl AsRef<Span> for Match {
 mod scope_resolution_tests {
     use super::{ElementsJetHinter, Program};
     use crate::driver::tests::setup_graph;
-    use crate::error::ErrorCollector;
 
     pub(super) fn analyze_multifile(files: Vec<(&str, &str)>) -> Result<(), String> {
-        let (graph, _ids, _dir) = setup_graph(files);
+        let (graph, _ids, _dir, mut diagnostics) = setup_graph(files);
 
-        let mut error_handler = ErrorCollector::new();
-        let Some(driver_program) = graph.linearize_and_build(&mut error_handler) else {
-            panic!("{}", &error_handler.to_string());
+        let Some(driver_program) = graph.linearize_and_assemble(&mut diagnostics) else {
+            panic!("{}", &diagnostics);
         };
 
         Program::analyze(&driver_program, Box::new(ElementsJetHinter))

--- a/src/compile/mod.rs
+++ b/src/compile/mod.rs
@@ -15,7 +15,7 @@ use crate::ast::{
     SingleExpressionInner, Statement,
 };
 use crate::debug::CallTracker;
-use crate::error::{Error, RichError, Span, WithSpan};
+use crate::error::{Diagnostic, Error, Span, WithSpan};
 use crate::named::{self, CoreExt, PairBuilder};
 use crate::num::{NonZeroPow2Usize, Pow2Usize};
 use crate::pattern::{BasePattern, Pattern};
@@ -206,7 +206,7 @@ impl<'brand> Scope<'brand> {
         args: PairBuilder<ProgNode<'brand>>,
         body: &ProgNode<'brand>,
         span: &S,
-    ) -> Result<PairBuilder<ProgNode<'brand>>, RichError> {
+    ) -> Result<PairBuilder<ProgNode<'brand>>, Diagnostic> {
         match self.call_tracker.get_cmr(span.as_ref()) {
             Some(cmr) if self.include_debug_symbols => {
                 let false_and_args = ProgNode::bit(self.ctx(), false).pair(args);
@@ -229,7 +229,7 @@ fn compile_blk<'brand>(
     scope: &mut Scope<'brand>,
     index: usize,
     last_expr: Option<&Expression>,
-) -> Result<PairBuilder<ProgNode<'brand>>, RichError> {
+) -> Result<PairBuilder<ProgNode<'brand>>, Diagnostic> {
     if index >= stmts.len() {
         return match last_expr {
             Some(expr) => expr.compile(scope),
@@ -266,7 +266,7 @@ impl Program {
         arguments: Arguments,
         include_debug_symbols: bool,
         jet_hinter: Box<dyn JetHinter>,
-    ) -> Result<Arc<named::CommitNode>, RichError> {
+    ) -> Result<Arc<named::CommitNode>, Diagnostic> {
         types::Context::with_context(|ctx| {
             let mut scope = Scope::new(
                 ctx,
@@ -289,7 +289,7 @@ impl Expression {
     fn compile<'brand>(
         &self,
         scope: &mut Scope<'brand>,
-    ) -> Result<PairBuilder<ProgNode<'brand>>, RichError> {
+    ) -> Result<PairBuilder<ProgNode<'brand>>, Diagnostic> {
         match self.inner() {
             ExpressionInner::Block(stmts, expr) => {
                 scope.push_scope();
@@ -306,7 +306,7 @@ impl SingleExpression {
     fn compile<'brand>(
         &self,
         scope: &mut Scope<'brand>,
-    ) -> Result<PairBuilder<ProgNode<'brand>>, RichError> {
+    ) -> Result<PairBuilder<ProgNode<'brand>>, Diagnostic> {
         let expr = match self.inner() {
             SingleExpressionInner::Constant(value) => {
                 let value = StructuralValue::from(value);
@@ -328,7 +328,7 @@ impl SingleExpression {
                 let compiled = elements
                     .iter()
                     .map(|e| e.compile(scope))
-                    .collect::<Result<Vec<PairBuilder<ProgNode>>, RichError>>()?;
+                    .collect::<Result<Vec<PairBuilder<ProgNode>>, Diagnostic>>()?;
                 let tree = BTreeSlice::from_slice(&compiled);
                 tree.fold(PairBuilder::pair)
                     .unwrap_or_else(|| PairBuilder::unit(scope.ctx()))
@@ -337,7 +337,7 @@ impl SingleExpression {
                 let compiled = elements
                     .iter()
                     .map(|e| e.compile(scope))
-                    .collect::<Result<Vec<PairBuilder<ProgNode>>, RichError>>()?;
+                    .collect::<Result<Vec<PairBuilder<ProgNode>>, Diagnostic>>()?;
                 let bound = self.ty().as_list().unwrap().1;
                 let partition = Partition::from_slice(&compiled, bound);
                 partition.fold(
@@ -379,7 +379,7 @@ impl Call {
     fn compile<'brand>(
         &self,
         scope: &mut Scope<'brand>,
-    ) -> Result<PairBuilder<ProgNode<'brand>>, RichError> {
+    ) -> Result<PairBuilder<ProgNode<'brand>>, Diagnostic> {
         let args_ast = SingleExpression::tuple(self.args().clone(), *self.as_ref());
         let args = args_ast.compile(scope)?;
 
@@ -657,7 +657,7 @@ impl Match {
     fn compile<'brand>(
         &self,
         scope: &mut Scope<'brand>,
-    ) -> Result<PairBuilder<ProgNode<'brand>>, RichError> {
+    ) -> Result<PairBuilder<ProgNode<'brand>>, Diagnostic> {
         scope.push_scope();
         scope.insert(
             self.left()

--- a/src/driver/linearization.rs
+++ b/src/driver/linearization.rs
@@ -8,19 +8,18 @@
 
 use std::collections::HashSet;
 
-use crate::driver::DependencyGraph;
-use crate::error::{Error, RichError, Span};
+use crate::driver::{DependencyGraph, MAIN_MODULE};
+use crate::error::{Diagnostic, Error};
 
 /// This is a core component of the [`DependencyGraph`].
 impl DependencyGraph {
     /// Returns the deterministic, BOTTOM-UP load order of dependencies.
-    pub(super) fn linearize(&self) -> Result<Vec<usize>, RichError> {
+    pub(super) fn linearize(&self) -> Result<Vec<usize>, Diagnostic> {
         let mut visited = HashSet::new();
         let mut visiting = Vec::new();
         let mut order = Vec::new();
 
-        self.dfs_linearize(0, &mut visited, &mut visiting, &mut order)?;
-
+        self.dfs_linearize(MAIN_MODULE, &mut visited, &mut visiting, &mut order)?;
         Ok(order)
     }
 
@@ -35,22 +34,19 @@ impl DependencyGraph {
         visited: &mut HashSet<usize>,
         visiting: &mut Vec<usize>,
         order: &mut Vec<usize>,
-    ) -> Result<(), RichError> {
+    ) -> Result<(), Diagnostic> {
         // If we have already fully processed this module, skip it (Diamond Deduplication)
         if visited.contains(&module) {
             return Ok(());
         }
 
         if let Some(cycle_start) = visiting.iter().position(|&m| m == module) {
-            return Err(RichError::new(
-                Error::LinearizationCycleDetected {
-                    deps: visiting[cycle_start..]
-                        .iter()
-                        .map(|&id| self.modules[id].source.str_name())
-                        .collect(),
-                },
-                Span::DUMMY,
-            ));
+            return Err(Diagnostic::global(Error::LinearizationCycleDetected {
+                deps: visiting[cycle_start..]
+                    .iter()
+                    .map(|&id| self.modules[&id].source.str_name())
+                    .collect(),
+            }));
         }
 
         visiting.push(module);
@@ -85,7 +81,7 @@ mod tests {
 
     #[test]
     fn test_linearize_simple_import() {
-        let (graph, ids, _dir) = setup_graph(vec![
+        let (graph, ids, _dir, _diags) = setup_graph(vec![
             ("main.simf", "use lib::math::some_func;"),
             ("libs/lib/math.simf", ""),
         ]);
@@ -106,7 +102,7 @@ mod tests {
         // B -> imports Common
         // Expected: Common loaded ONLY ONCE.
 
-        let (graph, ids, _dir) = setup_graph(vec![
+        let (graph, ids, _dir, _diags) = setup_graph(vec![
             ("main.simf", "use lib::A::foo; use lib::B::bar;"),
             ("libs/lib/A.simf", "use crate::Common::dummy1;"),
             ("libs/lib/B.simf", "use crate::Common::dummy2;"),
@@ -129,7 +125,7 @@ mod tests {
 
     #[test]
     fn test_linearize_detects_cycle() {
-        let (graph, _, _dir) = setup_graph(vec![
+        let (graph, _, _dir, _diags) = setup_graph(vec![
             ("main.simf", "use lib::A::entry;"),
             ("libs/lib/A.simf", "use crate::B::func;"),
             ("libs/lib/B.simf", "use crate::A::func;"),
@@ -147,7 +143,7 @@ mod tests {
     fn test_linearize_allows_conflicting_nested_import_order() {
         // A imports X then Y, while B imports Y then X.
         // This DAG is still valid because neither X nor Y depends on the other.
-        let (graph, ids, _dir) = setup_graph(vec![
+        let (graph, ids, _dir, _diags) = setup_graph(vec![
             ("main.simf", "use lib::A::foo; use lib::B::bar;"),
             ("libs/lib/A.simf", "use crate::X::foo; use crate::Y::bar;"),
             ("libs/lib/B.simf", "use crate::Y::baz; use crate::X::qux;"),

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -36,7 +36,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use crate::error::{Error, ErrorCollector, RichError, Span};
+use crate::error::{Diagnostic, DiagnosticManager, Error, Span};
 use crate::parse::{self, ParseFromStrWithErrors};
 use crate::resolution::{DependencyMap, ResolvedUse};
 use crate::source::{CanonPath, CanonSourceFile};
@@ -62,7 +62,7 @@ struct SourceModule {
 }
 
 /// Record of all modules that was discovered.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct SourceMap {
     /// Fast lookup: `CanonPath` -> Module ID.
     /// A reverse index mapping absolute file paths to their internal IDs.
@@ -79,18 +79,18 @@ pub struct SourceMap {
 }
 
 impl SourceMap {
-    fn new(root_source: CanonSourceFile) -> Self {
+    pub(crate) fn with_source(source: CanonSourceFile) -> Self {
         let mut ids = HashMap::new();
 
-        ids.insert(root_source.name().clone(), MAIN_MODULE);
+        ids.insert(source.name().clone(), MAIN_MODULE);
 
         Self {
             ids,
-            entries: vec![root_source],
+            entries: vec![source],
         }
     }
 
-    fn insert(&mut self, entry: CanonSourceFile) {
+    pub(crate) fn insert(&mut self, entry: CanonSourceFile) {
         let id = self.entries.len();
 
         self.ids.insert(entry.name().clone(), id);
@@ -99,7 +99,7 @@ impl SourceMap {
         debug_assert_eq!(self.ids.len(), self.entries.len());
     }
 
-    fn len(&self) -> usize {
+    pub(crate) fn len(&self) -> usize {
         self.entries.len()
     }
 
@@ -146,15 +146,18 @@ pub(crate) struct DependencyGraph {
     /// pointers (e.g., `List<Module*>`). In Rust, doing this requires either
     /// lifetimes or performance-heavy reference counting (`Rc<RefCell<T>>`).
     ///
-    /// Using a flat `Vec` as a memory arena is the idiomatic Rust solution.
-    modules: Vec<SourceModule>,
+    /// An entry should exist only for files that parsed successfully.
+    ///
+    /// A missing key for an id present in `sources` means the file was poisoned
+    /// during discovery and its imports were not propagated.
+    modules: HashMap<usize, SourceModule>,
 
     /// The configuration environment.
     /// Used to resolve external library dependencies and invoke their associated functions.
     dependency_map: Arc<DependencyMap>,
 
-    /// Fast bidirectional lookup between `CanonPath` and Module IDs.
-    source_map: SourceMap,
+    /// Fast bidirectional lookup between `CanonPath` and Module IDs
+    sources: SourceMap,
 
     /// Memoizes [`crate::resolution::DependencyMap::resolve_path_internal`] results,
     /// keyed by the source [`Span`] of each `use` declaration, so the resolver runs
@@ -173,47 +176,98 @@ pub(crate) struct DependencyGraph {
 }
 
 impl DependencyGraph {
-    /// Initializes a new `ProjectGraph` by parsing the root program and discovering all dependencies.
+    /// Compile a project into a single `parse::Program`.
     ///
-    /// Performs a BFS to recursively parse `use` statements,
-    /// building a DAG of the project's modules.
+    /// Runs both driver phases: dependency discovery, then linearization and
+    /// assembly. The returned [`DiagnosticManager`] has its [`SourceMap`]
+    /// attached and is ready to render.
     ///
     /// # Arguments
     ///
-    /// * `root_source` - The `SourceFile` representing the entry point of the project.
+    /// * `root_source` - The entry-point source file of the project.
     /// * `dependency_map` - The context-aware mapping rules used to resolve external imports.
-    /// * `root_program` - A reference to the already-parsed AST of the root file.
-    /// * `handler` - The diagnostics collector used to record resolution and parsing errors.
+    /// * `unstable_features` - Feature gates active for this compilation
     ///
     /// # Returns
     ///
-    /// * `Ok(Some(Self))` - If the entire project graph was successfully resolved and parsed.
-    /// * `Ok(None)` - If the graph traversal completed, but one or more modules contained
-    ///   errors (which have been safely logged into the `handler`).
-    ///
-    /// # Errors
-    ///
-    /// This function will return an `Err(String)` only for critical internal compiler errors.
-    pub fn new(
+    /// * `(Some(graph), diagnostics)` if the graph was built without errors.
+    ///   Warnings may be present in `diagnostics`; sources are on the graph.
+    /// * `(None, diagnostics)` if any error was reported. Sources are on
+    ///   the diagnostics manager, ready for rendering.
+    pub fn build_program(
         root_source: CanonSourceFile,
         dependency_map: Arc<DependencyMap>,
-        root_program: &parse::Program,
-        handler: &mut ErrorCollector,
         unstable_features: &UnstableFeatures,
-    ) -> Option<Self> {
-        let mut graph = Self {
-            modules: vec![SourceModule {
+    ) -> (Option<parse::Program>, DiagnosticManager) {
+        let (graph, mut diagnostics) =
+            Self::build_graph(root_source, dependency_map, unstable_features);
+
+        let Some(graph) = graph else {
+            return (None, diagnostics);
+        };
+
+        let program = graph.linearize_and_assemble(&mut diagnostics);
+        diagnostics.with_sources(graph.sources);
+        (program, diagnostics)
+    }
+
+    /// Build the dependency graph without linearizing. Exposed for tests
+    /// that need to inspect the intermediate graph state.
+    fn build_graph(
+        root_source: CanonSourceFile,
+        dependency_map: Arc<DependencyMap>,
+        unstable_features: &UnstableFeatures,
+    ) -> (Option<Self>, DiagnosticManager) {
+        let mut diagnostics = DiagnosticManager::default();
+        let sources = SourceMap::with_source(root_source.clone());
+
+        let Some(program) = parse::Program::parse_from_str_with_errors(
+            MAIN_MODULE,
+            &root_source.content(),
+            unstable_features,
+            &mut diagnostics,
+        ) else {
+            diagnostics.with_sources(sources);
+            return (None, diagnostics);
+        };
+
+        let mut modules = HashMap::new();
+        modules.insert(
+            MAIN_MODULE,
+            SourceModule {
                 source: root_source.clone(),
-                program: root_program.clone(),
-            }],
+                program,
+            },
+        );
+
+        // Build the graph
+        let mut graph = Self {
+            modules,
             dependency_map,
-            source_map: SourceMap::new(root_source),
+            sources,
             use_cache: HashMap::new(),
             dependencies: HashMap::new(),
         };
 
-        graph.dependencies.insert(MAIN_MODULE, Vec::new());
+        graph.discover_dependencies(&mut diagnostics, unstable_features);
 
+        if diagnostics.has_errors() {
+            diagnostics.with_sources(graph.sources);
+            (None, diagnostics)
+        } else {
+            (Some(graph), diagnostics)
+        }
+    }
+
+    /// BFS over `use` declarations, populating `modules`, `dependencies`,
+    /// and `use_cache`. Errors go into `diagnostics`; no `Result` because
+    /// partial state on failure is still useful for reporting.
+    fn discover_dependencies(
+        &mut self,
+        diagnostics: &mut DiagnosticManager,
+        unstable_features: &UnstableFeatures,
+    ) {
+        self.dependencies.insert(MAIN_MODULE, Vec::new());
         let mut use_cache = HashMap::new();
         let mut queue = VecDeque::new();
         queue.push_back(MAIN_MODULE);
@@ -222,12 +276,15 @@ impl DependencyGraph {
         let mut invalid_imports = HashSet::new();
 
         while let Some(curr_id) = queue.pop_front() {
-            let Some(current_source_module) = graph.modules.get(curr_id) else {
-                handler.push(RichError::new(Error::Internal { msg: format!(
-                    "Internal Driver Error: Module ID {} is in the queue but missing from the graph.modules.",
-                    curr_id
-                ) }, Span::DUMMY));
-                return None;
+            let Some(current_source_module) = self.modules.get(&curr_id) else {
+                debug_assert!(
+                    false,
+                    "poisoned invariant broken: id {curr_id} popped without a module"
+                );
+                diagnostics.push(Diagnostic::global(Error::Internal {
+                    msg: format!("module id {curr_id} missing from graph; aborting compilation"),
+                }));
+                return;
             };
 
             // We need this to report errors inside THIS file.
@@ -240,27 +297,21 @@ impl DependencyGraph {
             let valid_imports = Self::resolve_imports(
                 &current_source_module.program,
                 &current,
-                &graph.dependency_map,
+                &self.dependency_map,
                 &mut use_cache,
-                handler,
+                diagnostics,
             );
 
             let mut ctx = LoadContext {
                 invalid_imports: &mut invalid_imports,
-                handler,
+                diagnostics,
                 queue: &mut queue,
                 unstable_features,
             };
-            graph.load_and_parse_dependencies(&current, valid_imports, &mut ctx);
+            self.load_and_parse_dependencies(&current, valid_imports, &mut ctx);
         }
 
-        graph.use_cache = use_cache;
-
-        (!handler.has_errors()).then_some(graph)
-    }
-
-    pub fn source_map(&self) -> &SourceMap {
-        &self.source_map
+        self.use_cache = use_cache;
     }
 
     /// PHASE 1 OF GRAPH CONSTRUCTION: Resolves all `use` declarations within a single
@@ -274,13 +325,13 @@ impl DependencyGraph {
         current_module: &CurrentModule,
         dependency_map: &DependencyMap,
         use_cache: &mut HashMap<Span, ResolvedUse>,
-        handler: &mut ErrorCollector,
+        diagnostics: &mut DiagnosticManager,
     ) -> Vec<(CanonPath, Span)> {
         let mut ctx = ImportContext {
             current: current_module.clone(),
             dependency_map,
             use_cache,
-            handler,
+            diagnostics,
         };
 
         let mut valid_imports = Vec::new();
@@ -303,7 +354,7 @@ impl DependencyGraph {
                 continue;
             }
 
-            if let Some(existing_id) = self.source_map.id(&path) {
+            if let Some(existing_id) = self.sources.id(&path) {
                 let deps = self.dependencies.entry(current.id).or_default();
                 if !deps.contains(&existing_id) {
                     deps.push(existing_id);
@@ -311,30 +362,32 @@ impl DependencyGraph {
                 continue;
             }
 
-            let new_id = self.source_map.len();
-
             let Ok(content) = std::fs::read_to_string(path.as_path()) else {
-                let err = RichError::new(
+                let err = Diagnostic::new(
                     Error::FileNotFound {
                         filename: PathBuf::from(path.as_path()),
                     },
                     import_span,
-                )
-                .with_source(current.source.clone());
+                );
 
-                ctx.handler.push(err);
+                ctx.diagnostics.push(err);
 
                 // Safe to ignore output: previous `.contains` check prevents collisions.
                 let _ = ctx.invalid_imports.insert(path);
                 continue;
             };
 
+            // Store source inside source_map, before checking is it valid or not.
             let source = CanonSourceFile::new(path.clone(), Arc::from(content));
 
-            let Some(module) = Self::parse_and_get_source_module(
+            // Must be read before inserting!
+            let new_id = self.sources.len();
+            self.sources.insert(source.clone());
+
+            let Some(parsed_program) = Self::parse_and_get_source_module(
                 new_id,
-                source.clone(),
-                ctx.handler,
+                &source.content(),
+                ctx.diagnostics,
                 ctx.unstable_features,
             ) else {
                 // Safe to ignore output: previous `.contains` check prevents collisions.
@@ -342,9 +395,12 @@ impl DependencyGraph {
                 continue;
             };
 
-            self.source_map.insert(source);
-            self.modules.push(module);
+            let module = SourceModule {
+                source: source.clone(),
+                program: parsed_program,
+            };
 
+            self.modules.insert(new_id, module);
             self.dependencies
                 .entry(current.id)
                 .or_default()
@@ -359,24 +415,24 @@ impl DependencyGraph {
     /// `ErrorCollector` and safely returns `None`.
     fn parse_and_get_source_module(
         new_id: usize,
-        source: CanonSourceFile,
-        handler: &mut ErrorCollector,
+        content: &str,
+        diagnostics: &mut DiagnosticManager,
         unstable_features: &UnstableFeatures,
-    ) -> Option<SourceModule> {
-        let mut error_handler = ErrorCollector::new();
+    ) -> Option<parse::Program> {
+        let before = diagnostics.error_count();
+
         let ast = parse::Program::parse_from_str_with_errors(
             new_id,
-            source.clone(),
+            content,
             unstable_features,
-            &mut error_handler,
+            diagnostics,
         );
 
-        if error_handler.has_errors() {
-            handler.extend_with_handler(source, &error_handler);
+        if diagnostics.error_count() > before {
             return None;
         }
 
-        ast.map(|program| SourceModule { source, program })
+        ast
     }
 }
 
@@ -386,7 +442,7 @@ struct ImportContext<'a> {
     current: CurrentModule,
     dependency_map: &'a DependencyMap,
     use_cache: &'a mut HashMap<Span, ResolvedUse>,
-    handler: &'a mut ErrorCollector,
+    diagnostics: &'a mut DiagnosticManager,
 }
 
 impl<'a> ImportContext<'a> {
@@ -408,7 +464,7 @@ impl<'a> ImportContext<'a> {
 
     /// Resolves a single `use` declaration, caches the result for reuse during
     /// later graph construction phases, and returns the resolved path and span.
-    /// Returns `None` and reports to `handler` if resolution fails.
+    /// Returns `None` and reports to `diagnostics` if resolution fails.
     fn resolve_single(&mut self, use_decl: &parse::UseDecl) -> Option<(CanonPath, Span)> {
         let resolved = match self
             .dependency_map
@@ -416,8 +472,7 @@ impl<'a> ImportContext<'a> {
         {
             Ok(res) => res,
             Err(err) => {
-                self.handler
-                    .push(err.with_source(self.current.source.clone()));
+                self.diagnostics.push(err);
                 return None;
             }
         };
@@ -432,10 +487,11 @@ impl<'a> ImportContext<'a> {
                 "Reevaluated an existing use_decl. Old value was: {:?}",
                 old_value
             );
-            let err = RichError::new(Error::Internal { msg }, span)
-                .with_source(self.current.source.clone());
-            self.handler.push(err);
+
+            let err = Diagnostic::new(Error::Internal { msg }, span);
+            self.diagnostics.push(err);
         }
+
         Some(result)
     }
 }
@@ -444,7 +500,7 @@ impl<'a> ImportContext<'a> {
 /// Lives only for the duration of [`DependencyGraph::new`].
 struct LoadContext<'a> {
     invalid_imports: &'a mut HashSet<CanonPath>,
-    handler: &'a mut ErrorCollector,
+    diagnostics: &'a mut DiagnosticManager,
     queue: &'a mut VecDeque<usize>,
     unstable_features: &'a UnstableFeatures,
 }
@@ -482,77 +538,59 @@ pub(crate) mod tests {
     ///    This will be empty if graph creation fails.
     /// 3. `TempWorkspace`: The temporary directory instance. This must be kept in scope by the caller so
     ///    the OS doesn't delete the files before the test finishes.
-    /// 4. `ErrorCollector`: The handler containing any logged errors, useful fo
+    /// 4. `DiagnosticManager`: The manager containing any logged errors.
     pub(crate) fn setup_graph_raw(
         files: Vec<(&str, &str)>,
     ) -> (
         Option<DependencyGraph>,
         HashMap<String, usize>,
         TempWorkspace,
-        ErrorCollector,
+        DiagnosticManager,
     ) {
         let ws = TempWorkspace::new("graph");
-        let mut handler = ErrorCollector::new();
 
         // Create base directories
         let workspace_dir = canon(&ws.create_dir("workspace"));
         let lib_dir = canon(&ws.create_dir("workspace/libs/lib"));
 
         // Set up the dependency map for imports (e.g. `use lib::...`)
-        let map =
+        let dependency_map =
             Arc::new(build_map(&workspace_dir, &[(&workspace_dir, "lib", &lib_dir)]).unwrap());
 
-        let mut root_file_path = None;
-        let mut root_content = String::new();
-
         // Create all requested files
+        let mut root_source_opt = None;
         for (path, content) in files {
             let full_path = format!("workspace/{}", path);
-            let created_file = canon(&ws.create_file(&full_path, content));
+            let created = canon(&ws.create_file(&full_path, content));
 
             if path == "main.simf" {
-                root_file_path = Some(created_file);
-                root_content = content.to_string();
+                root_source_opt = Some(CanonSourceFile::new(created, Arc::from(content)));
             }
         }
+        let root_source = root_source_opt.expect("main.simf must be defined in file list");
 
-        let root_p = root_file_path.expect("main.simf must be defined in file list");
-        let main_canon_source = CanonSourceFile::new(root_p, Arc::from(root_content));
+        let (graph_opt, diagnostics) =
+            DependencyGraph::build_graph(root_source, dependency_map, &UnstableFeatures::all());
 
-        let main_program_option = parse::Program::parse_from_str_with_errors(
-            MAIN_MODULE,
-            main_canon_source.clone(),
-            &UnstableFeatures::all(),
-            &mut handler,
-        );
-
-        let Some(main_program) = main_program_option else {
-            return (None, HashMap::new(), ws, handler);
+        let file_ids = match &graph_opt {
+            Some(graph) => build_file_ids(&graph.sources),
+            None => diagnostics
+                .sources()
+                .map(build_file_ids)
+                .unwrap_or_default(),
         };
 
-        let graph_option = DependencyGraph::new(
-            main_canon_source,
-            map,
-            &main_program,
-            &mut handler,
-            &UnstableFeatures::all(),
-        );
+        (graph_opt, file_ids, ws, diagnostics)
+    }
 
-        let mut file_ids = HashMap::new();
-
-        if let Some(ref graph) = graph_option {
-            for (path, id) in graph.source_map.iter() {
-                let file_stem = path
-                    .as_path()
-                    .file_stem()
-                    .unwrap()
-                    .to_string_lossy()
-                    .to_string();
-                file_ids.insert(file_stem, *id);
-            }
-        }
-
-        (graph_option, file_ids, ws, handler)
+    fn build_file_ids(sources: &SourceMap) -> HashMap<String, usize> {
+        sources
+            .iter()
+            .filter_map(|(path, id)| {
+                let stem = path.as_path().file_stem()?;
+                Some((stem.to_string_lossy().into_owned(), *id))
+            })
+            .collect()
     }
 
     /// Initializes a complete graph environment for testing, expecting strict success.
@@ -579,17 +617,22 @@ pub(crate) mod tests {
     /// to standard error if the parser or graph builder encounters any issues.
     pub(crate) fn setup_graph(
         files: Vec<(&str, &str)>,
-    ) -> (DependencyGraph, HashMap<String, usize>, TempWorkspace) {
-        let (graph_option, file_ids, ws, handler) = setup_graph_raw(files);
+    ) -> (
+        DependencyGraph,
+        HashMap<String, usize>,
+        TempWorkspace,
+        DiagnosticManager,
+    ) {
+        let (graph_option, file_ids, ws, diagnostics) = setup_graph_raw(files);
 
         let Some(graph) = graph_option else {
             panic!(
                 "Parser or DependencyGraph Error in Test Setup:\n{}",
-                handler
+                diagnostics
             );
         };
 
-        (graph, file_ids, ws)
+        (graph, file_ids, ws, diagnostics)
     }
 
     #[test]
@@ -598,7 +641,7 @@ pub(crate) mod tests {
         // root.simf -> "use lib::math::some_func;"
         // libs/lib/math.simf -> ""
 
-        let (graph, ids, _ws) = setup_graph(vec![
+        let (graph, ids, _ws, _diags) = setup_graph(vec![
             ("main.simf", "use lib::math::some_func;"),
             ("libs/lib/math.simf", ""),
         ]);
@@ -625,7 +668,7 @@ pub(crate) mod tests {
         // B -> imports Common
         // Expected: Common loaded ONLY ONCE.
 
-        let (graph, ids, _ws) = setup_graph(vec![
+        let (graph, ids, _ws, _diags) = setup_graph(vec![
             ("main.simf", "use lib::A::foo; use lib::B::bar;"),
             ("libs/lib/A.simf", "use crate::Common::dummy1;"),
             ("libs/lib/B.simf", "use crate::Common::dummy2;"),
@@ -670,7 +713,7 @@ pub(crate) mod tests {
         // A -> imports B
         // B -> imports A
 
-        let (graph, ids, _ws) = setup_graph(vec![
+        let (graph, ids, _ws, _diags) = setup_graph(vec![
             ("main.simf", "use lib::A::entry;"),
             ("libs/lib/A.simf", "use crate::B::func;"),
             ("libs/lib/B.simf", "use crate::A::func;"),
@@ -701,7 +744,7 @@ pub(crate) mod tests {
         // Setup: root imports from "unknown", which is not in our dependency map.
         // We use `setup_graph_raw` because we expect graph generation to fail and
         // emit an error, rather than panicking the standard test helper.
-        let (graph_option, _ids, _ws, handler) =
+        let (graph_option, _ids, _ws, diagnostics) =
             setup_graph_raw(vec![("main.simf", "use unknown::library::item;")]);
 
         assert!(
@@ -710,7 +753,7 @@ pub(crate) mod tests {
         );
 
         assert!(
-            handler.has_errors(),
+            diagnostics.has_errors(),
             "The ErrorCollector should have logged an error about the unmapped import"
         );
     }
@@ -720,7 +763,7 @@ pub(crate) mod tests {
         // Goal: Verify that a simple chain (main -> a -> b) correctly pushes items
         // into the vectors and builds the adjacency list in BFS order.
 
-        let (graph, ids, _ws) = setup_graph(vec![
+        let (graph, ids, _ws, _diags) = setup_graph(vec![
             ("main.simf", "use lib::A::mock_item;"),
             ("libs/lib/A.simf", "use crate::B::mock_item;"),
             ("libs/lib/B.simf", ""),
@@ -728,7 +771,7 @@ pub(crate) mod tests {
 
         // Assert: Size checks
         assert_eq!(graph.modules.len(), 3);
-        assert_eq!(graph.source_map.entries.len(), 3);
+        assert_eq!(graph.sources.len(), 3);
 
         // Assert: Ensure BFS assigned the IDs in the exact correct order
         let main_id = ids["main"];

--- a/src/driver/resolve_order.rs
+++ b/src/driver/resolve_order.rs
@@ -1,37 +1,54 @@
+use std::collections::HashMap;
+
 use crate::driver::{DependencyGraph, CRATE_STR, MAIN_MODULE, MAIN_STR};
-use crate::error::{Error, ErrorCollector, RichError};
+use crate::error::{Diagnostic, DiagnosticManager, Error, Span};
 use crate::parse::{self, Visibility};
 use crate::str::{Identifier, ModuleName};
 
 /// This is a core component of the [`DependencyGraph`].
 impl DependencyGraph {
     /// Resolves the dependency graph and constructs the final AST program.
-    pub fn linearize_and_build(&self, handler: &mut ErrorCollector) -> Option<parse::Program> {
+    pub(crate) fn linearize_and_assemble(
+        &self,
+        diagnostics: &mut DiagnosticManager,
+    ) -> Option<parse::Program> {
         match self.linearize() {
-            Ok(order) => self.build_program(&order, handler),
+            Ok(order) => self.assemble_program(&order, diagnostics),
             Err(err) => {
-                handler.push(err);
+                diagnostics.push(err);
                 None
             }
         }
     }
 
     /// Constructs the unified array of items for the entire multi-program.
-    fn build_program(
+    fn assemble_program(
         &self,
         order: &[usize],
-        handler: &mut ErrorCollector,
+        diagnostics: &mut DiagnosticManager,
     ) -> Option<parse::Program> {
         let mut items = Vec::with_capacity(order.len());
 
+        let target_ids: HashMap<Span, usize> = self
+            .use_cache
+            .iter()
+            .map(|(span, resolved)| {
+                let id = self
+                    .sources
+                    .id(&resolved.path)
+                    .expect("resolved path must be registered in source map");
+                (*span, id)
+            })
+            .collect();
+
         for &source_id in order {
-            let module = &self.modules[source_id];
+            let module = &self.modules[&source_id];
 
             let local_items: Vec<parse::Item> = module
                 .program
                 .items()
                 .iter()
-                .filter_map(|item| self.rewrite_item(item))
+                .filter_map(|item| self.rewrite_item(item, &target_ids))
                 .collect();
 
             if source_id == MAIN_MODULE {
@@ -40,9 +57,9 @@ impl DependencyGraph {
                 });
 
                 if !has_main {
-                    handler.push(RichError::parsing_error(
-                        &Error::MainOutOfEntryFile.to_string(),
-                    ));
+                    diagnostics.push(Diagnostic::global(Error::CannotParse {
+                        msg: Error::MainOutOfEntryFile.to_string(),
+                    }));
                 }
             }
 
@@ -55,19 +72,23 @@ impl DependencyGraph {
             )));
         }
 
-        (!handler.has_errors())
-            .then(|| parse::Program::new(&items, *self.modules[MAIN_MODULE].program.as_ref()))
+        (!diagnostics.has_errors())
+            .then(|| parse::Program::new(&items, *self.modules[&MAIN_MODULE].program.as_ref()))
     }
 
     /// Rewrites a single item for the flattened single-file representation.
-    fn rewrite_item(&self, item: &parse::Item) -> Option<parse::Item> {
+    fn rewrite_item(
+        &self,
+        item: &parse::Item,
+        target_ids: &HashMap<Span, usize>,
+    ) -> Option<parse::Item> {
         match item {
-            parse::Item::Use(use_decl) => Some(self.rewrite_use(use_decl)),
+            parse::Item::Use(use_decl) => Some(self.rewrite_use(use_decl, target_ids)),
             parse::Item::Module(module) => {
                 let items: Vec<parse::Item> = module
                     .items()
                     .iter()
-                    .filter_map(|inner_item| self.rewrite_item(inner_item))
+                    .filter_map(|inner_item| self.rewrite_item(inner_item, target_ids))
                     .collect();
 
                 Some(parse::Item::Module(parse::Module::new(
@@ -82,22 +103,22 @@ impl DependencyGraph {
         }
     }
 
-    /// Rewrites a `use` declaration to its canonical `crate`-rooted form.
+    /// Rewrites a `use` declaration into its canonical `crate`-rooted form.
     ///
-    /// The resolved path becomes `crate::<module>::<mod_path...>`, where
-    /// `<module>` is `file_N` for dependency files and is omitted when the
-    /// target is [`MAIN_MODULE`] (via [`DependencyGraph::get_module_name`]).
+    /// The resolved path becomes `crate::unit_<N>::<mod_path...>`, where `N` is
+    /// the source id of the file that owns the imported item.
     ///
-    /// ## Examples
+    /// ## Example
     ///
-    /// - `use base_math::simple_op::hash` → `use crate::file_2::hash`
-    /// - `use some_dep::item` (target = [`MAIN_MODULE`]) → `use crate::item`
-    fn rewrite_use(&self, use_decl: &parse::UseDecl) -> parse::Item {
-        let resolved = &self.use_cache[use_decl.span()];
-        let target_id = self
-            .source_map
-            .id(&resolved.path)
-            .expect("resolved path must be registered");
+    /// - `use base_math::simple_op::hash` → `use crate::unit_2::hash`
+    fn rewrite_use(
+        &self,
+        use_decl: &parse::UseDecl,
+        target_ids: &HashMap<Span, usize>,
+    ) -> parse::Item {
+        let span = *use_decl.span();
+        let resolved = &self.use_cache[&span];
+        let target_id = target_ids[&span];
 
         let mut new_path = Vec::with_capacity(resolved.mod_path.len() + 2);
         new_path.push(Identifier::from_str_unchecked(CRATE_STR));
@@ -118,7 +139,6 @@ impl DependencyGraph {
 mod flattening_tests {
     use crate::driver::tests::setup_graph;
     use crate::driver::CRATE_STR;
-    use crate::error::ErrorCollector;
     use crate::parse::{self, Visibility};
 
     use std::collections::HashMap;
@@ -127,11 +147,10 @@ mod flattening_tests {
     fn build_flattened_program(
         files: Vec<(&str, &str)>,
     ) -> (parse::Program, HashMap<String, usize>) {
-        let (graph, ids, _dir) = setup_graph(files);
-        let mut error_handler = ErrorCollector::new();
+        let (graph, ids, _dir, mut diagnostics) = setup_graph(files);
 
-        let Some(program) = graph.linearize_and_build(&mut error_handler) else {
-            panic!("{}", &error_handler.to_string());
+        let Some(program) = graph.linearize_and_assemble(&mut diagnostics) else {
+            panic!("{}", &diagnostics);
         };
 
         (program, ids)
@@ -230,7 +249,7 @@ mod flattening_tests {
 
     #[test]
     fn dependency_main_does_not_satisfy_missing_root_main() {
-        let (graph, _ids, _dir) = setup_graph(vec![
+        let (graph, _ids, _dir, mut diagnostics) = setup_graph(vec![
             ("main.simf", "use lib::A::helper;"),
             (
                 "libs/lib/A.simf",
@@ -238,8 +257,7 @@ mod flattening_tests {
             ),
         ]);
 
-        let mut error_handler = ErrorCollector::new();
-        let driver_program = graph.linearize_and_build(&mut error_handler);
+        let driver_program = graph.linearize_and_assemble(&mut diagnostics);
 
         assert!(
             driver_program.is_none(),
@@ -248,7 +266,7 @@ mod flattening_tests {
         );
 
         assert!(
-            error_handler.has_errors(),
+            diagnostics.has_errors(),
             "a dependency `fn main` must not satisfy a missing entrypoint `fn main`"
         );
     }
@@ -257,27 +275,27 @@ mod flattening_tests {
 #[cfg(test)]
 mod dependency_map_tests {
     use crate::driver::tests::setup_graph;
-    use crate::error::ErrorCollector;
+    use crate::error::DiagnosticManager;
 
     // Helper to run the driver and return the error collector so we can inspect it.
-    fn run_driver(files: Vec<(&str, &str)>) -> ErrorCollector {
-        let (graph, _ids, _dir) = setup_graph(files);
-        let mut error_handler = ErrorCollector::new();
-        let _ = graph.linearize_and_build(&mut error_handler).unwrap();
-        error_handler
+    fn run_driver(files: Vec<(&str, &str)>) -> DiagnosticManager {
+        let (graph, _ids, _dir, mut diagnostics) = setup_graph(files);
+        let _ = graph.linearize_and_assemble(&mut diagnostics).unwrap();
+        diagnostics
     }
 
     #[test]
     fn test_crate_path_resolves_to_physical_file() {
         // Scenario: `crate::utils::math` should map to the physical `utils/math.simf` file.
-        let errors = run_driver(vec![
+        let diagnostics = run_driver(vec![
             ("utils/math.simf", "pub fn add() {}"),
             ("main.simf", "use crate::utils::math::add; fn main() {}"),
         ]);
 
         assert!(
-            !errors.has_errors(),
-            "Driver should successfully find the physical file 'utils/math.simf'. Errors: {errors}"
+            !diagnostics.has_errors(),
+            "Driver should successfully find the physical file 'utils/math.simf'. Errors: {}",
+            diagnostics
         );
     }
 
@@ -285,7 +303,7 @@ mod dependency_map_tests {
     fn test_crate_path_fallback_to_inline_module() {
         // Scenario: `brother.simf` does NOT exist. `crate::brother` must fallback
         // to `main.simf` and treat `brother` as an inline mod_path.
-        let errors = run_driver(vec![(
+        let diagnostics = run_driver(vec![(
             "main.simf",
             "
                 mod brother { pub fn toy() {} }
@@ -294,13 +312,17 @@ mod dependency_map_tests {
             ",
         )]);
 
-        assert!(!errors.has_errors(), "Driver must fallback to main.simf for inline modules without throwing FileNotFound. Errors: {errors}");
+        assert!(
+            !diagnostics.has_errors(),
+            "Driver must fallback to main.simf for inline modules without throwing FileNotFound. Errors: {}",
+            diagnostics
+        );
     }
 
     #[test]
     fn test_crate_path_deeply_nested_inline_fallback() {
         // Scenario: A physical file exists (`utils.simf`), but the REST of the path is inline modules!
-        let errors = run_driver(vec![
+        let diagnostics = run_driver(vec![
             (
                 "utils.simf",
                 "pub mod deeply { pub mod nested { pub fn func() {} } }",
@@ -312,22 +334,24 @@ mod dependency_map_tests {
         ]);
 
         assert!(
-            !errors.has_errors(),
-            "Driver must split the path at the file boundary correctly. Errors: {errors}"
+            !diagnostics.has_errors(),
+            "Driver must split the path at the file boundary correctly. Errors: {}",
+            diagnostics
         );
     }
 
     #[test]
     fn test_external_dependency_resolution() {
         // Scenario: Resolving `use lib::A::foo` across the remapping boundary.
-        let errors = run_driver(vec![
+        let diagnostics = run_driver(vec![
             ("libs/lib/A.simf", "pub fn foo() {}"),
             ("main.simf", "use lib::A::foo; fn main() {}"),
         ]);
 
         assert!(
-            !errors.has_errors(),
-            "External dependency resolution via drp_name failed. Errors: {errors}"
+            !diagnostics.has_errors(),
+            "External dependency resolution via drp_name failed. Errors: {}",
+            diagnostics
         );
     }
 }

--- a/src/driver/version_tests.rs
+++ b/src/driver/version_tests.rs
@@ -13,10 +13,12 @@ fn build(files: &[(&str, &str)]) -> (bool, String) {
         .iter()
         .map(|(p, c)| (*p, c.replace("{v}", v)))
         .collect();
+
     let refs: Vec<(&str, &str)> = owned.iter().map(|(p, c)| (*p, c.as_str())).collect();
-    let (graph_opt, _, _ws, handler) = setup_graph_raw(refs);
-    let ok = graph_opt.is_some() && !handler.has_errors();
-    (ok, handler.to_string())
+    let (graph_opt, _, _ws, diagnostics) = setup_graph_raw(refs);
+
+    let ok = graph_opt.is_some() && !diagnostics.has_errors();
+    (ok, diagnostics.to_string())
 }
 
 fn assert_builds(files: &[(&str, &str)]) {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,7 @@
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
 use std::fmt;
+use std::io::{self, Write};
 use std::ops::Range;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -7,16 +10,16 @@ use chumsky::error::Error as ChumskyError;
 use chumsky::input::ValueInput;
 use chumsky::label::LabelError;
 use chumsky::span::SimpleSpan;
-use chumsky::text::Char;
 use chumsky::util::MaybeRef;
 use chumsky::DefaultExpected;
 
+use ariadne::{Cache, Color, Config, Label as AriadneLabel, Report, ReportKind, Source};
+
 use itertools::Itertools;
 
-use crate::driver::CRATE_STR;
+use crate::driver::{SourceMap, CRATE_STR, MAIN_MODULE};
 use crate::lexer::Token;
 use crate::parse::MatchPattern;
-use crate::source::SourceFile;
 use crate::str::{AliasName, FunctionName, Identifier, JetName, ModuleName, WitnessName};
 use crate::types::{ResolvedType, UIntType};
 use crate::unstable::UnstableFeature;
@@ -32,8 +35,36 @@ pub struct Span {
     pub end: usize,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Severity {
+    Error,
+    Warning,
+}
+
+/// A span-anchored annotation attached to a diagnostic.
+///
+/// Used only for secondary highlights. The primary location is carried
+/// by [`Diagnostic::location`].
+#[derive(Debug, Clone)]
+pub struct Label {
+    pub span: Span,
+    pub message: String,
+}
+
+/// Where the diagnostic points.
+///
+/// - `Code`: Inside a file, at a specific span. Normal case.
+/// - `File`: The whole file. E.g. "main must be in the entry file".
+/// - `Global`: The whole build. E.g. dependency cycle, missing crate root.
+#[derive(Debug, Clone)]
+pub enum Location {
+    Code(Span),
+    File(usize),
+    Global,
+}
+
 impl Span {
-    pub(crate) const DUMMY: Self = Self::new(0, 0..0);
+    pub(crate) const DUMMY: Self = Self::new(MAIN_MODULE, 0..0);
 
     /// Create a new span.
     ///
@@ -55,8 +86,8 @@ impl Span {
         Self::new(file_id, source_len..source_len)
     }
 
-    pub const fn from_chumsky(file_id: usize, span: SimpleSpan<usize>) -> Self {
-        Self::new(file_id, span.start..span.end)
+    pub const fn from_chumsky(file_id: usize, span: SimpleSpan, start: usize) -> Self {
+        Self::new(file_id, span.start + start..span.end + start)
     }
 
     /// Return a slice from the given `file` that corresponds to the span.
@@ -111,218 +142,159 @@ impl<'a> arbitrary::Arbitrary<'a> for Span {
     }
 }
 
-/// Helper trait to convert `Result<T, E>` into `Result<T, RichError>`.
+/// Helper trait to convert `Result<T, E>` into `Result<T, Diagnostic>`.
 pub trait WithSpan<T> {
     /// Update the result with the affected span.
-    fn with_span<S: Into<Span>>(self, span: S) -> Result<T, RichError>;
+    fn with_span<S: Into<Span>>(self, span: S) -> Result<T, Diagnostic>;
 }
 
 impl<T, E: Into<Error>> WithSpan<T> for Result<T, E> {
-    fn with_span<S: Into<Span>>(self, span: S) -> Result<T, RichError> {
+    fn with_span<S: Into<Span>>(self, span: S) -> Result<T, Diagnostic> {
         self.map_err(|e| e.into().with_span(span.into()))
     }
 }
 
-/// Helper trait to update `Result<A, RichError>` with the affected source file.
-pub trait WithContent<T> {
-    /// Update the result with the affected source file.
-    ///
-    /// Enable pretty errors.
-    fn with_content<C: Into<Arc<str>>>(self, content: C) -> Result<T, RichError>;
-}
-
-impl<T> WithContent<T> for Result<T, RichError> {
-    fn with_content<C: Into<Arc<str>>>(self, content: C) -> Result<T, RichError> {
-        self.map_err(|e| e.with_content(content.into()))
-    }
-}
-
-/// Helper trait to update `Result<A, RichError>` with the affected source file.
-pub trait WithSource<T> {
-    /// Update the result with the affected source file.
-    ///
-    /// Enable pretty errors.
-    fn with_source<S: Into<SourceFile>>(self, source: S) -> Result<T, RichError>;
-}
-
-impl<T> WithSource<T> for Result<T, RichError> {
-    fn with_source<S: Into<SourceFile>>(self, source: S) -> Result<T, RichError> {
-        self.map_err(|e| e.with_source(source.into()))
-    }
-}
-
-/// An error enriched with context.
+/// A single diagnostic ready to be rendered.
 ///
-/// Records _what_ happened and _where_.
+/// Records *what* went wrong, *where*, and any extra context that helps
+/// the user act on it.
 #[derive(Debug, Clone)]
-pub struct RichError {
+pub struct Diagnostic {
+    /// How the diagnostic is classified for display and exit code.
+    severity: Severity,
+
     /// The error that occurred.
     ///
-    /// Wrapped in a `Box` to keep the `RichError` struct small on the stack,
+    /// Wrapped in a `Box` to keep the [`Error`] struct small on the stack,
     /// ensuring cheap moves when returning errors inside a `Result`.
     error: Box<Error>,
 
-    /// Area that the error spans inside the file.
-    span: Span,
+    location: Location,
 
-    /// File context in which the error occurred.
-    ///
-    /// Required to print pretty errors.
-    source: Option<SourceFile>,
+    /// Additional highlights attached to secondary spans.
+    /// Used for "X conflicts with Y" style errors. For example
+    /// a "redefined function" error.
+    secondary: Vec<Label>,
+
+    /// Free-form notes shown below the code snippet.
+    notes: Vec<Arc<str>>,
+
+    /// A single actionable suggestion, if one applies.
+    help: Option<Arc<str>>,
 }
 
-impl RichError {
+impl Diagnostic {
     /// Create a new error with context.
-    pub fn new(error: Error, span: Span) -> RichError {
-        RichError {
+    pub fn new(error: Error, span: Span) -> Self {
+        Self {
+            severity: Severity::Error,
             error: Box::new(error),
+            location: Location::Code(span),
+            secondary: Vec::new(),
+            notes: Vec::new(),
+            help: None,
+        }
+    }
+
+    /// Create a warning attached to a code span.
+    pub fn warning(error: Error, span: Span) -> Self {
+        Self {
+            severity: Severity::Warning,
+            ..Self::new(error, span)
+        }
+    }
+
+    pub fn file(error: Error, file_id: usize) -> Self {
+        Self {
+            location: Location::File(file_id),
+            ..Self::new(error, Span::DUMMY)
+        }
+    }
+
+    pub fn global(error: Error) -> Self {
+        Self {
+            location: Location::Global,
+            ..Self::new(error, Span::DUMMY)
+        }
+    }
+
+    pub fn with_secondary(mut self, span: Span, message: impl Into<String>) -> Self {
+        self.secondary.push(Label {
             span,
-            source: None,
-        }
+            message: message.into(),
+        });
+        self
     }
 
-    /// Adds raw source code content to the error context.
-    ///
-    /// Use this when the error occurs in an environment without a backing physical file
-    /// (e.g., raw string input for single-file program) to enable basic error formatting.
-    pub fn with_content(self, program_content: Arc<str>) -> Self {
-        Self {
-            error: self.error,
-            span: self.span,
-            source: Some(SourceFile::anonymous(program_content)),
-        }
+    pub fn with_note(mut self, note: impl Into<Arc<str>>) -> Self {
+        self.notes.push(note.into());
+        self
     }
 
-    /// Add the source file where the error occurred.
-    ///
-    /// Enable pretty errors.
-    pub fn with_source(self, source: impl Into<SourceFile>) -> Self {
-        Self {
-            error: self.error,
-            span: self.span,
-            source: Some(source.into()),
-        }
+    pub fn with_help(mut self, help: impl Into<Arc<str>>) -> Self {
+        self.help = Some(help.into());
+        self
     }
 
-    /// Constructs an error that is very unlikely to be encountered, but indicates
-    /// a problem on the parsing side.
-    pub fn parsing_error(reason: &str) -> Self {
-        Self {
-            error: Box::new(Error::CannotParse {
-                msg: reason.to_string(),
-            }),
-            span: Span::DUMMY,
-            source: None,
-        }
-    }
-
-    pub fn source(&self) -> &Option<SourceFile> {
-        &self.source
+    pub fn severity(&self) -> &Severity {
+        &self.severity
     }
 
     pub fn error(&self) -> &Error {
         &self.error
     }
 
-    pub fn span(&self) -> &Span {
-        &self.span
+    /// Returns where the diagnostic points: a code span, a whole file, or
+    /// the whole build.
+    pub fn location(&self) -> &Location {
+        &self.location
+    }
+
+    /// Returns the secondary labels, additional highlights that give
+    /// context for the primary error.
+    pub fn secondary(&self) -> &[Label] {
+        &self.secondary
+    }
+
+    /// Returns the free-form notes attached to this diagnostic.
+    pub fn notes(&self) -> &[Arc<str>] {
+        &self.notes
+    }
+
+    /// Returns the actionable suggestion, if one was set.
+    pub fn help(&self) -> &Option<Arc<str>> {
+        &self.help
     }
 }
 
-impl fmt::Display for RichError {
+impl fmt::Display for Diagnostic {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fn get_line_col(file: &str, offset: usize) -> (usize, usize) {
-            let mut line = 1;
-            let mut col = 0;
-
-            let slice = file.get(0..offset).unwrap_or_default();
-
-            for char in slice.chars() {
-                if char.is_newline() {
-                    line += 1;
-                    col = 0;
-                } else {
-                    col += char.len_utf16();
-                }
-            }
-
-            (line, col + 1)
-        }
-
-        let Some(source) = &self.source else {
-            return write!(f, "{}", self.error);
-        };
-
-        let content = source.content();
-
-        if content.is_empty() {
-            return write!(f, "{}", self.error);
-        }
-
-        let (start_line, start_col) = get_line_col(&content, self.span.start);
-        let (end_line, end_col) = get_line_col(&content, self.span.end);
-
-        let start_line_index = start_line - 1;
-
-        let n_spanned_lines = end_line - start_line_index;
-        let line_num_width = end_line.to_string().len();
-
-        if let Some(name) = source.name() {
-            writeln!(
-                f,
-                "{:>width$}--> {}:{}:{}",
-                "",
-                name.display(),
-                start_line,
-                start_col,
-                width = line_num_width
-            )?;
-        }
-
-        writeln!(f, "{:width$} |", " ", width = line_num_width)?;
-
-        let mut lines = content
-            .split(|c: char| c.is_newline())
-            .skip(start_line_index)
-            .peekable();
-        let start_line_len = lines
-            .peek()
-            .map_or(0, |l| l.chars().map(char::len_utf16).sum());
-
-        for (relative_line_index, line_str) in lines.take(n_spanned_lines).enumerate() {
-            let line_num = start_line_index + relative_line_index + 1;
-            writeln!(f, "{line_num:line_num_width$} | {line_str}")?;
-        }
-
-        let is_multiline = end_line > start_line;
-
-        let (underline_start, underline_length) = match is_multiline {
-            true => (0, start_line_len),
-            false => (start_col, (end_col - start_col).max(1)),
-        };
-        write!(f, "{:width$} |", " ", width = line_num_width)?;
-        write!(f, "{:width$}", " ", width = underline_start)?;
-        write!(f, "{:^<width$} ", "", width = underline_length)?;
+        // A bare Diagnostic has no source text; that lives in the SourceMap.
+        // Rich, span-highlighted output is produced by DiagnosticManager::render.
         write!(f, "{}", self.error)
     }
 }
 
-impl std::error::Error for RichError {}
-
-impl From<RichError> for Error {
-    fn from(error: RichError) -> Self {
-        *error.error
+impl From<Diagnostic> for Error {
+    fn from(diag: Diagnostic) -> Self {
+        *diag.error
     }
 }
 
-impl From<RichError> for String {
-    fn from(error: RichError) -> Self {
-        error.to_string()
+impl From<Diagnostic> for String {
+    fn from(diag: Diagnostic) -> Self {
+        diag.to_string()
+    }
+}
+
+impl std::error::Error for Diagnostic {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.error.source()
     }
 }
 
 /// Implementation of traits for using inside `chumsky` parsers.
-impl<'tokens, 'src: 'tokens, I> ChumskyError<'tokens, I> for RichError
+impl<'tokens, 'src: 'tokens, I> ChumskyError<'tokens, I> for Diagnostic
 where
     I: ValueInput<'tokens, Token = Token<'src>, Span = Span>,
 {
@@ -337,7 +309,7 @@ where
 }
 
 impl<'tokens, 'src: 'tokens, I> LabelError<'tokens, I, DefaultExpected<'tokens, Token<'src>>>
-    for RichError
+    for Diagnostic
 where
     I: ValueInput<'tokens, Token = Token<'src>, Span = Span>,
 {
@@ -362,19 +334,18 @@ where
 
         let found_string = found.map(|t| t.to_string());
 
-        Self {
-            error: Box::new(Error::Syntax {
+        Self::new(
+            Error::Syntax {
                 expected: expected_tokens,
                 label: None,
                 found: found_string,
-            }),
+            },
             span,
-            source: None,
-        }
+        )
     }
 }
 
-impl<'tokens, 'src: 'tokens, I> LabelError<'tokens, I, &'tokens str> for RichError
+impl<'tokens, 'src: 'tokens, I> LabelError<'tokens, I, &'tokens str> for Diagnostic
 where
     I: ValueInput<'tokens, Token = Token<'src>, Span = Span>,
 {
@@ -389,15 +360,14 @@ where
         let expected_strings: Vec<String> = expected.into_iter().map(|s| s.to_string()).collect();
         let found_string = found.map(|t| t.to_string());
 
-        Self {
-            error: Box::new(Error::Syntax {
+        Self::new(
+            Error::Syntax {
                 expected: expected_strings,
                 label: None,
                 found: found_string,
-            }),
+            },
             span,
-            source: None,
-        }
+        )
     }
 
     fn label_with(&mut self, label: &'tokens str) {
@@ -410,69 +380,287 @@ where
     }
 }
 
-#[derive(Debug, Clone)]
-pub struct ErrorCollector {
-    /// Collected errors.
-    errors: Vec<RichError>,
+#[derive(Debug, Clone, Default)]
+pub struct DiagnosticManager {
+    diags: Vec<Diagnostic>,
+    error_count: usize,
+    sources: Option<SourceMap>,
 }
 
-impl Default for ErrorCollector {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl std::error::Error for ErrorCollector {}
-
-impl ErrorCollector {
+impl DiagnosticManager {
     pub fn new() -> Self {
-        Self { errors: Vec::new() }
+        Self::default()
     }
 
-    /// Extend existing errors with specific `RichError`.
-    /// We assume that `RichError` contains `SourceFile`.
-    pub fn push(&mut self, error: RichError) {
-        self.errors.push(error);
+    pub(crate) fn with_sources(&mut self, sources: SourceMap) {
+        self.sources = Some(sources);
+    }
+
+    /// Extend existing errors with specific `Diagnostic`.
+    pub fn push(&mut self, diag: Diagnostic) {
+        if matches!(diag.severity, Severity::Error) {
+            self.error_count += 1;
+        }
+
+        self.diags.push(diag);
     }
 
     /// Appends new errors, tagging them with the provided source context.
     /// Automatically handles both single-file and multi-file environments.
-    pub fn extend(
-        &mut self,
-        source: impl Into<SourceFile> + Clone,
-        errors: impl IntoIterator<Item = RichError>,
-    ) {
-        let new_errors = errors
-            .into_iter()
-            .map(|err| err.with_source(source.clone()));
-
-        self.errors.extend(new_errors);
-    }
-
-    /// The same idea applies to the `extend()` function.
-    pub fn extend_with_handler(
-        &mut self,
-        source: impl Into<SourceFile> + Clone,
-        handler: &ErrorCollector,
-    ) {
-        self.extend(source, handler.errors.iter().cloned());
-    }
-
-    pub fn get(&self) -> &[RichError] {
-        &self.errors
+    pub fn extend(&mut self, iter: impl IntoIterator<Item = Diagnostic>) {
+        for diag in iter {
+            self.push(diag);
+        }
     }
 
     pub fn has_errors(&self) -> bool {
-        !self.errors.is_empty()
+        self.error_count > 0
+    }
+
+    pub fn error_count(&self) -> usize {
+        self.error_count
+    }
+
+    pub fn diagnostics(&self) -> &[Diagnostic] {
+        &self.diags
+    }
+
+    pub fn sources(&self) -> Option<&SourceMap> {
+        self.sources.as_ref()
+    }
+
+    // TODO(perf): rebuild-per-call cache + sources clone.
+    // Revisit after diagnostic refactor lands.
+    /// Render all diagnostics to `w` using `ariadne`.
+    pub fn render(&self, with_color: bool, mut w: impl Write) -> std::io::Result<()> {
+        // Empty-SourceMap fallback.
+        //
+        // The only caller that hits this branch is the legacy one-file program
+        // flow, which bypasses the driver. All modern paths (LSP, `simc`,
+        // Simplex, and the Web build via `TemplateProgram::flatten`) register
+        // sources with the driver and hit the `RenderCache`-based render below.
+        //
+        // Legacy callers get message-only output — no source snippets, no
+        // line/column info. Once the legacy flow migrates or is removed, this
+        // branch can go.
+        let Some(sources) = self.sources() else {
+            return write!(w, "{self}");
+        };
+
+        let mut cache = RenderCache::new(sources);
+
+        for diag in &self.diags {
+            render_one(diag, &mut cache, with_color, &mut w)?;
+        }
+
+        Ok(())
+    }
+
+    pub fn render_to_string(&self) -> String {
+        let mut buf = Vec::new();
+        self.render(false, &mut buf)
+            .expect("writing to Vec never fails");
+        String::from_utf8(buf).expect("ariadne output is valid utf-8")
     }
 }
 
-impl fmt::Display for ErrorCollector {
+impl fmt::Display for DiagnosticManager {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for err in self.get() {
-            writeln!(f, "{err}\n")?;
+        // Message-only, no source snippets. Callers that want rich output
+        // with span highlighting must call `render` or `render_to_string`
+        // explicitly, because `fmt::Formatter` can't carry the color flag
+        // or surface I/O errors.
+        for diag in &self.diags {
+            writeln!(f, "{diag}")?;
         }
         Ok(())
+    }
+}
+
+impl std::error::Error for DiagnosticManager {}
+
+/// Lazy ariadne cache that memoises `Source` construction across labels
+/// within a single `render` call.
+#[derive(Debug)]
+pub(crate) struct RenderCache<'a> {
+    pub(crate) sources: &'a SourceMap,
+    built: HashMap<usize, Source<Arc<str>>>,
+}
+
+impl<'a> RenderCache<'a> {
+    fn new(sources: &'a SourceMap) -> Self {
+        Self {
+            sources,
+            built: HashMap::new(),
+        }
+    }
+}
+
+impl<'a> Cache<usize> for RenderCache<'a> {
+    type Storage = Arc<str>;
+
+    fn fetch(&mut self, id: &usize) -> Result<&ariadne::Source<Arc<str>>, Box<dyn fmt::Debug>> {
+        match self.built.entry(*id) {
+            Entry::Occupied(e) => Ok(e.into_mut()),
+
+            Entry::Vacant(e) => {
+                let Some(content) = self.sources.content(*id) else {
+                    return Err(Box::new(format!("unknown file_id: {id}")));
+                };
+
+                Ok(e.insert(Source::from(content)))
+            }
+        }
+    }
+
+    fn display<'b>(&self, id: &'b usize) -> Option<Box<dyn std::fmt::Display + 'b>> {
+        self.sources.path(*id).map(|path| {
+            Box::new(path.as_path().display().to_string()) as Box<dyn fmt::Display + 'b>
+        })
+    }
+}
+
+fn render_one(
+    diag: &Diagnostic,
+    cache: &mut RenderCache,
+    with_color: bool,
+    w: &mut impl Write,
+) -> std::io::Result<()> {
+    match &diag.location {
+        Location::Code(span) => render_code(diag, *span, cache, with_color, w),
+        Location::File(file_id) => render_file(diag, *file_id, cache.sources, w),
+        Location::Global => render_global(diag, w),
+    }
+}
+
+fn render_code(
+    diag: &Diagnostic,
+    span: Span,
+    cache: &mut RenderCache,
+    with_color: bool,
+    w: &mut impl Write,
+) -> std::io::Result<()> {
+    if cache.sources.content(span.file_id).is_none() {
+        return render_missing_source(diag, span.file_id, w);
+    };
+
+    let span_range = span.start..span.end;
+
+    let mut report = Report::build(kind(diag.severity), (span.file_id, span_range.clone()))
+        .with_config(
+            Config::default()
+                .with_index_type(ariadne::IndexType::Byte)
+                .with_char_set(if with_color {
+                    ariadne::CharSet::Unicode
+                } else {
+                    ariadne::CharSet::Ascii
+                })
+                .with_color(with_color),
+        )
+        .with_message(diag.error.to_string())
+        .with_label(
+            // Consider polishing adding `with_message("")` string
+            AriadneLabel::new((span.file_id, span_range)).with_color(Color::Red),
+        );
+
+    for label in &diag.secondary {
+        if cache.sources.content(label.span.file_id).is_none() {
+            debug_assert!(
+                false,
+                "secondary label references unregistered file_id {}",
+                label.span.file_id
+            );
+            continue;
+        };
+
+        report = report.with_label(
+            AriadneLabel::new((label.span.file_id, label.span.start..label.span.end))
+                .with_message(&label.message)
+                .with_color(Color::Blue),
+        );
+    }
+
+    for note in &diag.notes {
+        report = report.with_note(note.as_ref());
+    }
+
+    if let Some(help) = &diag.help {
+        report = report.with_help(help);
+    }
+
+    report.finish().write(cache, &mut *w)
+}
+
+fn render_file(
+    diag: &Diagnostic,
+    file_id: usize,
+    sources: &SourceMap,
+    w: &mut impl Write,
+) -> std::io::Result<()> {
+    let Some(path) = sources.path(file_id) else {
+        return render_missing_source(diag, file_id, w);
+    };
+
+    writeln!(
+        w,
+        "{}: {}\n --> {}",
+        severity_prefix(diag.severity),
+        diag.error,
+        path.as_path().display()
+    )?;
+    write_notes_and_help(diag, w)
+}
+
+fn render_global(diag: &Diagnostic, w: &mut impl Write) -> std::io::Result<()> {
+    writeln!(w, "{}: {}", severity_prefix(diag.severity), diag.error)?;
+    write_notes_and_help(diag, w)
+}
+
+/// Fallback for diagnostics whose file isn't in the `SourceMap`.
+///
+/// Calling this function *is* the bug signal: if we got here, some pass
+/// constructed a `Span` with a `file_id` that was never registered. The
+/// `debug_assert!` fires in dev/test builds so the source-map bug is
+/// caught early; in release we degrade the diagnostic to message-only
+/// rather than panicking in the error-rendering path.
+fn render_missing_source(diag: &Diagnostic, file_id: usize, w: &mut impl Write) -> io::Result<()> {
+    debug_assert!(
+        false,
+        "diagnostic references unregistered file_id: {file_id}, check span construction"
+    );
+
+    writeln!(w, "{}: {}", severity_prefix(diag.severity), diag.error)?;
+    writeln!(
+        w,
+        " = note: (internal) source for file_id: {file_id} not registered; snippet unavailable"
+    )?;
+
+    write_notes_and_help(diag, w)
+}
+
+fn write_notes_and_help(diag: &Diagnostic, w: &mut impl Write) -> io::Result<()> {
+    for note in &diag.notes {
+        writeln!(w, " = note: {note}")?;
+    }
+
+    if let Some(help) = &diag.help {
+        writeln!(w, " = help: {help}")?;
+    }
+
+    Ok(())
+}
+
+fn kind(sev: Severity) -> ReportKind<'static> {
+    match sev {
+        Severity::Error => ReportKind::Error,
+        Severity::Warning => ReportKind::Warning,
+    }
+}
+
+fn severity_prefix(sev: Severity) -> &'static str {
+    match sev {
+        Severity::Error => "error",
+        Severity::Warning => "warning",
     }
 }
 
@@ -936,8 +1124,8 @@ impl std::error::Error for Error {
 
 impl Error {
     /// Update the error with the affected span.
-    pub fn with_span(self, span: Span) -> RichError {
-        RichError::new(self, span)
+    pub fn with_span(self, span: Span) -> Diagnostic {
+        Diagnostic::new(self, span)
     }
 }
 
@@ -961,9 +1149,9 @@ impl From<simplicity::types::Error> for Error {
 
 #[cfg(test)]
 mod tests {
-    use crate::driver::MAIN_MODULE;
-
     use super::*;
+
+    use crate::driver::MAIN_MODULE;
 
     impl Span {
         pub const fn new_in_default_file(range: Range<usize>) -> Self {
@@ -971,296 +1159,171 @@ mod tests {
         }
     }
 
-    const CONTENT: &str = r#"let a1: List<u32, 5> = None;
-let x: u32 = Left(
-    Right(0)
-);"#;
-    const EMPTY_FILE: &str = "";
-
     #[test]
-    fn display_single_line() {
-        let error = Error::ListBoundPow2 { bound: 5 }
-            .with_span(Span::new_in_default_file(13..19))
-            .with_content(Arc::from(CONTENT));
-        let expected = r#"
-  |
-1 | let a1: List<u32, 5> = None;
-  |              ^^^^^^ Expected a power of two greater than one (2, 4, 8, 16, 32, ...) as list bound, found 5"#;
-        assert_eq!(&expected[1..], &error.to_string());
+    fn has_errors_ignores_warnings() {
+        let mut m = DiagnosticManager::new();
+
+        let warning = Diagnostic::warning(Error::MainNoInputs, Span::DUMMY);
+        m.push(warning);
+        assert!(!m.has_errors());
+
+        let error = Diagnostic::new(Error::MainNoInputs, Span::DUMMY);
+        m.push(error);
+        assert!(m.has_errors());
     }
 
     #[test]
-    fn display_multi_line() {
-        let error = Error::CannotParse {
-            msg: "Expected value of type `u32`, got `Either<Either<_, u32>, _>`".to_string(),
+    fn with_span_attaches_location() {
+        let result: Result<(), Error> = Err(Error::MainRequired);
+        let diag = result.with_span(Span::new(0, 5..10)).unwrap_err();
+        assert!(matches!(diag.location(), Location::Code(s) if s.start == 5 && s.end == 10));
+    }
+}
+
+#[cfg(test)]
+mod render_tests {
+    use super::*;
+
+    use crate::driver::MAIN_MODULE;
+    use crate::resolution::tests::canon;
+    use crate::source::CanonSourceFile;
+    use crate::test_utils::TempWorkspace;
+
+    use std::sync::Arc;
+
+    const CONTENT: &str = "let a1: List<u32, 5> = None;\nlet x: u32 = Left(\n    Right(0)\n);";
+
+    /// A [`DiagnosticManager`] over one real file named `main.simf`.
+    ///
+    /// The file must exist on disk because [`CanonSourceFile`] canonicalizes.
+    /// Rendering never reads it back (the content lives in the [`SourceMap`])
+    /// so the workspace is kept alive only so a failing test can be inspected.
+    struct Fixture {
+        _ws: TempWorkspace,
+        manager: DiagnosticManager,
+        /// Absolute path of `main.simf`, stripped from rendered output.
+        abs_path: String,
+    }
+
+    impl Fixture {
+        fn new(content: &str) -> Self {
+            let ws = TempWorkspace::new("render");
+            let path = canon(&ws.create_file("main.simf", content));
+            let abs_path = path.as_path().display().to_string();
+
+            let sources = SourceMap::with_source(CanonSourceFile::new(path, Arc::from(content)));
+            let mut manager = DiagnosticManager::default();
+            manager.with_sources(sources);
+
+            Self {
+                _ws: ws,
+                manager,
+                abs_path,
+            }
         }
-        .with_span(Span::new_in_default_file(41..CONTENT.len()))
-        .with_content(Arc::from(CONTENT));
-        let expected = r#"
-  |
-2 | let x: u32 = Left(
-3 |     Right(0)
-4 | );
-  | ^^^^^^^^^^^^^^^^^^ Cannot parse: Expected value of type `u32`, got `Either<Either<_, u32>, _>`"#;
-        assert_eq!(&expected[1..], &error.to_string());
-    }
 
-    #[test]
-    fn display_entire_file() {
-        let error = Error::CannotParse {
-            msg: "This span covers the entire file".to_string(),
+        fn push(&mut self, diag: Diagnostic) {
+            self.manager.push(diag);
         }
-        .with_span(Span::from(CONTENT))
-        .with_content(Arc::from(CONTENT));
-        let expected = r#"
-  |
-1 | let a1: List<u32, 5> = None;
-2 | let x: u32 = Left(
-3 |     Right(0)
-4 | );
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Cannot parse: This span covers the entire file"#;
-        assert_eq!(&expected[1..], &error.to_string());
-    }
 
-    #[test]
-    fn display_no_file() {
-        let error = Error::CannotParse {
-            msg: "This error has no file".to_string(),
+        /// Render with color off, the temp-dir path replaced by `main.simf`,
+        /// and trailing whitespace stripped; ariadne pads gutter-only lines.
+        fn render(&self) -> String {
+            self.manager
+                .render_to_string()
+                .replace(&self.abs_path, "main.simf")
+                .lines()
+                .map(str::trim_end)
+                .collect::<Vec<_>>()
+                .join("\n")
         }
-        .with_span(Span::from(EMPTY_FILE));
-        let expected = "Cannot parse: This error has no file";
-        assert_eq!(&expected, &error.to_string());
+    }
 
-        let error = Error::CannotParse {
-            msg: "This error has no file".to_string(),
-        }
-        .with_span(Span::new_in_default_file(5..10));
-        assert_eq!(&expected, &error.to_string());
+    fn expect(actual: &str, expected: &str) {
+        assert_eq!(actual, expected.trim_start_matches('\n').trim_end());
+    }
+
+    fn span(range: std::ops::Range<usize>) -> Span {
+        Span::new(MAIN_MODULE, range)
     }
 
     #[test]
-    fn display_empty_file() {
-        let error = Error::CannotParse {
-            msg: "This error has an empty file".to_string(),
-        }
-        .with_span(Span::from(EMPTY_FILE))
-        .with_content(Arc::from(EMPTY_FILE));
-        let expected = "Cannot parse: This error has an empty file";
-        assert_eq!(&expected, &error.to_string());
-    }
-
-    #[test]
-    fn display_with_utf16_chars() {
-        let file = "/*😀*/ let a: u8 = 65536;";
-        let error = Error::CannotParse {
-            msg: "number too large to fit in target type".to_string(),
-        }
-        .with_span(Span::new_in_default_file(21..26))
-        .with_content(Arc::from(file));
-
-        let expected = r#"
-  |
-1 | /*😀*/ let a: u8 = 65536;
-  |                    ^^^^^ Cannot parse: number too large to fit in target type"#;
-
-        assert_eq!(&expected[1..], &error.to_string());
-    }
-
-    #[test]
-    fn multiline_display_with_utf16_chars() {
-        let file = r#"/*😀 this symbol should not break the rendering*/
-let a: u8 = 65536;
-let x: u32 = Left(
-    Right(0)
-);"#;
-        let error = Error::CannotParse {
-            msg: "This span covers the entire file".to_string(),
-        }
-        .with_span(Span::from(file))
-        .with_content(Arc::from(file));
-
-        let expected = r#"
-  |
-1 | /*😀 this symbol should not break the rendering*/
-2 | let a: u8 = 65536;
-3 | let x: u32 = Left(
-4 |     Right(0)
-5 | );
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Cannot parse: This span covers the entire file"#;
-
-        assert_eq!(&expected[1..], &error.to_string());
-    }
-
-    #[test]
-    fn display_with_unicode_separator() {
-        let file = "let a: u8 = 65536;\u{2028}let b: u8 = 0;";
-        let error = Error::CannotParse {
-            msg: "number too large to fit in target type".to_string(),
-        }
-        .with_span(Span::new_in_default_file(12..17))
-        .with_content(Arc::from(file));
-
-        let expected = r#"
-  |
-1 | let a: u8 = 65536;
-  |             ^^^^^ Cannot parse: number too large to fit in target type"#;
-
-        assert_eq!(&expected[1..], &error.to_string());
-    }
-
-    #[test]
-    fn display_span_as_point() {
-        let file = "fn main()";
-        let error = Error::Grammar {
-            msg: "Error span at (0,0)".to_string(),
-        }
-        .with_span(Span::new_in_default_file(0..0))
-        .with_content(Arc::from(file));
-
-        let expected = r#"
-  |
-1 | fn main()
-  | ^ Grammar error: Error span at (0,0)"#;
-        assert_eq!(&expected[1..], &error.to_string());
-    }
-
-    #[test]
-    fn display_span_as_point_on_trailing_empty_line() {
-        let file = "fn main(){\n    let a:\n";
-        let error = Error::CannotParse {
-            msg: "eof".to_string(),
-        }
-        .with_span(Span::new_in_default_file(file.len()..file.len()))
-        .with_content(Arc::from(file));
-
-        let expected = r#"
-  |
-3 | 
-  | ^ Cannot parse: eof"#;
-
-        assert_eq!(&expected[1..], &error.to_string());
-    }
-
-    #[test]
-    fn display_compiler_version_invalid_syntax() {
-        let file = "simc \"abc\";\nfn main() {}";
-        let error = Error::InvalidSimcVersionSyntax {
-            err: "unexpected character 'a'".to_string(),
-        }
-        .with_span(Span::new_in_default_file(0..11))
-        .with_content(Arc::from(file));
-
-        let expected = r#"
-  |
-1 | simc "abc";
-  | ^^^^^^^^^^^ Invalid version requirement in `simc` directive: unexpected character 'a'"#;
-
-        assert_eq!(&expected[1..], &error.to_string());
-    }
-
-    #[test]
-    fn display_compiler_version_mismatch() {
-        let file = "simc \">= 0.6.0\";\nfn main() {}";
-        let error = Error::SimcVersionMismatch {
-            required: ">= 0.6.0".to_string(),
-            current: "0.5.0".to_string(),
-        }
-        .with_span(Span::new_in_default_file(0..16))
-        .with_content(Arc::from(file));
-
-        let expected = r#"
-  |
-1 | simc ">= 0.6.0";
-  | ^^^^^^^^^^^^^^^^ Incompatible compiler version: file requires `>= 0.6.0`, but the compiler is `0.5.0`. Update the compiler or the `simc` directive."#;
-
-        assert_eq!(&expected[1..], &error.to_string());
-    }
-
-    #[test]
-    fn display_malformed_directive() {
-        let file = "simc \"1.0\"\nfn main() {}";
-        let error = Error::MalformedSimcDirective
-            .with_span(Span::new_in_default_file(0..10))
-            .with_content(Arc::from(file));
-
-        let expected = r#"
-  |
-1 | simc "1.0"
-  | ^^^^^^^^^^ Malformed compiler version directive: expected `simc "<version>";`"#;
-
-        assert_eq!(&expected[1..], &error.to_string());
-    }
-
-    #[test]
-    fn display_reserved_simc_keyword() {
-        let file = "fn main() {}\nsimc \"1.0\";";
-        let error = Error::ReservedSimcKeyword
-            .with_span(Span::new_in_default_file(13..17))
-            .with_content(Arc::from(file));
-
-        let expected = r#"
-  |
-2 | simc "1.0";
-  | ^^^^ `simc` is reserved for the compiler version directive, which must be the first item in the file and may appear at most once"#;
-
-        assert_eq!(&expected[1..], &error.to_string());
-    }
-
-    // --- Tests with filename ---
-    #[test]
-    fn display_single_line_with_file() {
-        let source = SourceFile::new(std::path::Path::new("src/main.simf"), Arc::from(CONTENT));
-        let error = Error::ListBoundPow2 { bound: 5 }
-            .with_span(Span::new_in_default_file(13..19))
-            .with_source(source);
-
-        let expected = r#"
- --> src/main.simf:1:14
-  |
-1 | let a1: List<u32, 5> = None;
-  |              ^^^^^^ Expected a power of two greater than one (2, 4, 8, 16, 32, ...) as list bound, found 5"#;
-        assert_eq!(&expected[1..], &error.to_string());
-    }
-
-    #[test]
-    fn display_multi_line_with_file() {
-        let source = SourceFile::new(std::path::Path::new("lib/parser.simf"), Arc::from(CONTENT));
-        let error = Error::CannotParse {
-            msg: "Expected value of type `u32`, got `Either<Either<_, u32>, _>`".to_string(),
-        }
-        .with_span(Span::new_in_default_file(41..CONTENT.len()))
-        .with_source(source);
-
-        let expected = r#"
- --> lib/parser.simf:2:13
-  |
-2 | let x: u32 = Left(
-3 |     Right(0)
-4 | );
-  | ^^^^^^^^^^^^^^^^^^ Cannot parse: Expected value of type `u32`, got `Either<Either<_, u32>, _>`"#;
-        assert_eq!(&expected[1..], &error.to_string());
-    }
-
-    #[test]
-    fn display_entire_file_with_file() {
-        let source = SourceFile::new(
-            std::path::Path::new("tests/integration.simf"),
-            Arc::from(CONTENT),
+    fn golden_full_diagnostic() {
+        let mut fixture = Fixture::new(CONTENT);
+        fixture.push(
+            Diagnostic::new(Error::ListBoundPow2 { bound: 5 }, span(13..19))
+                .with_secondary(span(0..2), "declared here")
+                .with_note("first note")
+                .with_note("second note")
+                .with_help("use 4 or 8"),
         );
-        let error = Error::CannotParse {
-            msg: "This span covers the entire file".to_string(),
-        }
-        .with_span(Span::from(CONTENT))
-        .with_source(source);
 
-        let expected = r#"
- --> tests/integration.simf:1:1
-  |
-1 | let a1: List<u32, 5> = None;
-2 | let x: u32 = Left(
-3 |     Right(0)
-4 | );
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Cannot parse: This span covers the entire file"#;
-        assert_eq!(&expected[1..], &error.to_string());
+        expect(
+            &fixture.render(),
+            r#"
+Error: Expected a power of two greater than one (2, 4, 8, 16, 32, ...) as list bound, found 5
+   ,-[main.simf:1:14]
+   |
+ 1 | let a1: List<u32, 5> = None;
+   | ^|           ^^^^^^
+   |  `------------------- declared here
+   |
+   | Help: use 4 or 8
+   |
+   | Note 1: first note
+   |
+   | Note 2: second note
+---'"#,
+        );
+    }
+
+    #[test]
+    fn caret_lands_on_byte_offset_after_emoji() {
+        // Pins the `IndexType::Byte` decision. Under `IndexType::Char`, ariadne
+        // reads our byte offset as a char offset and underlines the wrong text.
+        let mut fixture = Fixture::new("/*😀*/ let a: u8 = 65536;");
+        fixture.push(Diagnostic::new(
+            Error::CannotParse {
+                msg: "too large".into(),
+            },
+            span(21..26),
+        ));
+
+        expect(
+            &fixture.render(),
+            r#"
+Error: Cannot parse: too large
+   ,-[main.simf:1:19]
+   |
+ 1 | /*😀*/ let a: u8 = 65536;
+---'"#,
+        );
+    }
+
+    #[test]
+    fn secondary_label_message_is_forwarded() {
+        let mut fixture = Fixture::new(CONTENT);
+
+        fixture.push(
+            Diagnostic::new(Error::ListBoundPow2 { bound: 5 }, span(13..19))
+                .with_secondary(span(0..2), "declared here"),
+        );
+
+        assert!(fixture.render().contains("declared here"));
+    }
+
+    #[test]
+    fn warning_severity_reaches_report_kind() {
+        let mut fixture = Fixture::new(CONTENT);
+        fixture.push(Diagnostic::warning(Error::MainNoInputs, span(0..3)));
+        let out = fixture.render();
+
+        assert!(out.contains("Warning"), "{out}");
+        assert!(!out.contains("Error"), "{out}");
+    }
+
+    #[test]
+    fn empty_manager_renders_nothing() {
+        assert_eq!(Fixture::new(CONTENT).render(), "");
     }
 }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -4,7 +4,7 @@ use chumsky::prelude::{any, choice, end, just, recursive, skip_then_retry_until}
 use chumsky::{error::Rich, extra, span::SimpleSpan, text, IterParser, Parser};
 
 use crate::driver::CRATE_STR;
-use crate::error::{Error, RichError, Span};
+use crate::error::{Diagnostic, Error, Span};
 use crate::str::{Binary, Decimal, Hexadecimal};
 use crate::version::SIMC_STR;
 
@@ -273,30 +273,14 @@ pub fn lex(
     file_id: usize,
     input: &str,
     start: usize,
-) -> (Option<Tokens<'_>>, Vec<crate::error::RichError>) {
+) -> (Option<Tokens<'_>>, Vec<crate::error::Diagnostic>) {
     let (tokens, lex_errors) = lexer().parse(&input[start..]).into_output_errors();
-    let shift = |span: SimpleSpan| Span::new(file_id, span.start + start..span.end + start);
+    let shift = |span| Span::from_chumsky(file_id, span, start);
 
-    // The reserved-keyword errors come first: a stray directive also produces
-    // follow-up errors for its `"<range>";` remnant, and the sentinel is their cause.
-    let mut errors: Vec<RichError> = Vec::new();
-    let tokens = tokens.map(|vec| {
-        vec.into_iter()
-            .filter_map(|(tok, span)| match tok {
-                Token::Comment | Token::BlockComment => None,
-                // The reserved keyword is a sentinel: the prescan consumed the one
-                // legitimate directive before lexing, so any occurrence is misplaced.
-                Token::Simc => {
-                    errors.push(RichError::new(Error::ReservedSimcKeyword, shift(span)));
-                    None
-                }
-                tok => Some((tok, shift(span))),
-            })
-            .collect()
-    });
+    let mut diagnostics: Vec<Diagnostic> = Vec::new();
 
-    errors.extend(lex_errors.into_iter().map(|err| {
-        RichError::new(
+    diagnostics.extend(lex_errors.into_iter().map(|err| {
+        Diagnostic::new(
             Error::CannotParse {
                 msg: err.reason().to_string(),
             },
@@ -304,7 +288,20 @@ pub fn lex(
         )
     }));
 
-    (tokens, errors)
+    let tokens = tokens.map(|vec| {
+        vec.into_iter()
+            .filter_map(|(tok, span)| match tok {
+                Token::Comment | Token::BlockComment => None,
+                Token::Simc => {
+                    diagnostics.push(Diagnostic::new(Error::ReservedSimcKeyword, shift(span)));
+                    None
+                }
+                tok => Some((tok, shift(span))),
+            })
+            .collect()
+    });
+
+    (tokens, diagnostics)
 }
 
 /// A list of all reserved keywords.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,11 +41,10 @@ pub use simplicity::elements;
 
 use crate::debug::DebugSymbols;
 use crate::driver::{DependencyGraph, SourceMap, MAIN_MODULE};
-use crate::error::{ErrorCollector, WithContent, WithSource as _};
+use crate::error::DiagnosticManager;
 use crate::parse::ParseFromStrWithErrors;
 use crate::resolution::DependencyMap;
 use crate::source::CanonSourceFile;
-use crate::source::SourceFile;
 pub use crate::types::ResolvedType;
 pub use crate::unstable::{UnstableFeature, UnstableFeatures};
 pub use crate::value::Value;
@@ -59,7 +58,7 @@ pub struct TemplateProgram {
     simfony: ast::Program,
     file: Arc<str>,
     jet_hinter: Box<dyn ast::JetHinter>,
-    source_map: SourceMap,
+    diagnostics: DiagnosticManager,
     resolved_program: parse::Program,
 }
 
@@ -74,15 +73,15 @@ impl TemplateProgram {
         source: CanonSourceFile,
         dependency_map: &DependencyMap,
         unstable_features: &UnstableFeatures,
-    ) -> Result<String, ErrorCollector> {
-        let mut error_handler = ErrorCollector::new();
-        let Some((resolved_program, _)) = Self::dependency_helper(
+    ) -> Result<String, DiagnosticManager> {
+        let (program, diagnostics) = DependencyGraph::build_program(
             source,
-            dependency_map,
+            Arc::from(dependency_map.clone()),
             unstable_features,
-            &mut error_handler,
-        ) else {
-            return Err(error_handler);
+        );
+
+        let Some(resolved_program) = program else {
+            return Err(diagnostics);
         };
 
         Ok(resolved_program.to_string())
@@ -98,35 +97,31 @@ impl TemplateProgram {
         dependency_map: &DependencyMap,
         unstable_features: &UnstableFeatures,
         jet_hinter: Box<dyn ast::JetHinter>,
-    ) -> Result<Self, ErrorCollector> {
-        let mut error_handler = ErrorCollector::new();
+    ) -> Result<Self, DiagnosticManager> {
+        let file = source.content();
+        let (program, mut diagnostics) = DependencyGraph::build_program(
+            source,
+            Arc::from(dependency_map.clone()),
+            unstable_features,
+        );
 
-        let build_program = || -> Result<Self, ()> {
-            let Some((resolved_program, source_map)) = Self::dependency_helper(
-                source.clone(),
-                dependency_map,
-                unstable_features,
-                &mut error_handler,
-            ) else {
-                return Err(());
-            };
-
-            let ast_program = ast::Program::analyze(&resolved_program, jet_hinter.clone_box())
-                .with_source(source.clone())
-                .map_err(|e| error_handler.push(e))?;
-
-            Ok(Self {
-                simfony: ast_program,
-                file: source.content(),
-                jet_hinter,
-                source_map,
-                resolved_program,
-            })
+        let Some(resolved_program) = program else {
+            return Err(diagnostics);
         };
 
-        match build_program() {
-            Ok(instance) => Ok(instance),
-            Err(()) => Err(error_handler),
+        // TODO: Add multierror to analyze
+        match ast::Program::analyze(&resolved_program, jet_hinter.clone_box()) {
+            Ok(simfony) => Ok(Self {
+                simfony,
+                file,
+                jet_hinter,
+                diagnostics,
+                resolved_program,
+            }),
+            Err(e) => {
+                diagnostics.push(e);
+                Err(diagnostics)
+            }
         }
     }
 
@@ -138,7 +133,7 @@ impl TemplateProgram {
     pub fn new<Str: Into<Arc<str>>>(
         s: Str,
         jet_hinter: Box<dyn ast::JetHinter>,
-    ) -> Result<Self, ErrorCollector> {
+    ) -> Result<Self, DiagnosticManager> {
         Self::new_with_unstable(s, &UnstableFeatures::none(), jet_hinter)
     }
 
@@ -148,62 +143,32 @@ impl TemplateProgram {
         s: Str,
         unstable_features: &UnstableFeatures,
         jet_hinter: Box<dyn ast::JetHinter>,
-    ) -> Result<Self, ErrorCollector> {
+    ) -> Result<Self, DiagnosticManager> {
+        let mut diagnostics = DiagnosticManager::default();
         let file = s.into();
-        let source = SourceFile::anonymous(file.clone());
-        let mut error_handler = ErrorCollector::new();
 
-        let parsed_program = parse::Program::parse_from_str_with_errors(
+        let Some(resolved_program) = parse::Program::parse_from_str_with_errors(
             MAIN_MODULE,
-            source,
+            &file,
             unstable_features,
-            &mut error_handler,
-        );
+            &mut diagnostics,
+        ) else {
+            return Err(diagnostics);
+        };
 
-        if let Some(program) = parsed_program {
-            let Ok(ast_program) = ast::Program::analyze(&program, jet_hinter.clone_box())
-                .with_content(Arc::clone(&file))
-                .map_err(|e| error_handler.push(e))
-            else {
-                Err(error_handler)?
-            };
-
-            Ok(Self {
-                simfony: ast_program,
+        match ast::Program::analyze(&resolved_program, jet_hinter.clone_box()) {
+            Ok(simfony) => Ok(Self {
+                simfony,
                 file,
                 jet_hinter,
-                source_map: SourceMap::default(),
-                resolved_program: program,
-            })
-        } else {
-            Err(error_handler)?
+                diagnostics,
+                resolved_program,
+            }),
+            Err(e) => {
+                diagnostics.push(e);
+                Err(diagnostics)
+            }
         }
-    }
-
-    fn dependency_helper(
-        source: CanonSourceFile,
-        dependency_map: &DependencyMap,
-        unstable_features: &UnstableFeatures,
-        handler: &mut ErrorCollector,
-    ) -> Option<(parse::Program, SourceMap)> {
-        let program = parse::Program::parse_from_str_with_errors(
-            MAIN_MODULE,
-            source.clone(),
-            unstable_features,
-            handler,
-        )?;
-
-        let graph = DependencyGraph::new(
-            source,
-            Arc::from(dependency_map.clone()),
-            &program,
-            handler,
-            unstable_features,
-        )?;
-
-        let program = graph.linearize_and_build(handler);
-
-        program.map(|opt| (opt, graph.source_map().clone()))
     }
 
     /// Access the parameters of the program.
@@ -239,14 +204,11 @@ impl TemplateProgram {
             .is_consistent(self.simfony.parameters())
             .map_err(|error| error.to_string())?;
 
-        let commit = self
-            .simfony
-            .compile(
-                arguments,
-                include_debug_symbols,
-                self.jet_hinter.clone_box(),
-            )
-            .with_content(Arc::clone(&self.file))?;
+        let commit = self.simfony.compile(
+            arguments,
+            include_debug_symbols,
+            self.jet_hinter.clone_box(),
+        )?;
 
         Ok(CompiledProgram {
             debug_symbols: self.simfony.debug_symbols(self.file.as_ref()),
@@ -263,8 +225,12 @@ impl TemplateProgram {
         })
     }
 
-    pub fn source_map(&self) -> &SourceMap {
-        &self.source_map
+    pub fn source_map(&self) -> Option<&SourceMap> {
+        self.diagnostics.sources()
+    }
+
+    pub fn diagnostics(&self) -> &DiagnosticManager {
+        &self.diagnostics
     }
 
     pub fn resolved_program(&self) -> &parse::Program {
@@ -302,7 +268,7 @@ impl CompiledProgram {
             unstable_features,
             jet_hinter.clone_box(),
         )
-        .map_err(|e| e.to_string())
+        .map_err(|diagnostics| diagnostics.render_to_string())
         .and_then(|template| template.instantiate(arguments, include_debug_symbols))
     }
 
@@ -337,7 +303,7 @@ impl CompiledProgram {
         jet_hinter: Box<dyn ast::JetHinter>,
     ) -> Result<Self, String> {
         TemplateProgram::new_with_unstable(s, unstable_features, jet_hinter.clone_box())
-            .map_err(|e| e.to_string())
+            .map_err(|error| error.to_string())
             .and_then(|template| template.instantiate(arguments, include_debug_symbols))
     }
 
@@ -589,20 +555,20 @@ pub(crate) mod tests {
 
         match TemplateProgram::flatten(source, dependency_map, &UnstableFeatures::all()) {
             Ok(single_file) => single_file,
-            Err(error) => panic!("{error}"),
+            Err(error) => panic!("{}", &error),
         }
     }
 
     pub(crate) fn format_program_file(prog_path: &Path) -> String {
         let file = Arc::<str>::from(std::fs::read_to_string(prog_path).unwrap());
-        let source = SourceFile::anonymous(file.clone());
 
-        let mut error_handler = ErrorCollector::new();
+        let mut diagnostics = DiagnosticManager::new();
+
         let parse_program = parse::Program::parse_from_str_with_errors(
             MAIN_MODULE,
-            source,
+            &file,
             &UnstableFeatures::all(),
-            &mut error_handler,
+            &mut diagnostics,
         )
         .unwrap();
         parse_program.to_string()
@@ -665,7 +631,7 @@ pub(crate) mod tests {
                 Box::new(ElementsJetHinter::new()),
             ) {
                 Ok(x) => x,
-                Err(error) => panic!("{error}"),
+                Err(error) => panic!("{}", &error),
             };
 
             Self {
@@ -690,7 +656,7 @@ pub(crate) mod tests {
                 Box::new(ElementsJetHinter::new()),
             ) {
                 Ok(x) => x,
-                Err(error) => panic!("{error}"),
+                Err(error) => panic!("{}", &error),
             };
             Self {
                 program,
@@ -1633,7 +1599,8 @@ mod error_tests {
 
         assert!(
             err.to_string().contains(&dependency_source),
-            "expected diagnostic to point at dependency source {dependency_source}, got:\n{err}"
+            "expected diagnostic to point at dependency source {dependency_source}, got:\n{}",
+            err
         );
     }
 
@@ -1683,7 +1650,8 @@ mod error_tests {
 
         assert!(
             err.to_string().contains("missing.simf"),
-            "diagnostic should mention the missing module path, got:\n{err}"
+            "diagnostic should mention the missing module path, got:\n{}",
+            err
         );
     }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -18,13 +18,12 @@ use either::Either;
 use miniscript::iter::{Tree, TreeLike};
 
 use crate::driver::{CRATE_STR, MAIN_MODULE};
-use crate::error::ErrorCollector;
-use crate::error::{Error, RichError, Span};
+use crate::error::DiagnosticManager;
+use crate::error::{Diagnostic, Error, Span};
 use crate::impl_eq_hash;
 use crate::lexer::Token;
 use crate::num::NonZeroPow2Usize;
 use crate::pattern::Pattern;
-use crate::source::SourceFile;
 use crate::str::{
     AliasName, Binary, Decimal, FunctionName, Hexadecimal, Identifier, JetName, ModuleName,
     SymbolName, WitnessName,
@@ -162,8 +161,8 @@ impl UseDecl {
     ///
     /// # Errors
     ///
-    /// Returns a `RichError` if the use declaration path is completely empty.
-    pub fn drp_name(&self) -> Result<&str, RichError> {
+    /// Returns a `Diagnostic` if the use declaration path is completely empty.
+    pub fn drp_name(&self) -> Result<&str, Diagnostic> {
         let parts: Vec<&str> = self.path().iter().map(|iden| iden.as_inner()).collect();
         parts.first().copied().ok_or_else(|| {
             Error::CannotParse {
@@ -1177,20 +1176,20 @@ impl_parse_wrapped_string!(ModuleName, "module name");
 /// Copy of [`FromStr`] that internally uses the `chumsky` parser.
 pub trait ParseFromStr: Sized {
     /// Parse a value from the string `s`.
-    fn parse_from_str(s: &str) -> Result<Self, RichError>;
+    fn parse_from_str(s: &str) -> Result<Self, Diagnostic>;
 }
 
 /// Trait for parsing with collection of errors.
 pub trait ParseFromStrWithErrors: Sized {
-    /// Parse a value from the string `s` with Errors.
+    /// Parse a value from the string `content` with Errors.
     ///
     /// Feature-gated syntax in the parsed AST is checked against
-    /// `unstable_features`; uses of disabled features are pushed to `handler`.
+    /// `unstable_features`; uses of disabled features are pushed to `diagnostics`.
     fn parse_from_str_with_errors(
         file_id: usize,
-        source: impl Into<SourceFile>,
+        content: &str,
         unstable_features: &UnstableFeatures,
-        handler: &mut ErrorCollector,
+        diagnostics: &mut DiagnosticManager,
     ) -> Option<Self>;
 }
 
@@ -1203,11 +1202,11 @@ pub trait ChumskyParse: Sized {
         I: ValueInput<'tokens, Token = Token<'src>, Span = Span>;
 }
 
-type ParseError<'src> = extra::Err<RichError>;
+type ParseError<'src> = extra::Err<Diagnostic>;
 
 /// This implementation only returns first encountered error.
 impl<A: ChumskyParse + std::fmt::Debug> ParseFromStr for A {
-    fn parse_from_str(s: &str) -> Result<Self, RichError> {
+    fn parse_from_str(s: &str) -> Result<Self, Diagnostic> {
         let (tokens, mut lex_errs) = crate::lexer::lex(MAIN_MODULE, s, 0);
 
         // The `simc` directive is source-file syntax, so fragments have no prescan
@@ -1215,15 +1214,17 @@ impl<A: ChumskyParse + std::fmt::Debug> ParseFromStr for A {
         // lex either, so the first reserved-keyword error is reported alone.
         if let Some(err) = lex_errs
             .iter()
-            .find(|e| matches!(e.error(), Error::ReservedSimcKeyword))
+            .find(|diag| matches!(diag.error(), Error::ReservedSimcKeyword))
         {
             return Err(err.clone());
         }
 
         let Some(tokens) = tokens else {
-            return Err(lex_errs.pop().unwrap_or(RichError::parsing_error(
-                "Empty token stream without an error.",
-            )));
+            return Err(lex_errs
+                .pop()
+                .unwrap_or(Diagnostic::global(Error::CannotParse {
+                    msg: "Empty token stream without an error".to_string(),
+                })));
         };
 
         let (ast, parse_errs) = A::parser()
@@ -1236,7 +1237,9 @@ impl<A: ChumskyParse + std::fmt::Debug> ParseFromStr for A {
             .into_output_errors();
 
         if parse_errs.is_empty() {
-            Ok(ast.ok_or(RichError::parsing_error("Empty AST without an error."))?)
+            Ok(ast.ok_or(Diagnostic::global(Error::CannotParse {
+                msg: "Empty AST without an error.".to_string(),
+            }))?)
         } else {
             let err = parse_errs.first().unwrap().clone();
             Err(err)
@@ -1249,26 +1252,25 @@ impl<A: ChumskyParse + crate::unstable::RequireFeature + std::fmt::Debug> ParseF
 {
     fn parse_from_str_with_errors(
         file_id: usize,
-        source: impl Into<SourceFile>,
+        content: &str,
         unstable_features: &UnstableFeatures,
-        handler: &mut ErrorCollector,
+        diagnostics: &mut DiagnosticManager,
     ) -> Option<Self> {
-        let source: SourceFile = source.into();
-        let content = source.content();
+        let before = diagnostics.error_count();
 
         // Handle the `simc` directive before lexing: an incompatible or malformed
         // directive is reported as the only diagnostic (the rest is noise), and
         // lexing starts right after a valid one, so the lexer and grammar never
         // see it.
-        let start = match SimcDirective::prescan(&content, file_id) {
+        let start = match SimcDirective::prescan(content, file_id) {
             Ok(start) => start,
             Err((err, span)) => {
-                handler.push(RichError::new(err, span).with_source(source));
+                diagnostics.push(Diagnostic::new(err, span));
                 return None;
             }
         };
 
-        let (tokens, mut lex_errs) = crate::lexer::lex(file_id, &content, start);
+        let (tokens, mut lex_errs) = crate::lexer::lex(file_id, content, start);
         // A stray `simc` makes every other diagnostic noise — its `"<range>";` remnant
         // does not lex — so the reserved-keyword errors are reported alone.
         if lex_errs
@@ -1276,11 +1278,11 @@ impl<A: ChumskyParse + crate::unstable::RequireFeature + std::fmt::Debug> ParseF
             .any(|e| matches!(e.error(), Error::ReservedSimcKeyword))
         {
             lex_errs.retain(|e| matches!(e.error(), Error::ReservedSimcKeyword));
-            handler.extend(source, lex_errs);
+            diagnostics.extend(lex_errs);
             return None;
         }
         let lex_ok = lex_errs.is_empty();
-        handler.extend(source.clone(), lex_errs);
+        diagnostics.extend(lex_errs);
         let tokens = tokens?;
 
         let eoi = Span::eof(file_id, content.len());
@@ -1288,15 +1290,15 @@ impl<A: ChumskyParse + crate::unstable::RequireFeature + std::fmt::Debug> ParseF
             .parse(tokens.as_slice().map(eoi, |(t, s)| (t, s)))
             .into_output_errors();
         let parse_ok = parse_errs.is_empty();
-        handler.extend(source.clone(), parse_errs);
+        diagnostics.extend(parse_errs);
 
         if let (Some(ast), true) = (&ast, lex_ok && parse_ok) {
-            unstable_features.check_program(ast, &source, handler);
+            unstable_features.check_program(ast, diagnostics);
         }
 
         // TODO: We should return parsed result if we found errors, but because analyzing in `ast` module
         // is not handling poisoned tree right now, we don't return parsed result
-        if handler.has_errors() {
+        if diagnostics.error_count() > before {
             None
         } else {
             ast
@@ -2697,42 +2699,45 @@ mod test {
     #[test]
     fn test_double_colon() {
         let input = "fn main() { let ab: u8 = <(u4, u4)> : :into((0b1011, 0b1101)); }";
-        let source = SourceFile::anonymous(Arc::from(input));
-        let mut error_handler = ErrorCollector::new();
+        let mut diagnostics = DiagnosticManager::new();
+
         let parsed_program = Program::parse_from_str_with_errors(
             MAIN_MODULE,
-            source,
+            input,
             &UnstableFeatures::all(),
-            &mut error_handler,
+            &mut diagnostics,
         );
 
         assert!(parsed_program.is_none());
-        assert!(ErrorCollector::to_string(&error_handler).contains("Expected '::', found ':'"));
+        assert!(diagnostics.to_string().contains("Expected '::', found ':'"));
     }
 
     #[test]
     fn test_double_double_colon() {
         let input = "fn main() { let pk: Pubkey = witnes::::PK; }";
-        let source = SourceFile::anonymous(Arc::from(input));
-        let mut error_handler = ErrorCollector::new();
+        let mut diagnostics = DiagnosticManager::new();
+
         let parsed_program = Program::parse_from_str_with_errors(
             MAIN_MODULE,
-            source,
+            input,
             &UnstableFeatures::all(),
-            &mut error_handler,
+            &mut diagnostics,
         );
 
         assert!(parsed_program.is_none());
-        assert!(ErrorCollector::to_string(&error_handler).contains("Expected ';', found '::'"));
+        assert!(&diagnostics.to_string().contains("Expected ';', found '::'"));
     }
 
     /// Parse `input` and return whether it was rejected and the collected error text.
     fn parse_with(input: &str, features: &UnstableFeatures) -> (bool, String) {
-        let source = SourceFile::anonymous(Arc::from(input));
-        let mut handler = ErrorCollector::new();
+        let mut diagnostics = DiagnosticManager::new();
         let program =
-            Program::parse_from_str_with_errors(MAIN_MODULE, source, features, &mut handler);
-        (program.is_none(), ErrorCollector::to_string(&handler))
+            Program::parse_from_str_with_errors(MAIN_MODULE, input, features, &mut diagnostics);
+
+        let rejected = program.is_none();
+        let text = diagnostics.to_string();
+
+        (rejected, text)
     }
 
     #[test]

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::driver::CRATE_STR;
-use crate::error::{Error, RichError, WithSpan as _};
+use crate::error::{Diagnostic, Error, WithSpan as _};
 use crate::parse::UseDecl;
 use crate::source::CanonPath;
 use crate::str::Identifier;
@@ -255,7 +255,7 @@ impl DependencyMap {
         &self,
         current_file: &CanonPath,
         use_decl: &UseDecl,
-    ) -> Result<CanonPath, RichError> {
+    ) -> Result<CanonPath, Diagnostic> {
         Ok(self.resolve_path_internal(current_file, use_decl)?.path)
     }
 
@@ -263,7 +263,7 @@ impl DependencyMap {
         &self,
         current_file: &CanonPath,
         use_decl: &UseDecl,
-    ) -> Result<ResolvedUse, RichError> {
+    ) -> Result<ResolvedUse, Diagnostic> {
         let drp_name = use_decl.drp_name()?;
         let span = *use_decl.span();
 
@@ -277,7 +277,7 @@ impl DependencyMap {
             .iter()
             .find(|r| current_file.starts_with(&r.context_prefix) && r.drp_name == drp_name)
             .ok_or_else(|| {
-                RichError::new(
+                Diagnostic::new(
                     Error::UnknownLibrary {
                         name: drp_name.to_string(),
                     },
@@ -292,13 +292,13 @@ impl DependencyMap {
         remapping: &Remapping,
         current_file: &CanonPath,
         use_decl: &UseDecl,
-    ) -> Result<ResolvedUse, RichError> {
+    ) -> Result<ResolvedUse, Diagnostic> {
         let drp_name = use_decl.drp_name()?;
         let parts_without_drp_name = &use_decl.path()[1..];
 
         let resolved = Self::build_and_verify_path(&remapping.target, parts_without_drp_name)
             .map_err(|failed_path| {
-                RichError::new(
+                Diagnostic::new(
                     Error::ExternalFileNotFound {
                         lib: drp_name.to_string(),
                         filename: failed_path,
@@ -319,13 +319,13 @@ impl DependencyMap {
         &self,
         current_file: &CanonPath,
         use_decl: &UseDecl,
-    ) -> Result<ResolvedUse, RichError> {
+    ) -> Result<ResolvedUse, Diagnostic> {
         let root = self
             .get_package_root(current_file)
             .ok_or_else(|| Error::Internal {
                 msg: "The 'crate' root path was not configured by the compiler.".to_string(),
             })
-            .map_err(|e| RichError::new(e, *use_decl.span()))?;
+            .map_err(|e| Diagnostic::new(e, *use_decl.span()))?;
 
         let parts_without_drp_name = &use_decl.path()[1..];
         let failed_path = match Self::build_and_verify_path(root, parts_without_drp_name) {
@@ -342,7 +342,7 @@ impl DependencyMap {
             });
         }
 
-        Err(RichError::new(
+        Err(Diagnostic::new(
             Error::FileNotFound {
                 filename: failed_path,
             },
@@ -356,7 +356,7 @@ impl DependencyMap {
         current_file: &CanonPath,
         resolved: &CanonPath,
         use_decl_span: &crate::error::Span,
-    ) -> Result<(), RichError> {
+    ) -> Result<(), Diagnostic> {
         if let (Some(curr), Some(res)) = (
             self.get_package_root(current_file),
             self.get_package_root(resolved),
@@ -377,7 +377,7 @@ impl DependencyMap {
     /// # Errors
     ///
     /// Returns the failed candidate path as a raw `PathBuf`, without any additional context.
-    /// The caller is responsible for enriching this into a [`RichError`] with the appropriate
+    /// The caller is responsible for wrapping this into a [`Diagnostic`] with the appropriate
     /// span, library name, and any other diagnostic information.
     fn build_and_verify_path(
         base_target: &CanonPath,

--- a/src/source.rs
+++ b/src/source.rs
@@ -106,7 +106,7 @@ impl CanonPath {
     ///
     /// Returns a `String` containing the OS error if the path does not exist or
     /// cannot be accessed. The caller is expected to map this into a more specific
-    /// compiler diagnostic (e.g., `RichError`).
+    /// compiler diagnostic.
     pub fn canonicalize(path: &Path) -> Result<Self, String> {
         // We use `map_err` here to intercept the generic OS error and enrich
         // it with the specific path that failed

--- a/src/unstable.rs
+++ b/src/unstable.rs
@@ -2,8 +2,7 @@ use std::fmt;
 use std::fmt::Write;
 use std::str::FromStr;
 
-use crate::error::{Error, ErrorCollector, RichError, Span};
-use crate::source::SourceFile;
+use crate::error::{Diagnostic, DiagnosticManager, Error, Span};
 
 #[allow(rustdoc::private_intra_doc_links)]
 /// The set of unstable compiler features, enabled per-feature with
@@ -112,13 +111,12 @@ impl UnstableFeatures {
         self.enabled_features.contains(&feature) // linear scan; n is always tiny
     }
 
-    /// Walk a program and push one [`RichError`] per use of a feature
+    /// Walk a program and push one [`Diagnostic`] per use of a feature
     /// that this set does not enable.
     pub(crate) fn check_program(
         &self,
         program: &impl RequireFeature,
-        source: &SourceFile,
-        handler: &mut ErrorCollector,
+        diagnostics: &mut DiagnosticManager,
     ) {
         let mut uses = Vec::new();
         program.feature_requirements(&mut uses);
@@ -126,8 +124,8 @@ impl UnstableFeatures {
             if self.is_enabled(feature) {
                 continue;
             }
-            let error = Error::UnstableFeature { feature };
-            handler.push(RichError::new(error, span).with_source(source.clone()));
+
+            diagnostics.push(Diagnostic::new(Error::UnstableFeature { feature }, span));
         }
     }
 }
@@ -331,9 +329,6 @@ pub(crate) use impl_require_feature;
 mod tests {
     use super::*;
     use std::collections::HashSet;
-    use std::sync::Arc;
-
-    use crate::source::SourceFile;
 
     // Just dev sanity check
     #[test]
@@ -377,11 +372,10 @@ mod tests {
             return;
         };
 
-        let mut handler = ErrorCollector::new();
-        let source = SourceFile::anonymous(Arc::from("x"));
-        UnstableFeatures::none().check_program(&Requires(feature), &source, &mut handler);
+        let mut diagnostics = DiagnosticManager::new();
+        UnstableFeatures::none().check_program(&Requires(feature), &mut diagnostics);
 
-        let error = handler.to_string();
+        let error = diagnostics.to_string();
         assert!(
             error.contains(&feature.to_string()),
             "error should name the feature `{feature}`: {error}"
@@ -396,14 +390,13 @@ mod tests {
             return;
         };
 
-        let mut handler = ErrorCollector::new();
-        let source = SourceFile::anonymous(Arc::from("x"));
-        UnstableFeatures::new([feature]).check_program(&Requires(feature), &source, &mut handler);
+        let mut diagnostics = DiagnosticManager::new();
+        UnstableFeatures::new([feature]).check_program(&Requires(feature), &mut diagnostics);
 
         assert!(
-            !handler.has_errors(),
+            !diagnostics.has_errors(),
             "enabling `{feature}` should accept a node that requires it: {}",
-            handler
+            diagnostics
         );
     }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -8,7 +8,7 @@ use simplicity::types::Final as SimType;
 use simplicity::{BitCollector, Value as SimValue, ValueRef};
 
 use crate::array::{BTreeSlice, Combiner, Partition, Unfolder};
-use crate::error::{Error, RichError, WithSpan};
+use crate::error::{Diagnostic, Error, WithSpan};
 use crate::num::{NonZeroPow2Usize, Pow2Usize, U256};
 use crate::parse::ParseFromStr;
 use crate::str::{Binary, Decimal, Hexadecimal};
@@ -786,7 +786,7 @@ impl Value {
     }
 
     /// Parse a value of the given type from a string.
-    pub fn parse_from_str(s: &str, ty: &ResolvedType) -> Result<Self, RichError> {
+    pub fn parse_from_str(s: &str, ty: &ResolvedType) -> Result<Self, Diagnostic> {
         let parse_expr = parse::Expression::parse_from_str(s)?;
         let ast_expr = ast::Expression::analyze_const(&parse_expr, ty)?;
         Self::from_const_expr(&ast_expr)

--- a/src/witness.rs
+++ b/src/witness.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::fmt;
 use std::sync::Arc;
 
-use crate::error::{Error, RichError, WithContent, WithSpan};
+use crate::error::{Diagnostic, Error, WithSpan};
 use crate::parse::ParseFromStr;
 use crate::str::WitnessName;
 use crate::types::{AliasedType, ResolvedType};
@@ -131,13 +131,12 @@ impl WitnessValues {
 }
 
 impl ParseFromStr for ResolvedType {
-    fn parse_from_str(s: &str) -> Result<Self, RichError> {
+    fn parse_from_str(s: &str) -> Result<Self, Diagnostic> {
         let aliased = AliasedType::parse_from_str(s)?;
         aliased
             .resolve_builtin()
             .map_err(|name| Error::UndefinedAlias { name })
             .with_span(s)
-            .with_content(s)
     }
 }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -285,3 +285,38 @@ fn cli_dependency_version_mismatch_rejected() {
         "expected an incompatible-version error pointing at the dependency, got:\n{stderr}"
     );
 }
+
+#[test]
+fn cli_diagnostics_respect_no_color_env() {
+    const ESC: u8 = 0x1b;
+
+    let file = Path::new(env!("CARGO_TARGET_TMPDIR")).join("no_color.simf");
+    std::fs::write(&file, "fn main() { let x: u32 = true; }\n").expect("write source file");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_simc"))
+        .arg(&file)
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("run simc");
+
+    assert!(
+        !output.status.success(),
+        "compilation of an ill-typed program must fail; got {:?}",
+        output.status,
+    );
+
+    // Guard against the vacuous case: empty stderr also contains no
+    // escape bytes. We want to prove a real diagnostic came out AND
+    // that it's clean.
+    assert!(
+        !output.stderr.is_empty(),
+        "expected a diagnostic on stderr; got nothing.\nstdout: {}",
+        String::from_utf8_lossy(&output.stdout),
+    );
+
+    assert!(
+        !output.stderr.contains(&ESC),
+        "NO_COLOR=1 was set but stderr contains ANSI escape bytes:\n{}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+}


### PR DESCRIPTION
## What's in this PR?
- Migrate error rendering to `ariadne`.
- Replace `RichError` with `Diagnostic`, which carries all the information needed for error rendering.
- Rename `ErrorCollector` to `DiagnosticManager` and give it ownership of `SourceMap`.
- Remove the `WithContent` and `WithSource` traits. No longer needed.